### PR TITLE
Bug fix in socket communication

### DIFF
--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -212,7 +212,6 @@ runMessageQueue opts queue =
             pure queued
       let msgList = F.toList msgs
       msgList `seq` sendObject sock msgList
-
     receiver :: Socket -> IO ()
     receiver sock = forever $ do
       msg :: Bool <- receiveObject sock


### PR DESCRIPTION
when message size is an exact multiple of 1024, the last payload message is zero-sized, which caused vanishing resource error.
This fixed the bug.