### PR TITLE
Internalize DOM and SVG

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -53,7 +53,6 @@ import GHCSpecter.UI.ConcurReplica.Run (runDefault)
 import GHCSpecter.UI.ConcurReplica.Types
   ( IHTML,
     blockDOMUpdate,
-    unblockDOMUpdate,
   )
 import GHCSpecter.UI.Types
   ( HasUIState (..),
@@ -200,8 +199,8 @@ webServer var = do
             if ui ^. uiShouldUpdate
               then do
                 unsafeBlockingIO $ print "unblocking"
-                unblockDOMUpdate renderUI0
+                renderUI0
               else do
                 unsafeBlockingIO $ print "blocking"
-                blockDOMUpdate renderUI0
+                blockDOMUpdate
       renderUI <|> (Left <$> await stepStartTime)

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -53,6 +53,7 @@ import GHCSpecter.UI.ConcurReplica.Run (runDefault)
 import GHCSpecter.UI.ConcurReplica.Types
   ( IHTML,
     blockDOMUpdate,
+    unblockDOMUpdate,
   )
 import GHCSpecter.UI.Types
   ( HasUIState (..),
@@ -199,8 +200,8 @@ webServer var = do
             if ui ^. uiShouldUpdate
               then do
                 unsafeBlockingIO $ print "unblocking"
-                renderUI0
+                unblockDOMUpdate renderUI0
               else do
                 unsafeBlockingIO $ print "blocking"
-                blockDOMUpdate
+                blockDOMUpdate renderUI0
       renderUI <|> (Left <$> await stepStartTime)

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -40,6 +40,7 @@ import GHCSpecter.Server.Types
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,
     el,
+    link,
     nav,
     section,
     text,
@@ -82,12 +83,10 @@ renderMainPanel stepStartTime ui ss =
 
 cssLink :: Text -> Widget IHTML a
 cssLink url =
-  el
-    "link"
+  link
     [ textProp "rel" "stylesheet"
     , textProp "href" url
     ]
-    []
 
 renderNavbar :: Tab -> Widget IHTML Event
 renderNavbar tab =

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -14,11 +14,7 @@ import Concur.Core
 import Concur.Replica
   ( Props,
     classList,
-    div,
-    el,
-    nav,
     onClick,
-    section,
     style,
     textProp,
   )
@@ -41,7 +37,13 @@ import GHCSpecter.Server.Types
     ServerState (..),
     type ChanModule,
   )
-import GHCSpecter.UI.ConcurReplica.DOM (text)
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( div,
+    el,
+    nav,
+    section,
+    text,
+  )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
   ( HasModuleGraphUI (..),

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -28,7 +28,6 @@ import Concur.Replica
     onMouseLeave,
     width,
   )
-import Concur.Replica.DOM.Props (Prop (PropEvent), Props (Props))
 import Concur.Replica.DOM.Props qualified as DP (checked, name, type_)
 import Concur.Replica.SVG.Props qualified as SP
 import Control.Error.Util (note)
@@ -37,8 +36,6 @@ import Control.Monad (void)
 import Control.Monad.Extra (loop)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Resource (allocate)
-import Data.Aeson qualified as A
-import Data.Aeson.KeyMap qualified as A
 import Data.Bits ((.|.))
 import Data.Foldable qualified as F
 import Data.IntMap (IntMap)
@@ -47,13 +44,11 @@ import Data.List qualified as L
 import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe, mapMaybe)
-import Data.Scientific (toRealFloat)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time.Clock
   ( NominalDiffTime,
     UTCTime,
-    diffUTCTime,
     secondsToNominalDiffTime,
   )
 import Data.Tuple (swap)
@@ -201,11 +196,7 @@ makePolylineText (p0, p1) xys =
   where
     each (Point x y) = T.pack $ printf "%.2f,%.2f" x y
 
-minTimeDiff :: NominalDiffTime
-minTimeDiff = secondsToNominalDiffTime 0.1
-
 renderModuleGraphSVG ::
-  (UTCTime, UTCTime) ->
   IntMap ModuleName ->
   Map Text Timer ->
   [(Text, [Text])] ->
@@ -214,7 +205,6 @@ renderModuleGraphSVG ::
   (Maybe Text, Maybe Text) ->
   Widget IHTML ModuleGraphEvent
 renderModuleGraphSVG
-  (stepStartTime, lastUpdatedTime)
   nameMap
   timing
   clustering
@@ -346,7 +336,6 @@ renderModuleGraphSVG
      in div [classList [("is-fullwidth", True)]] [svgElement]
 
 renderMainModuleGraph ::
-  (UTCTime, UTCTime) ->
   IntMap ModuleName ->
   Map ModuleName Timer ->
   [(Text, [Text])] ->
@@ -355,7 +344,6 @@ renderMainModuleGraph ::
   ModuleGraphUI ->
   Widget IHTML Event
 renderMainModuleGraph
-  (stepStartTime, lastUpdatedTime)
   nameMap
   timing
   clustering
@@ -365,7 +353,6 @@ renderMainModuleGraph
         mhovered = mgUI ^. modGraphUIHover
      in MainModuleEv
           <$> renderModuleGraphSVG
-            (stepStartTime, lastUpdatedTime)
             nameMap
             timing
             clustering
@@ -373,7 +360,6 @@ renderMainModuleGraph
             (mclicked, mhovered)
 
 renderSubModuleGraph ::
-  (UTCTime, UTCTime) ->
   IntMap ModuleName ->
   Map ModuleName Timer ->
   [(DetailLevel, [(ModuleName, GraphVisInfo)])] ->
@@ -381,7 +367,6 @@ renderSubModuleGraph ::
   (ModuleGraphUI, (DetailLevel, ModuleGraphUI)) ->
   Widget IHTML Event
 renderSubModuleGraph
-  (stepStartTime, lastUpdatedTime)
   nameMap
   timing
   subgraphs
@@ -407,7 +392,6 @@ renderSubModuleGraph
                     (subgraph ^. gviNodes)
              in SubModuleEv . SubModuleGraphEv
                   <$> renderModuleGraphSVG
-                    (stepStartTime, lastUpdatedTime)
                     nameMap
                     timing
                     tempclustering
@@ -451,7 +435,6 @@ render stepStartTime ui ss =
                 Nothing -> []
                 Just grVisInfo ->
                   [ renderMainModuleGraph
-                      (stepStartTime, ui ^. uiLastUpdated)
                       nameMap
                       timing
                       clustering
@@ -459,7 +442,6 @@ render stepStartTime ui ss =
                       (ui ^. uiMainModuleGraph)
                   , renderDetailLevel ui
                   , renderSubModuleGraph
-                      (stepStartTime, ui ^. uiLastUpdated)
                       nameMap
                       timing
                       (mgs ^. mgsSubgraph)

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -30,7 +30,6 @@ import Concur.Replica
   )
 import Concur.Replica.DOM.Props (Prop (PropEvent), Props (Props))
 import Concur.Replica.DOM.Props qualified as DP (checked, name, type_)
-import Concur.Replica.SVG qualified as S
 import Concur.Replica.SVG.Props qualified as SP
 import Control.Error.Util (note)
 import Control.Lens ((^.), _1)
@@ -86,6 +85,7 @@ import GHCSpecter.UI.ConcurReplica.DOM
     text,
   )
 import GHCSpecter.UI.ConcurReplica.DOM.Events (onMouseMove)
+import GHCSpecter.UI.ConcurReplica.SVG qualified as S
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
   ( HasModuleGraphUI (..),

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -21,15 +21,11 @@ where
 import Concur.Core (Widget)
 import Concur.Replica
   ( classList,
-    div,
     height,
-    input,
-    label,
     onClick,
     onInput,
     onMouseEnter,
     onMouseLeave,
-    pre,
     width,
   )
 import Concur.Replica.DOM.Props (Prop (PropEvent), Props (Props))
@@ -82,7 +78,13 @@ import GHCSpecter.Server.Types
     ServerState (..),
     transposeGraphVis,
   )
-import GHCSpecter.UI.ConcurReplica.DOM (text)
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( div,
+    input,
+    label,
+    pre,
+    text,
+  )
 import GHCSpecter.UI.ConcurReplica.DOM.Events (onMouseMove)
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -5,11 +5,8 @@ where
 
 import Concur.Core (Widget)
 import Concur.Replica
-  ( button,
-    classList,
-    div,
+  ( classList,
     onClick,
-    pre,
   )
 import Control.Lens ((^.))
 import Data.Map qualified as M
@@ -19,7 +16,12 @@ import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState (..),
   )
-import GHCSpecter.UI.ConcurReplica.DOM (text)
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( button,
+    div,
+    pre,
+    text,
+  )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types.Event
   ( Event (..),

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -8,15 +8,8 @@ import Concur.Core (Widget)
 import Concur.Replica
   ( MouseEvent,
     classList,
-    div,
-    el,
-    hr,
-    li,
     onClick,
-    pre,
-    span,
     style,
-    ul,
   )
 import Control.Lens (at, to, (^.), (^..), (^?), _1, _Just)
 import Control.Monad.Trans.State (State, get, put, runState)
@@ -42,7 +35,16 @@ import GHCSpecter.Server.Types
     ModuleHieInfo,
     ServerState (..),
   )
-import GHCSpecter.UI.ConcurReplica.DOM (text)
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( div,
+    el,
+    hr,
+    li,
+    pre,
+    span,
+    text,
+    ul,
+  )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
   ( HasSourceViewUI (..),

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -34,7 +34,7 @@ import GHCSpecter.UI.ConcurReplica.DOM
     label,
     text,
   )
-import GHCSpecter.UI.ConcurReplica.SVG qualified as S  
+import GHCSpecter.UI.ConcurReplica.SVG qualified as S
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
   ( HasTimingUI (..),

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -10,10 +10,7 @@ where
 import Concur.Core (Widget)
 import Concur.Replica
   ( classList,
-    div,
     height,
-    input,
-    label,
     onChange,
     style,
     width,
@@ -32,7 +29,12 @@ import Data.Time.Clock
 import GHCSpecter.Channel (type ModuleName)
 import GHCSpecter.Render.Util (xmlns)
 import GHCSpecter.Server.Types (ServerState (..))
-import GHCSpecter.UI.ConcurReplica.DOM (text)
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( div,
+    input,
+    label,
+    text,
+  )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
   ( HasTimingUI (..),

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -16,7 +16,6 @@ import Concur.Replica
     width,
   )
 import Concur.Replica.DOM.Props qualified as DP (checked, name, type_)
-import Concur.Replica.SVG qualified as S
 import Concur.Replica.SVG.Props qualified as SP
 import Control.Lens (to, (^.), _2)
 import Data.Text (Text)
@@ -35,6 +34,7 @@ import GHCSpecter.UI.ConcurReplica.DOM
     label,
     text,
   )
+import GHCSpecter.UI.ConcurReplica.SVG qualified as S  
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
   ( HasTimingUI (..),

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
@@ -150,7 +150,7 @@ elWithNamespace mNamespace e attrs children = do
   where
     f :: [(T.Text, Attr)] -> IHTML -> IHTML
     f xs (Update ys) = Update [VNode e (M.fromList xs) mNamespace ys]
-    f _ NoUpdate = NoUpdate
+    f xs (NoUpdate ys) = NoUpdate [VNode e (M.fromList xs) mNamespace ys]
 
     toAttr :: Props a -> IO ((T.Text, Attr), [m a])
     toAttr (Props k (PropText v)) = pure ((k, AText v), [])

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
@@ -149,8 +149,8 @@ elWithNamespace mNamespace e attrs children = do
     $ orr (children <> concatMap snd attrs')
   where
     f :: [(T.Text, Attr)] -> IHTML -> IHTML
-    f _ NoUpdate = NoUpdate
     f xs (Update ys) = Update [VNode e (M.fromList xs) mNamespace ys]
+    f _ NoUpdate = NoUpdate
 
     toAttr :: Props a -> IO ((T.Text, Attr), [m a])
     toAttr (Props k (PropText v)) = pure ((k, AText v), [])

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
@@ -5,9 +5,9 @@ where
 
 import Concur.Core (Widget, display)
 import Data.Text (Text)
-import GHCSpecter.UI.ConcurReplica.Types (IHTML (..), embed)
+import GHCSpecter.UI.ConcurReplica.Types (IHTML (..))
 import Replica.VDOM (VDOM (..))
 
 -- | @Concur.Replica.DOM.text@ was specialized to Widget HTML, so we reintroduced this @text@ for Widget IHTML.
 text :: Text -> Widget IHTML a
-text txt = display (embed [VText txt])
+text txt = display (Update [VText txt])

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
@@ -1,13 +1,568 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | This module is originated from Concur.Replica.DOM and tailored
+-- for IHTML.
 module GHCSpecter.UI.ConcurReplica.DOM
-  ( text,
+  ( WidgetConstraints,
+    el,
+    elWithNamespace,
+    text,
+    div,
+    table,
+    thead,
+    tbody,
+    tr,
+    trKeyed,
+    th,
+    td,
+    tfoot,
+    section,
+    header,
+    footer,
+    button,
+    form,
+    p,
+    s,
+    ul,
+    span,
+    strong,
+    li,
+    liKeyed,
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    hr,
+    pre,
+    input,
+    label,
+    a,
+    mark,
+    ruby,
+    rt,
+    rp,
+    bdi,
+    bdo,
+    wbr,
+    details,
+    summary,
+    menuitem,
+    menu,
+    fieldset,
+    legend,
+    datalist,
+    optgroup,
+    keygen,
+    output,
+    progress,
+    meter,
+    center,
+    audio,
+    video,
+    source,
+    track,
+    embed,
+    object,
+    param,
+    ins,
+    del,
+    small,
+    cite,
+    dfn,
+    abbr,
+    time,
+    var,
+    samp,
+    kbd,
+    caption,
+    colgroup,
+    col,
+    nav,
+    article,
+    aside,
+    address,
+    main_,
+    body,
+    figure,
+    figcaption,
+    dl,
+    dt,
+    dd,
+    img,
+    iframe,
+    canvas,
+    math,
+    select,
+    option,
+    textarea,
+    sub,
+    sup,
+    br,
+    ol,
+    blockquote,
+    code,
+    em,
+    i,
+    b,
+    u,
+    q,
+    script,
+    link,
   )
 where
 
-import Concur.Core (Widget, display)
-import Data.Text (Text)
+import Concur.Core (MonadSafeBlockingIO (liftSafeBlockingIO), MonadUnsafeBlockingIO (liftUnsafeBlockingIO), MultiAlternative, Widget, display, orr, wrapView)
+import Concur.Replica.DOM.Props (Prop (PropBool, PropEvent, PropMap, PropText), Props (Props), key)
+import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
+import Control.ShiftMap (ShiftMap (shiftMap))
+import Data.Map qualified as M
+import Data.Monoid ((<>))
+import Data.Text qualified as T
 import GHCSpecter.UI.ConcurReplica.Types (IHTML (..))
-import Replica.VDOM (VDOM (..))
+import Replica.VDOM (Attr (ABool, AEvent, AMap, AText), HTML, Namespace, VDOM (VNode, VText))
+import Prelude hiding (div, span)
+
+type WidgetConstraints m = (ShiftMap (Widget HTML) m, Monad m, MonadSafeBlockingIO m, MonadUnsafeBlockingIO m, MultiAlternative m)
+
+el :: forall m a. WidgetConstraints m => T.Text -> [Props a] -> [m a] -> m a
+el = elWithNamespace Nothing
+
+elWithNamespace :: forall m a. WidgetConstraints m => Maybe Namespace -> T.Text -> [Props a] -> [m a] -> m a
+elWithNamespace mNamespace e attrs children = do
+  attrs' <- liftUnsafeBlockingIO $ mapM toAttr attrs
+  shiftMap (wrapView (VNode e (M.fromList $ fmap fst attrs') mNamespace)) $ orr (children <> concatMap snd attrs')
+  where
+    toAttr :: Props a -> IO ((T.Text, Attr), [m a])
+    toAttr (Props k (PropText v)) = pure ((k, AText v), [])
+    toAttr (Props k (PropBool v)) = pure ((k, ABool v), [])
+    toAttr (Props k (PropEvent extract)) = do
+      n <- newEmptyMVar
+      pure ((k, AEvent $ putMVar n), [liftSafeBlockingIO (extract <$> takeMVar n)])
+    toAttr (Props k (PropMap m)) = do
+      m' <- mapM toAttr m
+      pure ((k, AMap $ M.fromList $ fmap fst m'), concatMap snd m')
 
 -- | @Concur.Replica.DOM.text@ was specialized to Widget HTML, so we reintroduced this @text@ for Widget IHTML.
-text :: Text -> Widget IHTML a
+text :: T.Text -> Widget IHTML a
 text txt = display (Update [VText txt])
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div
+div :: WidgetConstraints m => [Props a] -> [m a] -> m a
+div = el "div"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table
+table :: WidgetConstraints m => [Props a] -> [m a] -> m a
+table = el "table"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/thead
+thead :: WidgetConstraints m => [Props a] -> [m a] -> m a
+thead = el "thead"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
+tbody :: WidgetConstraints m => [Props a] -> [m a] -> m a
+tbody = el "tbody"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr
+tr :: WidgetConstraints m => [Props a] -> [m a] -> m a
+tr = el "tr"
+
+-- | Contains `Key`, inteded to be used for child replacement patch
+--
+-- <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tr>
+trKeyed :: WidgetConstraints m => T.Text -> [Props a] -> [m a] -> m a
+trKeyed k props = el "tr" (key k : props)
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/th
+th :: WidgetConstraints m => [Props a] -> [m a] -> m a
+th = el "th"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/td
+td :: WidgetConstraints m => [Props a] -> [m a] -> m a
+td = el "td"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
+tfoot :: WidgetConstraints m => [Props a] -> [m a] -> m a
+tfoot = el "tfoot"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section
+section :: WidgetConstraints m => [Props a] -> [m a] -> m a
+section = el "section"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
+header :: WidgetConstraints m => [Props a] -> [m a] -> m a
+header = el "header"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer
+footer :: WidgetConstraints m => [Props a] -> [m a] -> m a
+footer = el "footer"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button
+button :: WidgetConstraints m => [Props a] -> [m a] -> m a
+button = el "button"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
+form :: WidgetConstraints m => [Props a] -> [m a] -> m a
+form = el "form"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/p
+p :: WidgetConstraints m => [Props a] -> [m a] -> m a
+p = el "p"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/s
+s :: WidgetConstraints m => [Props a] -> [m a] -> m a
+s = el "s"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul
+ul :: WidgetConstraints m => [Props a] -> [m a] -> m a
+ul = el "ul"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span
+span :: WidgetConstraints m => [Props a] -> [m a] -> m a
+span = el "span"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/strong
+strong :: WidgetConstraints m => [Props a] -> [m a] -> m a
+strong = el "strong"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li
+li :: WidgetConstraints m => [Props a] -> [m a] -> m a
+li = el "li"
+
+-- | Contains `Key`, inteded to be used for child replacement patch
+--
+-- <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li>
+liKeyed :: WidgetConstraints m => T.Text -> [Props a] -> [m a] -> m a
+liKeyed k props = el "li" (key k : props)
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h1
+h1 :: WidgetConstraints m => [Props a] -> [m a] -> m a
+h1 = el "h1"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h2
+h2 :: WidgetConstraints m => [Props a] -> [m a] -> m a
+h2 = el "h2"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h3
+h3 :: WidgetConstraints m => [Props a] -> [m a] -> m a
+h3 = el "h3"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h4
+h4 :: WidgetConstraints m => [Props a] -> [m a] -> m a
+h4 = el "h4"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h5
+h5 :: WidgetConstraints m => [Props a] -> [m a] -> m a
+h5 = el "h5"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/h6
+h6 :: WidgetConstraints m => [Props a] -> [m a] -> m a
+h6 = el "h6"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr
+hr :: WidgetConstraints m => [Props a] -> m a
+hr = flip (el "hr") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre
+pre :: WidgetConstraints m => [Props a] -> [m a] -> m a
+pre = el "pre"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+input :: WidgetConstraints m => [Props a] -> m a
+input = flip (el "input") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label
+label :: WidgetConstraints m => [Props a] -> [m a] -> m a
+label = el "label"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
+a :: WidgetConstraints m => [Props a] -> [m a] -> m a
+a = el "a"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
+mark :: WidgetConstraints m => [Props a] -> [m a] -> m a
+mark = el "mark"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
+ruby :: WidgetConstraints m => [Props a] -> [m a] -> m a
+ruby = el "ruby"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rt
+rt :: WidgetConstraints m => [Props a] -> [m a] -> m a
+rt = el "rt"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/rp
+rp :: WidgetConstraints m => [Props a] -> [m a] -> m a
+rp = el "rp"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdi
+bdi :: WidgetConstraints m => [Props a] -> [m a] -> m a
+bdi = el "bdi"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/bdo
+bdo :: WidgetConstraints m => [Props a] -> [m a] -> m a
+bdo = el "bdo"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr
+wbr :: WidgetConstraints m => [Props a] -> m a
+wbr = flip (el "wbr") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details
+details :: WidgetConstraints m => [Props a] -> [m a] -> m a
+details = el "details"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary
+summary :: WidgetConstraints m => [Props a] -> [m a] -> m a
+summary = el "summary"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menuitem
+menuitem :: WidgetConstraints m => [Props a] -> [m a] -> m a
+menuitem = el "menuitem"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu
+menu :: WidgetConstraints m => [Props a] -> [m a] -> m a
+menu = el "menu"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset
+fieldset :: WidgetConstraints m => [Props a] -> [m a] -> m a
+fieldset = el "fieldset"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend
+legend :: WidgetConstraints m => [Props a] -> [m a] -> m a
+legend = el "legend"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist
+datalist :: WidgetConstraints m => [Props a] -> [m a] -> m a
+datalist = el "datalist"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup
+optgroup :: WidgetConstraints m => [Props a] -> [m a] -> m a
+optgroup = el "optgroup"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/keygen
+keygen :: WidgetConstraints m => [Props a] -> [m a] -> m a
+keygen = el "keygen"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/output
+output :: WidgetConstraints m => [Props a] -> [m a] -> m a
+output = el "output"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
+progress :: WidgetConstraints m => [Props a] -> [m a] -> m a
+progress = el "progress"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meter
+meter :: WidgetConstraints m => [Props a] -> [m a] -> m a
+meter = el "meter"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/center
+center :: WidgetConstraints m => [Props a] -> [m a] -> m a
+center = el "center"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
+audio :: WidgetConstraints m => [Props a] -> [m a] -> m a
+audio = el "audio"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video
+video :: WidgetConstraints m => [Props a] -> [m a] -> m a
+video = el "video"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source
+source :: WidgetConstraints m => [Props a] -> m a
+source = flip (el "source") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/track
+track :: WidgetConstraints m => [Props a] -> m a
+track = flip (el "track") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/embed
+embed :: WidgetConstraints m => [Props a] -> m a
+embed = flip (el "embed") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/object
+object :: WidgetConstraints m => [Props a] -> [m a] -> m a
+object = el "object"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/param
+param :: WidgetConstraints m => [Props a] -> m a
+param = flip (el "param") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ins
+ins :: WidgetConstraints m => [Props a] -> [m a] -> m a
+ins = el "ins"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/del
+del :: WidgetConstraints m => [Props a] -> [m a] -> m a
+del = el "del"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/small
+small :: WidgetConstraints m => [Props a] -> [m a] -> m a
+small = el "small"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/cite
+cite :: WidgetConstraints m => [Props a] -> [m a] -> m a
+cite = el "cite"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dfn
+dfn :: WidgetConstraints m => [Props a] -> [m a] -> m a
+dfn = el "dfn"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
+abbr :: WidgetConstraints m => [Props a] -> [m a] -> m a
+abbr = el "abbr"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
+time :: WidgetConstraints m => [Props a] -> [m a] -> m a
+time = el "time"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/var
+var :: WidgetConstraints m => [Props a] -> [m a] -> m a
+var = el "var"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/samp
+samp :: WidgetConstraints m => [Props a] -> [m a] -> m a
+samp = el "samp"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd
+kbd :: WidgetConstraints m => [Props a] -> [m a] -> m a
+kbd = el "kbd"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/caption
+caption :: WidgetConstraints m => [Props a] -> [m a] -> m a
+caption = el "caption"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/colgroup
+colgroup :: WidgetConstraints m => [Props a] -> [m a] -> m a
+colgroup = el "colgroup"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/col
+col :: WidgetConstraints m => [Props a] -> m a
+col = flip (el "col") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav
+nav :: WidgetConstraints m => [Props a] -> [m a] -> m a
+nav = el "nav"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article
+article :: WidgetConstraints m => [Props a] -> [m a] -> m a
+article = el "article"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside
+aside :: WidgetConstraints m => [Props a] -> [m a] -> m a
+aside = el "aside"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address
+address :: WidgetConstraints m => [Props a] -> [m a] -> m a
+address = el "address"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main
+main_ :: WidgetConstraints m => [Props a] -> [m a] -> m a
+main_ = el "main"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body
+body :: WidgetConstraints m => [Props a] -> [m a] -> m a
+body = el "body"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
+figure :: WidgetConstraints m => [Props a] -> [m a] -> m a
+figure = el "figure"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figcaption
+figcaption :: WidgetConstraints m => [Props a] -> [m a] -> m a
+figcaption = el "figcaption"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
+dl :: WidgetConstraints m => [Props a] -> [m a] -> m a
+dl = el "dl"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
+dt :: WidgetConstraints m => [Props a] -> [m a] -> m a
+dt = el "dt"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
+dd :: WidgetConstraints m => [Props a] -> [m a] -> m a
+dd = el "dd"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
+img :: WidgetConstraints m => [Props a] -> m a
+img = flip (el "img") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe
+iframe :: WidgetConstraints m => [Props a] -> [m a] -> m a
+iframe = el "iframe"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas
+canvas :: WidgetConstraints m => [Props a] -> [m a] -> m a
+canvas = el "canvas"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/math
+math :: WidgetConstraints m => [Props a] -> [m a] -> m a
+math = el "math"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select
+select :: WidgetConstraints m => [Props a] -> [m a] -> m a
+select = el "select"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
+option :: WidgetConstraints m => [Props a] -> [m a] -> m a
+option = el "option"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea
+textarea :: WidgetConstraints m => [Props a] -> [m a] -> m a
+textarea = el "textarea"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sub
+sub :: WidgetConstraints m => [Props a] -> [m a] -> m a
+sub = el "sub"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/sup
+sup :: WidgetConstraints m => [Props a] -> [m a] -> m a
+sup = el "sup"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
+br :: WidgetConstraints m => [Props a] -> m a
+br = flip (el "br") []
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol
+ol :: WidgetConstraints m => [Props a] -> [m a] -> m a
+ol = el "ol"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/blockquote
+blockquote :: WidgetConstraints m => [Props a] -> [m a] -> m a
+blockquote = el "blockquote"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/code
+code :: WidgetConstraints m => [Props a] -> [m a] -> m a
+code = el "code"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em
+em :: WidgetConstraints m => [Props a] -> [m a] -> m a
+em = el "em"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/i
+i :: WidgetConstraints m => [Props a] -> [m a] -> m a
+i = el "i"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
+b :: WidgetConstraints m => [Props a] -> [m a] -> m a
+b = el "b"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u
+u :: WidgetConstraints m => [Props a] -> [m a] -> m a
+u = el "u"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q
+q :: WidgetConstraints m => [Props a] -> [m a] -> m a
+q = el "q"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
+script :: WidgetConstraints m => [Props a] -> [m a] -> m a
+script = el "script"
+
+-- | https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link
+link :: WidgetConstraints m => [Props a] -> m a
+link = flip (el "link") []

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
@@ -124,16 +124,14 @@ import Concur.Core
     display,
     mapView,
     orr,
-    wrapView,
   )
 import Concur.Replica.DOM.Props (Prop (PropBool, PropEvent, PropMap, PropText), Props (Props), key)
 import Control.Concurrent (newEmptyMVar, putMVar, takeMVar)
 import Control.ShiftMap (ShiftMap (shiftMap))
 import Data.Map qualified as M
-import Data.Monoid ((<>))
 import Data.Text qualified as T
 import GHCSpecter.UI.ConcurReplica.Types (IHTML (..))
-import Replica.VDOM (Attr (ABool, AEvent, AMap, AText), HTML, Namespace, VDOM (VNode, VText))
+import Replica.VDOM (Attr (ABool, AEvent, AMap, AText), Namespace, VDOM (VNode, VText))
 import Prelude hiding (div, span)
 
 type WidgetConstraints m = (ShiftMap (Widget IHTML) m, Monad m, MonadSafeBlockingIO m, MonadUnsafeBlockingIO m, MultiAlternative m)

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
@@ -9,7 +9,7 @@ import Concur.Core (SuspendF (Forever, StepBlock, StepIO, StepSTM, StepView), Wi
 import Control.Concurrent.STM (atomically)
 import Control.Monad.Free (Free (Free, Pure))
 import Data.Text qualified as T
-import GHCSpecter.UI.ConcurReplica.Types (IHTML (..))
+import GHCSpecter.UI.ConcurReplica.Types (IHTML (..), project)
 import GHCSpecter.UI.ConcurReplica.WaiHandler qualified as R
 import Network.Wai (Middleware)
 import Network.Wai.Handler.Warp qualified as W
@@ -35,7 +35,7 @@ stepWidget ::
     ( Maybe
         ( IHTML
         , R.Context -> Free (SuspendF IHTML) a
-        , HTML -> R.Event -> Maybe (IO ())
+        , R.Event -> Maybe (IO ())
         )
     )
 stepWidget ctx v = case v ctx of
@@ -45,7 +45,7 @@ stepWidget ctx v = case v ctx of
       Just
         ( new
         , const next
-        , \html event -> fireEvent html (R.evtPath event) (R.evtType event) (DOMEvent $ R.evtEvent event)
+        , \event -> fireEvent (project new) (R.evtPath event) (R.evtType event) (DOMEvent $ R.evtEvent event)
         )
   Free (StepIO io next) ->
     io >>= stepWidget ctx . \r _ -> next r

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
@@ -9,15 +9,15 @@ import Concur.Core (SuspendF (Forever, StepBlock, StepIO, StepSTM, StepView), Wi
 import Control.Concurrent.STM (atomically)
 import Control.Monad.Free (Free (Free, Pure))
 import Data.Text qualified as T
-import GHCSpecter.UI.ConcurReplica.Types (IHTML (..), embed, project)
+import GHCSpecter.UI.ConcurReplica.Types (IHTML (..), project)
 import GHCSpecter.UI.ConcurReplica.WaiHandler qualified as R
 import Network.Wai (Middleware)
 import Network.Wai.Handler.Warp qualified as W
 import Network.WebSockets.Connection (ConnectionOptions, defaultConnectionOptions)
 import Replica.VDOM (defaultIndex, fireEvent)
-import Replica.VDOM.Types (DOMEvent (DOMEvent))
+import Replica.VDOM.Types (DOMEvent (DOMEvent), HTML)
 
-run :: Int -> IHTML -> ConnectionOptions -> Middleware -> (R.Context -> Widget IHTML a) -> IO ()
+run :: Int -> HTML -> ConnectionOptions -> Middleware -> (R.Context -> Widget IHTML a) -> IO ()
 run port index connectionOptions middleware widget =
   W.run port $
     R.app index connectionOptions middleware (step <$> widget) stepWidget
@@ -25,7 +25,7 @@ run port index connectionOptions middleware widget =
 runDefault :: Int -> T.Text -> (R.Context -> Widget IHTML a) -> IO ()
 runDefault port title widget =
   W.run port $
-    R.app (embed (defaultIndex title [])) defaultConnectionOptions id (step <$> widget) stepWidget
+    R.app (defaultIndex title []) defaultConnectionOptions id (step <$> widget) stepWidget
 
 -- | No need to use this directly if you're using 'run' or 'runDefault'.
 stepWidget ::

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
@@ -9,7 +9,7 @@ import Concur.Core (SuspendF (Forever, StepBlock, StepIO, StepSTM, StepView), Wi
 import Control.Concurrent.STM (atomically)
 import Control.Monad.Free (Free (Free, Pure))
 import Data.Text qualified as T
-import GHCSpecter.UI.ConcurReplica.Types (IHTML (..), project)
+import GHCSpecter.UI.ConcurReplica.Types (IHTML (..))
 import GHCSpecter.UI.ConcurReplica.WaiHandler qualified as R
 import Network.Wai (Middleware)
 import Network.Wai.Handler.Warp qualified as W
@@ -35,7 +35,7 @@ stepWidget ::
     ( Maybe
         ( IHTML
         , R.Context -> Free (SuspendF IHTML) a
-        , R.Event -> Maybe (IO ())
+        , HTML -> R.Event -> Maybe (IO ())
         )
     )
 stepWidget ctx v = case v ctx of
@@ -45,7 +45,7 @@ stepWidget ctx v = case v ctx of
       Just
         ( new
         , const next
-        , \event -> fireEvent (project new) (R.evtPath event) (R.evtType event) (DOMEvent $ R.evtEvent event)
+        , \html event -> fireEvent html (R.evtPath event) (R.evtType event) (DOMEvent $ R.evtEvent event)
         )
   Free (StepIO io next) ->
     io >>= stepWidget ctx . \r _ -> next r

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/SVG.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/SVG.hs
@@ -87,9 +87,9 @@ where
 -- Note that this module is auto-generated.
 -- See @./misc/gen-svg-modules@ for details.
 
-import Concur.Replica.DOM (WidgetConstraints, elWithNamespace)
 import Concur.Replica.DOM.Props (Props)
 import Data.Text qualified as T
+import GHCSpecter.UI.ConcurReplica.DOM (WidgetConstraints, elWithNamespace)
 import Replica.VDOM.Types (Namespace (Namespace))
 import Prelude hiding (filter)
 

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/SVG.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/SVG.hs
@@ -1,0 +1,316 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- | This module is originated from Concur.Replica.SVG and tailored for IHTML.
+--
+--   SVG elements
+--
+-- See: <https://developer.mozilla.org/en-US/docs/Web/SVG/Element>
+module GHCSpecter.UI.ConcurReplica.SVG
+  ( el,
+    animate,
+    animateMotion,
+    animateTransform,
+    circle,
+    clipPath,
+    colorProfile,
+    defs,
+    desc,
+    discard,
+    ellipse,
+    feBlend,
+    feColorMatrix,
+    feComponentTransfer,
+    feComposite,
+    feConvolveMatrix,
+    feDiffuseLighting,
+    feDisplacementMap,
+    feDistantLight,
+    feDropShadow,
+    feFlood,
+    feFuncA,
+    feFuncB,
+    feFuncG,
+    feFuncR,
+    feGaussianBlur,
+    feImage,
+    feMerge,
+    feMergeNode,
+    feMorphology,
+    feOffset,
+    fePointLight,
+    feSpecularLighting,
+    feSpotLight,
+    feTile,
+    feTurbulence,
+    filter,
+    foreignObject,
+    g,
+    hatch,
+    hatchpath,
+    image,
+    line,
+    linearGradient,
+    marker,
+    mask,
+    mesh,
+    meshgradient,
+    meshpatch,
+    meshrow,
+    metadata,
+    mpath,
+    path,
+    pattern,
+    polygon,
+    polyline,
+    radialGradient,
+    rect,
+    script,
+    set,
+    solidcolor,
+    stop,
+    style,
+    svg,
+    switch,
+    symbol,
+    text,
+    textPath,
+    title,
+    tspan,
+    unknown,
+    use,
+    view,
+  )
+where
+
+-- Note that this module is auto-generated.
+-- See @./misc/gen-svg-modules@ for details.
+
+import Concur.Replica.DOM (WidgetConstraints, elWithNamespace)
+import Concur.Replica.DOM.Props (Props)
+import Data.Text qualified as T
+import Replica.VDOM.Types (Namespace (Namespace))
+import Prelude hiding (filter)
+
+-- | Helper function for creating SVG elements.
+el :: forall m a. WidgetConstraints m => T.Text -> [Props a] -> [m a] -> m a
+el = elWithNamespace (Just (Namespace "http://www.w3.org/2000/svg"))
+
+-- * SVG Elements
+
+animate :: WidgetConstraints m => [Props a] -> [m a] -> m a
+animate = el "animate"
+
+animateMotion :: WidgetConstraints m => [Props a] -> [m a] -> m a
+animateMotion = el "animateMotion"
+
+animateTransform :: WidgetConstraints m => [Props a] -> [m a] -> m a
+animateTransform = el "animateTransform"
+
+circle :: WidgetConstraints m => [Props a] -> [m a] -> m a
+circle = el "circle"
+
+clipPath :: WidgetConstraints m => [Props a] -> [m a] -> m a
+clipPath = el "clipPath"
+
+colorProfile :: WidgetConstraints m => [Props a] -> [m a] -> m a
+colorProfile = el "color-profile"
+
+defs :: WidgetConstraints m => [Props a] -> [m a] -> m a
+defs = el "defs"
+
+desc :: WidgetConstraints m => [Props a] -> [m a] -> m a
+desc = el "desc"
+
+discard :: WidgetConstraints m => [Props a] -> [m a] -> m a
+discard = el "discard"
+
+ellipse :: WidgetConstraints m => [Props a] -> [m a] -> m a
+ellipse = el "ellipse"
+
+feBlend :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feBlend = el "feBlend"
+
+feColorMatrix :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feColorMatrix = el "feColorMatrix"
+
+feComponentTransfer :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feComponentTransfer = el "feComponentTransfer"
+
+feComposite :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feComposite = el "feComposite"
+
+feConvolveMatrix :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feConvolveMatrix = el "feConvolveMatrix"
+
+feDiffuseLighting :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feDiffuseLighting = el "feDiffuseLighting"
+
+feDisplacementMap :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feDisplacementMap = el "feDisplacementMap"
+
+feDistantLight :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feDistantLight = el "feDistantLight"
+
+feDropShadow :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feDropShadow = el "feDropShadow"
+
+feFlood :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feFlood = el "feFlood"
+
+feFuncA :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feFuncA = el "feFuncA"
+
+feFuncB :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feFuncB = el "feFuncB"
+
+feFuncG :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feFuncG = el "feFuncG"
+
+feFuncR :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feFuncR = el "feFuncR"
+
+feGaussianBlur :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feGaussianBlur = el "feGaussianBlur"
+
+feImage :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feImage = el "feImage"
+
+feMerge :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feMerge = el "feMerge"
+
+feMergeNode :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feMergeNode = el "feMergeNode"
+
+feMorphology :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feMorphology = el "feMorphology"
+
+feOffset :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feOffset = el "feOffset"
+
+fePointLight :: WidgetConstraints m => [Props a] -> [m a] -> m a
+fePointLight = el "fePointLight"
+
+feSpecularLighting :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feSpecularLighting = el "feSpecularLighting"
+
+feSpotLight :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feSpotLight = el "feSpotLight"
+
+feTile :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feTile = el "feTile"
+
+feTurbulence :: WidgetConstraints m => [Props a] -> [m a] -> m a
+feTurbulence = el "feTurbulence"
+
+filter :: WidgetConstraints m => [Props a] -> [m a] -> m a
+filter = el "filter"
+
+foreignObject :: WidgetConstraints m => [Props a] -> [m a] -> m a
+foreignObject = el "foreignObject"
+
+g :: WidgetConstraints m => [Props a] -> [m a] -> m a
+g = el "g"
+
+hatch :: WidgetConstraints m => [Props a] -> [m a] -> m a
+hatch = el "hatch"
+
+hatchpath :: WidgetConstraints m => [Props a] -> [m a] -> m a
+hatchpath = el "hatchpath"
+
+image :: WidgetConstraints m => [Props a] -> [m a] -> m a
+image = el "image"
+
+line :: WidgetConstraints m => [Props a] -> [m a] -> m a
+line = el "line"
+
+linearGradient :: WidgetConstraints m => [Props a] -> [m a] -> m a
+linearGradient = el "linearGradient"
+
+marker :: WidgetConstraints m => [Props a] -> [m a] -> m a
+marker = el "marker"
+
+mask :: WidgetConstraints m => [Props a] -> [m a] -> m a
+mask = el "mask"
+
+mesh :: WidgetConstraints m => [Props a] -> [m a] -> m a
+mesh = el "mesh"
+
+meshgradient :: WidgetConstraints m => [Props a] -> [m a] -> m a
+meshgradient = el "meshgradient"
+
+meshpatch :: WidgetConstraints m => [Props a] -> [m a] -> m a
+meshpatch = el "meshpatch"
+
+meshrow :: WidgetConstraints m => [Props a] -> [m a] -> m a
+meshrow = el "meshrow"
+
+metadata :: WidgetConstraints m => [Props a] -> [m a] -> m a
+metadata = el "metadata"
+
+mpath :: WidgetConstraints m => [Props a] -> [m a] -> m a
+mpath = el "mpath"
+
+path :: WidgetConstraints m => [Props a] -> [m a] -> m a
+path = el "path"
+
+pattern :: WidgetConstraints m => [Props a] -> [m a] -> m a
+pattern = el "pattern"
+
+polygon :: WidgetConstraints m => [Props a] -> [m a] -> m a
+polygon = el "polygon"
+
+polyline :: WidgetConstraints m => [Props a] -> [m a] -> m a
+polyline = el "polyline"
+
+radialGradient :: WidgetConstraints m => [Props a] -> [m a] -> m a
+radialGradient = el "radialGradient"
+
+rect :: WidgetConstraints m => [Props a] -> [m a] -> m a
+rect = el "rect"
+
+script :: WidgetConstraints m => [Props a] -> [m a] -> m a
+script = el "script"
+
+set :: WidgetConstraints m => [Props a] -> [m a] -> m a
+set = el "set"
+
+solidcolor :: WidgetConstraints m => [Props a] -> [m a] -> m a
+solidcolor = el "solidcolor"
+
+stop :: WidgetConstraints m => [Props a] -> [m a] -> m a
+stop = el "stop"
+
+style :: WidgetConstraints m => [Props a] -> [m a] -> m a
+style = el "style"
+
+svg :: WidgetConstraints m => [Props a] -> [m a] -> m a
+svg = el "svg"
+
+switch :: WidgetConstraints m => [Props a] -> [m a] -> m a
+switch = el "switch"
+
+symbol :: WidgetConstraints m => [Props a] -> [m a] -> m a
+symbol = el "symbol"
+
+text :: WidgetConstraints m => [Props a] -> [m a] -> m a
+text = el "text"
+
+textPath :: WidgetConstraints m => [Props a] -> [m a] -> m a
+textPath = el "textPath"
+
+title :: WidgetConstraints m => [Props a] -> [m a] -> m a
+title = el "title"
+
+tspan :: WidgetConstraints m => [Props a] -> [m a] -> m a
+tspan = el "tspan"
+
+unknown :: WidgetConstraints m => [Props a] -> [m a] -> m a
+unknown = el "unknown"
+
+use :: WidgetConstraints m => [Props a] -> [m a] -> m a
+use = el "use"
+
+view :: WidgetConstraints m => [Props a] -> [m a] -> m a
+view = el "view"

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
@@ -23,19 +23,20 @@ import Replica.VDOM (HTML)
 -- For example, onMouseMove events are fired too frequently, and most of the handling action
 -- is just to update internal state, not leading to DOM changes.
 -- With IHTML, we tag the HTML content as non-update and bypass expensive websocket diff update steps.
--- Left: no need for update, Right: need for update
 data IHTML
-  = NoUpdate
-  | Update HTML
+  = -- | update
+    Update HTML
+  | -- | no update
+    NoUpdate
 
 instance Semigroup IHTML where
-  NoUpdate <> NoUpdate = NoUpdate
-  NoUpdate <> Update e2 = Update e2
-  Update e1 <> NoUpdate = Update e1
   Update e1 <> Update e2 = Update (e1 <> e2)
+  Update e1 <> NoUpdate = NoUpdate
+  NoUpdate <> Update e2 = NoUpdate
+  NoUpdate <> NoUpdate = NoUpdate
 
 instance Monoid IHTML where
-  mempty = NoUpdate
+  mempty = Update []
 
 -- instance ShiftMap (Widget IHTML) (Widget IHTML) where
 --   shiftMap f = f

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
@@ -14,13 +14,9 @@ module GHCSpecter.UI.ConcurReplica.Types
 where
 
 import Concur.Core
-  ( SuspendF (..),
-    Widget (Widget, step),
-    awaitViewAction,
+  ( Widget,
     mapView,
   )
-import Control.Monad.Free (Free (..), hoistFree)
-import Control.ShiftMap (ShiftMap (..))
 import Replica.VDOM (HTML)
 
 -- | IHTML has additional tag about whether one wants to bypass DOM update.

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
@@ -37,6 +37,10 @@ instance Semigroup IHTML where
 instance Monoid IHTML where
   mempty = NoUpdate
 
+-- instance ShiftMap (Widget IHTML) (Widget IHTML) where
+--   shiftMap f = f
+
+{-
 instance ShiftMap (Widget HTML) (Widget IHTML) where
   -- shiftMap ::
   --    (forall a. Widget HTML a -> Widget HTML a) ->
@@ -67,6 +71,7 @@ instance ShiftMap (Widget HTML) (Widget IHTML) where
 
         stepT' = convert stepT
      in Widget stepT'
+-}
 
 blockDOMUpdate :: Widget IHTML a
 blockDOMUpdate = awaitViewAction (\_ -> NoUpdate)

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
@@ -4,8 +4,12 @@ module GHCSpecter.UI.ConcurReplica.Types
   ( -- * IHTML type
     IHTML (..),
 
+    -- * project
+    project,
+
     -- * block
     blockDOMUpdate,
+    unblockDOMUpdate,
   )
 where
 
@@ -27,52 +31,23 @@ data IHTML
   = -- | update
     Update HTML
   | -- | no update
-    NoUpdate
+    NoUpdate HTML
 
 instance Semigroup IHTML where
   Update e1 <> Update e2 = Update (e1 <> e2)
-  Update e1 <> NoUpdate = NoUpdate
-  NoUpdate <> Update e2 = NoUpdate
-  NoUpdate <> NoUpdate = NoUpdate
+  Update e1 <> NoUpdate e2 = NoUpdate (e1 <> e2)
+  NoUpdate e1 <> Update e2 = NoUpdate (e1 <> e2)
+  NoUpdate e1 <> NoUpdate e2 = NoUpdate (e1 <> e2)
 
 instance Monoid IHTML where
   mempty = Update []
 
--- instance ShiftMap (Widget IHTML) (Widget IHTML) where
---   shiftMap f = f
+project :: IHTML -> HTML
+project (NoUpdate v) = v
+project (Update v) = v
 
-{-
-instance ShiftMap (Widget HTML) (Widget IHTML) where
-  -- shiftMap ::
-  --    (forall a. Widget HTML a -> Widget HTML a) ->
-  --    (forall b. Widget IHTML b -> Widget IHTML b)
-  shiftMap f t =
-    let f' = step . f . Widget
+blockDOMUpdate :: Widget IHTML a -> Widget IHTML a
+blockDOMUpdate = mapView (\x -> NoUpdate (project x))
 
-        -- stepT :: Free (SuspendF IHTML) a
-        stepT = step t
-
-        convert :: Free (SuspendF IHTML) a -> Free (SuspendF IHTML) a
-        convert s =
-          case s of
-            Pure r -> Pure r
-            Free (StepView NoUpdate next) -> Free (StepView NoUpdate next)
-            Free (StepView (Update v) next) ->
-              let stepS = Free (StepView v (Pure ()))
-                  stepS' = f' stepS
-               in case stepS' of
-                    -- NOTE (IWK): This seems very ad hoc, but I couldn't find
-                    -- any better solution yet
-                    Free (StepView v' _) -> Free (StepView (Update v') (convert next))
-                    _ -> Free Forever
-            Free (StepBlock a next) -> Free (StepBlock a next)
-            Free (StepSTM a next) -> Free (StepSTM a next)
-            Free (StepIO a next) -> Free (StepIO a next)
-            Free Forever -> Free Forever
-
-        stepT' = convert stepT
-     in Widget stepT'
--}
-
-blockDOMUpdate :: Widget IHTML a
-blockDOMUpdate = awaitViewAction (\_ -> NoUpdate)
+unblockDOMUpdate :: Widget IHTML a -> Widget IHTML a
+unblockDOMUpdate = mapView (\x -> Update (project x))

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
@@ -29,6 +29,8 @@ data IHTML
   | -- | no update
     NoUpdate HTML
 
+-- NOTE: NoUpdate is the upper bound of IHTML and Update [] is mempty, so once meeting NoUpate,
+-- the DOM is not updated after that.
 instance Semigroup IHTML where
   Update e1 <> Update e2 = Update (e1 <> e2)
   Update e1 <> NoUpdate e2 = NoUpdate (e1 <> e2)

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Types.hs
@@ -6,7 +6,6 @@ module GHCSpecter.UI.ConcurReplica.Types
 
     -- * IHTML <-> HTML
     project,
-    embed,
 
     -- * block / unblock DOM
     blockDOMUpdate,
@@ -45,9 +44,6 @@ project :: IHTML -> HTML
 project (NoUpdate a) = a
 project (Update a) = a
 
-embed :: HTML -> IHTML
-embed a = Update a
-
 instance ShiftMap (Widget HTML) (Widget IHTML) where
   shiftMap f t =
     let -- stepT :: Free (SuspendF IHTML) a
@@ -61,7 +57,7 @@ instance ShiftMap (Widget HTML) (Widget IHTML) where
         to Forever = Forever
 
         fro :: SuspendF HTML a -> SuspendF IHTML a
-        fro (StepView v next) = StepView (embed v) next
+        fro (StepView v next) = StepView (Update v) next
         fro (StepBlock a next) = StepBlock a next
         fro (StepSTM a next) = StepSTM a next
         fro (StepIO a next) = StepIO a next

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
@@ -212,12 +212,12 @@ websocketApp initial step pendingConn = do
       case r of
         Nothing -> pure ()
         -- for Left case, we do not update client frame
-        Just (IHTML (Left newDom), next, fire) -> do
+        Just (NoUpdate newDom, next, fire) -> do
           atomically $ writeTVar chan (Just fire)
-          go conn ctx chan cf (Just (IHTML (Left newDom))) next (serverFrame + 1)
+          go conn ctx chan cf (Just (NoUpdate newDom)) next (serverFrame + 1)
         -- for Right case, we update both the client frame (i.e. sending DOM diff to the websocket)
         -- and server frame
-        Just (IHTML (Right newDom), next, fire) -> do
+        Just (Update newDom, next, fire) -> do
           clientFrame <- atomically $ do
             a <- readTVar cf
             writeTVar cf Nothing
@@ -235,4 +235,4 @@ websocketApp initial step pendingConn = do
 
           atomically $ writeTVar chan (Just fire)
 
-          go conn ctx chan cf (Just (IHTML (Right newDom))) next (serverFrame + 1)
+          go conn ctx chan cf (Just (Update newDom)) next (serverFrame + 1)

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
@@ -213,9 +213,8 @@ websocketApp initial step pendingConn = do
       case r of
         Nothing -> pure ()
         -- for Left case, we do not update client frame
-        Just (NoUpdate, next, fire_) -> do
-          for_ oldDom $ \oldDom' ->
-            atomically $ writeTVar chan (Just (fire_ oldDom'))
+        Just (NoUpdate newDom, next, fire_) -> do
+          atomically $ writeTVar chan (Just (fire_ newDom))
           go conn ctx chan cf oldDom next (serverFrame + 1)
         -- for Right case, we update both the client frame (i.e. sending DOM diff to the websocket)
         -- and server frame

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
@@ -21,7 +21,6 @@ import Control.Monad (forever, join)
 import Data.Aeson ((.:), (.=))
 import Data.Aeson qualified as A
 import Data.ByteString.Lazy qualified as BL
-import Data.Foldable (for_)
 import Data.IORef (atomicModifyIORef', newIORef, readIORef)
 import Data.Map qualified as M
 import Data.Text qualified as T
@@ -213,7 +212,7 @@ websocketApp initial step pendingConn = do
       case r of
         Nothing -> pure ()
         -- for Left case, we do not update client frame
-        Just (NoUpdate newDom, next, fire) -> do
+        Just (NoUpdate _, next, fire) -> do
           atomically $ writeTVar chan (Just fire)
           go conn ctx chan cf oldDom next (serverFrame + 1)
         -- for Right case, we update both the client frame (i.e. sending DOM diff to the websocket)

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -59,7 +59,9 @@ emptyTimingUI :: TimingUI
 emptyTimingUI = TimingUI False False False
 
 data UIState = UIState
-  { _uiLastUpdated :: UTCTime
+  { _uiShouldUpdate :: Bool
+  -- ^ should update?
+  , _uiLastUpdated :: UTCTime
   -- ^ last updated time
   , _uiTab :: Tab
   -- ^ current tab
@@ -80,7 +82,8 @@ makeClassy ''UIState
 emptyUIState :: UTCTime -> UIState
 emptyUIState now =
   UIState
-    { _uiLastUpdated = now
+    { _uiShouldUpdate = True
+    , _uiLastUpdated = now
     , _uiTab = TabSession
     , _uiMainModuleGraph = ModuleGraphUI Nothing Nothing
     , _uiSubModuleGraph = (UpTo30, ModuleGraphUI Nothing Nothing)


### PR DESCRIPTION
As the UI framework is diverted from the original concur-replica (in terms of HTML/IHTML), I internalize DOM and SVG modules in the ghc-specter code base. The IHTML data type is simplified as well.