### PR TITLE
Session-wide connection

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -5,7 +5,7 @@ module Main (main) where
 import Concur.Core (liftSTM)
 import Concur.Replica (runDefault)
 import Control.Applicative ((<|>))
-import Control.Concurrent (forkOS, threadDelay)
+import Control.Concurrent (forkIO, forkOS, threadDelay)
 import Control.Concurrent.STM
   ( TVar,
     atomically,
@@ -107,11 +107,9 @@ listener socketFile var =
           case o of
             CMSession s' -> do
               let mgi = sessionModuleGraph s'
-              void $ forkOS (moduleGraphWorker var mgi)
-              pure ()
+              void $ forkIO (moduleGraphWorker var mgi)
             CMHsSource _modu (HsSourceInfo hiefile) -> do
-              void $ forkOS (hieWorker var hiefile)
-              pure ()
+              void $ forkIO (hieWorker var hiefile)
             _ -> pure ()
           atomically . modifyTVar' var . updateInbox $ CMBox o
     )

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -18,9 +18,7 @@ module GHCSpecter.UI.Types
 where
 
 import Control.Lens (makeClassy)
-import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
-import GHC.Generics (Generic)
 import GHCSpecter.UI.Types.Event (DetailLevel (..), Tab (..))
 
 data ModuleGraphUI = ModuleGraphUI

--- a/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
@@ -123,5 +123,5 @@ layOutModuleSubgraph mgi detailLevel (clusterName, members_) = do
           IM.filterWithKey (\m _ -> m `elem` largeNodes) modDep
       subModDepReversed = makeRevDep subModDep
   grVisInfo <- layOutGraph modNameMap subModDepReversed
-  printf "Cluster %s subgraph layout has been calculated." (T.unpack clusterName)
+  printf "Cluster %s subgraph layout has been calculated.\n" (T.unpack clusterName)
   pure (clusterName, grVisInfo)

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -218,9 +218,9 @@ startSession opts env = do
           modifyTVar' sessionRef (first (const startedSession))
           pure (Just startedSession, queue, willStartMsgQueue)
         Just _ -> pure (Nothing, queue, willStartMsgQueue)
-
-  when willStartMsgQueue $ do
-    putStrLn "this is called"
+  -- If session connection was never initiated, then make connection
+  -- and start receiving message from the queue.
+  when willStartMsgQueue $
     void $ forkOS $ runMessageQueue opts queue'
   for_ mNewStartedSession $ \newStartedSession ->
     queueMessage queue (CMSession newStartedSession)


### PR DESCRIPTION
Previously, client-to-server (GHC-to-daemon) connection was made every time a message was sent.
Now, by storing session connection in the session variable, the connection is only made once and messages are queued and sent. This stabilizes the connection and enables bidirectional communication.