### PR TITLE
More fine-grained timing information

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -34,6 +34,7 @@ import GHCSpecter.Channel
     Channel (..),
     HsSourceInfo (..),
     SessionInfo (..),
+    Timer (..),
   )
 import GHCSpecter.Comm
   ( receiveObject,
@@ -118,7 +119,10 @@ updateInbox chanMsg = incrementSN . updater
       CMBox (CMCheckImports modu msg) ->
         (serverInbox %~ M.insert (CheckImports, modu) msg)
       CMBox (CMTiming modu timer') ->
-        (serverTiming %~ M.insert modu timer')
+        let f Nothing = Just timer'
+            f (Just timer0) =
+              Just $ Timer (unTimer timer0 ++ unTimer timer')
+         in (serverTiming %~ M.alter f modu)
       CMBox (CMSession s') ->
         (serverSessionInfo .~ s')
       CMBox (CMHsSource _modu _info) ->

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -61,6 +61,7 @@ import GHCSpecter.Channel
     SessionInfo (..),
     Timer,
   )
+import GHCSpecter.Render.Util (xmlns)
 import GHCSpecter.Server.Types
   ( DetailLevel (..),
     Dimension (..),
@@ -111,9 +112,6 @@ import Replica.VDOM.Types (HTML)
 import STD.Deletable (delete)
 import Text.Printf (printf)
 import Prelude hiding (div)
-
-xmlns :: Props a
-xmlns = textProp "xmlns" "http://www.w3.org/2000/svg"
 
 analyze :: ModuleGraphInfo -> Text
 analyze graphInfo =

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -32,7 +32,7 @@ import GHCSpecter.Channel
     ModuleGraphInfo (..),
     ModuleName,
     SessionInfo (..),
-    Timer (..),
+    getEndTime,
   )
 import GHCSpecter.Server.Types
   ( Event (..),
@@ -157,7 +157,7 @@ render srcUI ss =
 
     eachRender :: ModuleName -> Widget HTML Event
     eachRender modu =
-      let isCompiled = isJust (timing ^? at modu . _Just . to timerEnd . _Just)
+      let isCompiled = isJust (timing ^? at modu . _Just . to getEndTime . _Just)
           colorTxt
             | isCompiled = "has-text-success-dark"
             | otherwise = "has-text-grey"

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -6,13 +6,11 @@ where
 
 import Concur.Core (Widget)
 import Concur.Replica
-  ( Props,
-    classList,
+  ( classList,
     div,
     height,
     pre,
     text,
-    textProp,
     width,
   )
 import Concur.Replica.SVG qualified as S
@@ -35,15 +33,13 @@ import GHCSpecter.Channel
     getStartTime,
     type ModuleName,
   )
+import GHCSpecter.Render.Util (xmlns)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState (..),
   )
 import Replica.VDOM.Types (HTML)
 import Prelude hiding (div)
-
-xmlns :: Props a
-xmlns = textProp "xmlns" "http://www.w3.org/2000/svg"
 
 maxWidth :: (Num a) => a
 maxWidth = 10240
@@ -62,8 +58,6 @@ renderTimingChart timingInfos =
       topOfBox i = 5 * i + 1
       leftOfBox (_, (startTime, _, _)) =
         floor (startTime / totalTime * maxWidth) :: Int
-      middleOfBox (_, (_, hscOutTime, _)) =
-        floor (hscOutTime / totalTime * maxWidth) :: Int
       rightOfBox (_, (_, _, endTime)) =
         floor (endTime / totalTime * maxWidth) :: Int
       widthOfBox (_, (startTime, _, endTime)) =
@@ -76,7 +70,7 @@ renderTimingChart timingInfos =
           , SP.y (T.pack $ show (topOfBox i))
           , width (T.pack $ show (widthOfBox item))
           , height "3"
-          , SP.fill "red"
+          , SP.fill "lightskyblue"
           ]
           []
       box1 (i, item) =
@@ -85,7 +79,7 @@ renderTimingChart timingInfos =
           , SP.y (T.pack $ show (topOfBox i))
           , width (T.pack $ show (width1OfBox item))
           , height "3"
-          , SP.fill "blue"
+          , SP.fill "royalblue"
           ]
           []
       sec2X sec =

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -30,7 +30,8 @@ import Data.Time.Clock
   )
 import GHCSpecter.Channel
   ( SessionInfo (..),
-    Timer (..),
+    getEndTime,
+    getStartTime,
     type ModuleName,
   )
 import GHCSpecter.Server.Types
@@ -108,9 +109,9 @@ render ss =
   case ss ^. serverSessionInfo . to sessionStartTime of
     Nothing -> pre [] [text "GHC Session has not been started"]
     Just sessionStartTime ->
-      let subtractTime (modName, Timer mstart mend) = do
-            modStartTime <- mstart
-            modEndTime <- mend
+      let subtractTime (modName, timer) = do
+            modStartTime <- getStartTime timer
+            modEndTime <- getEndTime timer
             let modStartTimeDiff = modStartTime `diffUTCTime` sessionStartTime
                 modEndTimeDiff = modEndTime `diffUTCTime` sessionStartTime
             pure (modName, (modStartTimeDiff, modEndTimeDiff))

--- a/daemon/src/GHCSpecter/Render/Util.hs
+++ b/daemon/src/GHCSpecter/Render/Util.hs
@@ -1,0 +1,12 @@
+module GHCSpecter.Render.Util
+  ( xmlns,
+  )
+where
+
+import Concur.Replica
+  ( Props,
+    textProp,
+  )
+
+xmlns :: Props a
+xmlns = textProp "xmlns" "http://www.w3.org/2000/svg"

--- a/plugin/src/GHCSpecter/Channel.hs
+++ b/plugin/src/GHCSpecter/Channel.hs
@@ -9,6 +9,7 @@ module GHCSpecter.Channel
     Timer (..),
     getStartTime,
     getHscOutTime,
+    getAsTime,
     getEndTime,
     HsSourceInfo (..),
     ModuleGraphInfo (..),
@@ -71,7 +72,15 @@ instance FromJSON SessionInfo
 
 instance ToJSON SessionInfo
 
-data TimerTag = TimerStart | TimerHscOut | TimerEnd
+data TimerTag
+  = -- | start
+    TimerStart
+  | -- | Haskell compiler finished
+    TimerHscOut
+  | -- | Assembler phase
+    TimerAs
+  | -- | StopLn phase
+    TimerEnd
   deriving (Enum, Eq, Ord, Generic, Show)
 
 instance FromJSON TimerTag
@@ -90,6 +99,9 @@ getStartTime (Timer ts) = L.lookup TimerStart ts
 
 getHscOutTime :: Timer -> Maybe UTCTime
 getHscOutTime (Timer ts) = L.lookup TimerHscOut ts
+
+getAsTime :: Timer -> Maybe UTCTime
+getAsTime (Timer ts) = L.lookup TimerAs ts
 
 getEndTime :: Timer -> Maybe UTCTime
 getEndTime (Timer ts) = L.lookup TimerEnd ts

--- a/plugin/src/GHCSpecter/Channel.hs
+++ b/plugin/src/GHCSpecter/Channel.hs
@@ -8,6 +8,7 @@ module GHCSpecter.Channel
     TimerTag (..),
     Timer (..),
     getStartTime,
+    getHscOutTime,
     getEndTime,
     HsSourceInfo (..),
     ModuleGraphInfo (..),
@@ -70,7 +71,7 @@ instance FromJSON SessionInfo
 
 instance ToJSON SessionInfo
 
-data TimerTag = TimerStart | TimerEnd
+data TimerTag = TimerStart | TimerHscOut | TimerEnd
   deriving (Enum, Eq, Ord, Generic, Show)
 
 instance FromJSON TimerTag
@@ -78,17 +79,17 @@ instance FromJSON TimerTag
 instance ToJSON TimerTag
 
 instance Binary TimerTag where
-  put TimerStart = put (0 :: Int)
-  put TimerEnd = put (1 :: Int)
-  get = do
-    tag <- get
-    pure (toEnum tag)
+  put tag = put (fromEnum tag)
+  get = toEnum <$> get
 
 newtype Timer = Timer {unTimer :: [(TimerTag, UTCTime)]}
   deriving (Show, Generic, Binary, FromJSON, ToJSON)
 
 getStartTime :: Timer -> Maybe UTCTime
 getStartTime (Timer ts) = L.lookup TimerStart ts
+
+getHscOutTime :: Timer -> Maybe UTCTime
+getHscOutTime (Timer ts) = L.lookup TimerHscOut ts
 
 getEndTime :: Timer -> Maybe UTCTime
 getEndTime (Timer ts) = L.lookup TimerEnd ts

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -99,8 +99,8 @@ import GHCSpecter.Channel
     ModuleName,
     SessionInfo (..),
     Timer (..),
+    TimerTag (..),
     emptyModuleGraphInfo,
-    resetTimer,
   )
 import GHCSpecter.Comm (runClient, sendObject)
 import System.Directory (canonicalizePath, doesFileExist)
@@ -192,8 +192,7 @@ driver opts env = do
           runClient ipcfile $ \sock ->
             sendObject sock $ CMBox (CMSession newStartedSession)
       _ -> pure ()
-  let timer0 = resetTimer {timerStart = Just startTime}
-      hooks = hsc_hooks env
+  let hooks = hsc_hooks env
       runPhaseHook' phase fp = do
         (phase', fp') <- runPhase phase fp
         case phase' of
@@ -215,7 +214,11 @@ driver opts env = do
               Nothing -> pure ()
               Just modName -> liftIO $ do
                 endTime <- getCurrentTime
-                let timer = timer0 {timerEnd = Just endTime}
+                let timer =
+                      Timer
+                        [ (TimerStart, startTime)
+                        , (TimerEnd, endTime)
+                        ]
                 sendMsgToDaemon opts (CMTiming modName timer)
           _ -> pure ()
 


### PR DESCRIPTION
Recording the end time of different phases, more fine-grained timing information is retrieved and visualized. 
With this PR, Haskell compilation, assembler and linker time are separately shown in timing bar graph.