### PR TITLE
Control eDSL for separation of business logic and UI rendering

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -2,7 +2,7 @@
 
 module Main (main) where
 
-import Concur.Core (Widget, liftSTM, unsafeBlockingIO)
+import Concur.Core (liftSTM, unsafeBlockingIO)
 import Control.Applicative ((<|>))
 import Control.Concurrent (forkIO, forkOS, threadDelay)
 import Control.Concurrent.STM
@@ -12,7 +12,6 @@ import Control.Concurrent.STM
     newTVar,
     readTVar,
     retry,
-    writeTVar,
   )
 import Control.Lens (to, (%~), (.~), (^.))
 import Control.Monad (forever, void, when)
@@ -64,13 +63,11 @@ import GHCSpecter.Server.Types
   )
 import GHCSpecter.UI.ConcurReplica.Run (runDefault)
 import GHCSpecter.UI.ConcurReplica.Types
-  ( IHTML,
-    blockDOMUpdate,
+  ( blockDOMUpdate,
     unblockDOMUpdate,
   )
 import GHCSpecter.UI.Types
   ( HasUIState (..),
-    UIState,
     emptyUIState,
   )
 import GHCSpecter.UI.Types.Event (Event (MessageChanUpdated))
@@ -213,10 +210,8 @@ webServer var = do
             put (ui, ss'')
             pure MessageChanUpdated
 
-      let renderUI0 = render stepStartTime (ui, ss)
-          -- wait for update interval, not to have too frequent update
-          renderUI =
+      let renderUI =
             if ui ^. uiShouldUpdate
-              then lift (unblockDOMUpdate renderUI0) -- >>= updateSS
-              else lift (blockDOMUpdate renderUI0) -- >>= updateSS
+              then lift (unblockDOMUpdate (render (ui, ss)))
+              else lift (blockDOMUpdate (render (ui, ss)))
       renderUI <|> await stepStartTime

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -46,9 +46,9 @@ import GHCSpecter.Comm
     runServer,
     sendObject,
   )
-import GHCSpecter.Control
+import GHCSpecter.Control qualified as Control (main)
+import GHCSpecter.Control.Runner
   ( Runner,
-    control,
     stepControlUpToEvent,
   )
 import GHCSpecter.Control.Types (Control)
@@ -171,7 +171,10 @@ webServer var = do
   ss0 <- atomically (readTVar var)
   initTime <- getCurrentTime
   runDefault 8080 "ghc-specter" $
-    \_ -> runStateT (loopM step (MessageChanUpdated, \_ -> control)) (emptyUIState initTime, ss0)
+    \_ ->
+      runStateT
+        (loopM step (MessageChanUpdated, \_ -> Control.main))
+        (emptyUIState initTime, ss0)
   where
     -- A single step of the outer loop (See Note [Control Loops]).
     step ::

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -47,11 +47,11 @@ import GHCSpecter.Comm
     sendObject,
   )
 import GHCSpecter.Control
-  ( Control,
-    Runner,
+  ( Runner,
     control,
     stepControlUpToEvent,
   )
+import GHCSpecter.Control.Types (Control)
 import GHCSpecter.Render (render)
 import GHCSpecter.Server.Types
   ( HasServerState (..),

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -29,11 +29,9 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Foldable qualified as F
 import Data.Map.Strict qualified as M
 import Data.Time.Clock
-  ( NominalDiffTime,
-    diffUTCTime,
+  ( diffUTCTime,
     getCurrentTime,
     nominalDiffTimeToSeconds,
-    secondsToNominalDiffTime,
   )
 import GHCSpecter.Channel
   ( ChanMessage (..),
@@ -66,6 +64,7 @@ import GHCSpecter.UI.ConcurReplica.Types
   ( blockDOMUpdate,
     unblockDOMUpdate,
   )
+import GHCSpecter.UI.Constants (chanUpdateInterval)
 import GHCSpecter.UI.Types
   ( HasUIState (..),
     emptyUIState,
@@ -116,9 +115,6 @@ main = do
         Right ss -> do
           var <- atomically $ newTVar ss
           webServer var
-
-chanUpdateInterval :: NominalDiffTime
-chanUpdateInterval = secondsToNominalDiffTime (fromRational (1 / 2))
 
 listener :: FilePath -> TVar ServerState -> IO ()
 listener socketFile var = do

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -50,7 +50,7 @@ import GHCSpecter.Comm
   )
 import GHCSpecter.Control
   ( Control,
-    ControlRunner,
+    Runner,
     control,
     stepControlUpToEvent,
   )
@@ -179,7 +179,7 @@ webServer var = do
   where
     step ::
       (Event, Event -> Control ()) ->
-      ControlRunner (Either (Event, Event -> Control ()) ())
+      Runner (Either (Event, Event -> Control ()) ())
     step (ev, c) = do
       result <- stepControlUpToEvent ev c
       ev' <- stepRender
@@ -187,7 +187,7 @@ webServer var = do
         Left c' -> pure (Left (ev', c'))
         Right r -> pure (Right r)
 
-    stepRender :: ControlRunner Event
+    stepRender :: Runner Event
     stepRender = do
       (ui, ss) <- get
       stepStartTime <- lift $ unsafeBlockingIO getCurrentTime

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -177,6 +177,7 @@ webServer var = do
   runDefault 8080 "ghc-specter" $
     \_ -> runStateT (loopM step (MessageChanUpdated, \_ -> control)) (emptyUIState initTime, ss0)
   where
+    -- A single step of the outer loop (See Note [Control Loops]).
     step ::
       (Event, Event -> Control ()) ->
       Runner (Either (Event, Event -> Control ()) ())

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -42,6 +42,7 @@ import GHCSpecter.Comm
     runServer,
     sendObject,
   )
+import GHCSpecter.Control (control, runControl)
 import GHCSpecter.Render (render)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
@@ -159,6 +160,7 @@ updateInbox chanMsg = incrementSN . updater
 
 webServer :: TVar ServerState -> IO ()
 webServer var = do
+  runControl control
   ss0 <- atomically (readTVar var)
   initTime <- getCurrentTime
   runDefault 8080 "test" $
@@ -166,6 +168,7 @@ webServer var = do
   where
     step :: (UIState, ServerState) -> Widget IHTML (Either (UIState, ServerState) ())
     step (ui0, ss) = do
+      -- unsafeBlockingIO control
       let lastUpdatedUI = ui0 ^. uiLastUpdated
       stepStartTime <- unsafeBlockingIO getCurrentTime
       unsafeBlockingIO $ print stepStartTime
@@ -199,9 +202,9 @@ webServer var = do
           renderUI =
             if ui ^. uiShouldUpdate
               then do
-                unsafeBlockingIO $ putStrLn "unblocking"
+                -- unsafeBlockingIO $ putStrLn "unblocking"
                 unblockDOMUpdate renderUI0
               else do
-                unsafeBlockingIO $ putStrLn "blocking"
+                -- unsafeBlockingIO $ putStrLn "blocking"
                 blockDOMUpdate renderUI0
       renderUI <|> (Left <$> await stepStartTime)

--- a/daemon/package.yaml
+++ b/daemon/package.yaml
@@ -126,6 +126,7 @@ executables:
       - optparse-applicative
       - stm
       - time
+      - transformers
 
 tests:
   ghc-specter-daemon-test:

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -1,30 +1,16 @@
 module GHCSpecter.Control
-  ( type Runner,
-    control,
-    stepControl,
-    stepControlUpToEvent,
+  ( main,
   )
 where
 
-import Concur.Core (Widget, unsafeBlockingIO)
 import Control.Lens ((.~), (^.), _1, _2)
 import Control.Monad (forever)
-import Control.Monad.Extra (loopM)
-import Control.Monad.Free (Free (..))
-import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.State (StateT (..), get, modify', put)
-import Data.Aeson (encode)
-import Data.ByteString.Lazy qualified as BL
-import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Text qualified as T
-import Data.Text.IO qualified as TIO
 import Data.Time.Clock (UTCTime)
 import Data.Time.Clock qualified as Clock
 import GHCSpecter.Channel (SessionInfo (..))
 import GHCSpecter.Control.Types
-  ( ControlF (..),
-    getCurrentTime,
+  ( getCurrentTime,
     getLastUpdatedUI,
     getState,
     nextEvent,
@@ -34,11 +20,7 @@ import GHCSpecter.Control.Types
     shouldUpdate,
     type Control,
   )
-import GHCSpecter.Server.Types
-  ( HasServerState (..),
-    ServerState (..),
-  )
-import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import GHCSpecter.Server.Types (HasServerState (..))
 import GHCSpecter.UI.Constants (uiUpdateInterval)
 import GHCSpecter.UI.Types
   ( HasModuleGraphUI (..),
@@ -55,88 +37,6 @@ import GHCSpecter.UI.Types.Event
     SubModuleEvent (..),
     TimingEvent (..),
   )
-import System.IO (IOMode (..), withFile)
-import System.IO.Unsafe (unsafePerformIO)
-
--- TODO: remove this
-tempRef :: IORef Int
-tempRef = unsafePerformIO (newIORef 0)
-{-# NOINLINE tempRef #-}
-
-type Runner = StateT (UIState, ServerState) (Widget IHTML)
-
-{-
-
-Note [Control Loops]
-~~~~~~~~~~~~~~~~~~~
-
-Control monad is embedded DSL (eDSL) which describe the program logic of the ghc-specter
-daemon. It is based on Free monad over a pattern functor that defines the allowed effects
-of the program logic.
-
-Among the effects, NextEvent is special since, at that step, the control runner yields
-its operation to the underlying Widget rendering engine or message receiver until a new
-event comes. Therefore, the control loop is defined in terms of 2-layered nested loops,
-where the outer loop is to run the event poking step interleaved with inner loop operations,
-and the inner loop is to process non-event-poking steps.
-
--}
-
--- | A single primitive step for the inner loop. See Note [Control Loops].
-stepControl ::
-  Control r ->
-  -- | What the result means:
-  -- Left _: continuation in the inner loop.
-  -- Right (Left _): continuation that waits for a new event in the outer loop
-  -- Right (Right _): final result as the business logic reaches its end.
-  -- TODO: Use more descriptive custom types.
-  Runner
-    ( Either
-        (Control r)
-        ( Either
-            (Event -> Control r)
-            r
-        )
-    )
-stepControl (Pure r) = pure (Right (Right r))
-stepControl (Free (GetState cont)) = do
-  (ui, ss) <- get
-  pure (Left (cont (ui, ss)))
-stepControl (Free (PutState (ui, ss) next)) = do
-  put (ui, ss)
-  pure (Left next)
-stepControl (Free (NextEvent cont)) =
-  pure (Right (Left cont))
-stepControl (Free (PrintMsg txt next)) = do
-  lift $
-    unsafeBlockingIO $ do
-      n <- readIORef tempRef
-      modifyIORef' tempRef (+ 1)
-      TIO.putStrLn $ (T.pack (show n) <> " : " <> txt)
-  pure (Left next)
-stepControl (Free (GetCurrentTime cont)) = do
-  now <- lift $ unsafeBlockingIO Clock.getCurrentTime
-  pure (Left (cont now))
-stepControl (Free (GetLastUpdatedUI cont)) = do
-  lastUpdatedUI <- (^. _1 . uiLastUpdated) <$> get
-  pure (Left (cont lastUpdatedUI))
-stepControl (Free (ShouldUpdate b next)) = do
-  modify' (_1 . uiShouldUpdate .~ b)
-  pure (Left next)
-stepControl (Free (SaveSession next)) = do
-  (_, ss) <- get
-  -- TODO: use asynchronous worker
-  liftIO $
-    withFile "session.json" WriteMode $ \h ->
-      BL.hPutStr h (encode ss)
-  pure (Left next)
-
--- | The inner loop described in the Note [Control Loops].
-stepControlUpToEvent ::
-  Event ->
-  (Event -> Control r) ->
-  Runner (Either (Event -> Control r) r)
-stepControlUpToEvent ev cont0 = loopM stepControl (cont0 ev)
 
 handleEvent :: Event -> UTCTime -> Control ()
 handleEvent topEv stepStartTime = do
@@ -229,8 +129,8 @@ handleEvent topEv stepStartTime = do
             then (uiLastUpdated .~ t) . (uiMousePosition .~ xy) $ ui_
             else uiMousePosition .~ xy $ ui_
 
-control :: Control ()
-control = forever $ do
+main :: Control ()
+main = forever $ do
   lastUpdatedUI <- getLastUpdatedUI
   stepStartTime <- getCurrentTime
 

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -1,6 +1,6 @@
 module GHCSpecter.Control
   ( Control,
-    ControlRunner,
+    type Runner,
     control,
     stepControl,
     stepControlUpToEvent,
@@ -89,12 +89,12 @@ tempRef :: IORef Int
 tempRef = unsafePerformIO (newIORef 0)
 {-# NOINLINE tempRef #-}
 
-type ControlRunner = StateT (UIState, ServerState) (Widget IHTML)
+type Runner = StateT (UIState, ServerState) (Widget IHTML)
 
 -- | step interpretation
 stepControl ::
   Control r ->
-  ControlRunner
+  Runner
     ( Either
         (Control r)
         ( Either
@@ -138,7 +138,7 @@ stepControl (Free (SaveSession next)) = do
 stepControlUpToEvent ::
   Event ->
   (Event -> Control r) ->
-  ControlRunner (Either (Event -> Control r) r)
+  Runner (Either (Event -> Control r) r)
 stepControlUpToEvent ev cont0 = loopM stepControl (cont0 ev)
 
 uiUpdateInterval :: NominalDiffTime

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -6,13 +6,18 @@ module GHCSpecter.Control
 where
 
 import Concur.Core (Widget, unsafeBlockingIO)
+import Control.Lens ((.~), (^.), _1)
 import Control.Monad (forever)
 import Control.Monad.Free (Free (..), liftF)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State (StateT (..), get, modify')
 import Data.Text (Text)
 import Data.Text.IO qualified as TIO
+import Data.Time.Clock (NominalDiffTime, UTCTime)
+import Data.Time.Clock qualified as Clock
 import GHCSpecter.Server.Types (ServerState (..))
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
-import GHCSpecter.UI.Types (UIState (..))
+import GHCSpecter.UI.Types (HasUIState (..), UIState)
 import GHCSpecter.UI.Types.Event (Event)
 
 data ControlF r
@@ -20,6 +25,9 @@ data ControlF r
   | CommitServer ServerState r
   | NextEvent (Event -> r)
   | PrintMsg Text r
+  | GetCurrentTime (UTCTime -> r)
+  | GetLastUpdatedUI (UTCTime -> r)
+  | ShouldUpdate Bool r
   deriving (Functor)
 
 type Control = Free ControlF
@@ -36,21 +44,43 @@ nextEvent = liftF (NextEvent id)
 printMsg :: Text -> Control ()
 printMsg txt = liftF (PrintMsg txt ())
 
+getCurrentTime :: Control UTCTime
+getCurrentTime = liftF (GetCurrentTime id)
+
+getLastUpdatedUI :: Control UTCTime
+getLastUpdatedUI = liftF (GetLastUpdatedUI id)
+
+shouldUpdate :: Bool -> Control ()
+shouldUpdate b = liftF (ShouldUpdate b ())
+
 -- | step interpretation
-stepControl :: Control r -> Widget IHTML (Either (Control r) r)
+stepControl :: Control r -> StateT (UIState, ServerState) (Widget IHTML) (Either (Control r) r)
 stepControl (Pure r) = pure (Right r)
 stepControl (Free (CommitUI _ next)) = pure (Left next)
 stepControl (Free (CommitServer _ next)) = pure (Left next)
 stepControl (Free (NextEvent cont)) = pure (Left (cont undefined))
 stepControl (Free (PrintMsg txt next)) = do
-  unsafeBlockingIO (TIO.putStrLn txt)
+  lift $ unsafeBlockingIO (TIO.putStrLn txt)
   pure (Left next)
+stepControl (Free (GetCurrentTime cont)) = do
+  now <- lift $ unsafeBlockingIO Clock.getCurrentTime
+  pure (Left (cont now))
+stepControl (Free (GetLastUpdatedUI cont)) = do
+  lastUpdatedUI <- (^. _1 . uiLastUpdated) <$> get
+  pure (Left (cont lastUpdatedUI))
+stepControl (Free (ShouldUpdate b next)) = do
+  modify' (_1 . uiShouldUpdate .~ b)
+  pure (Left next)
+
+uiUpdateInterval :: NominalDiffTime
+uiUpdateInterval = Clock.secondsToNominalDiffTime (fromRational (1 / 10))
 
 control :: Control ()
 control = forever $ do
-  commitUI undefined
-  printMsg "message1"
-  commitServer undefined
-  printMsg "message2"
-  _ <- nextEvent
-  printMsg "message3"
+  printMsg "control message"
+  lastUpdatedUI <- getLastUpdatedUI
+  stepStartTime <- getCurrentTime
+
+  if (stepStartTime `Clock.diffUTCTime` lastUpdatedUI > uiUpdateInterval)
+    then shouldUpdate True
+    else shouldUpdate False

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -1,5 +1,6 @@
 module GHCSpecter.Control
-  ( control,
+  ( Control,
+    control,
     stepControl,
   )
 where

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -1,0 +1,54 @@
+module GHCSpecter.Control
+  ( control,
+    runControl,
+  )
+where
+
+import Control.Monad.Extra (loopM)
+import Control.Monad.Free (Free (..), liftF)
+import Data.Text (Text)
+import Data.Text.IO qualified as TIO
+import GHCSpecter.Server.Types (ServerState (..))
+import GHCSpecter.UI.Types (UIState (..))
+import GHCSpecter.UI.Types.Event (Event)
+
+data ControlF r
+  = CommitUI UIState r
+  | CommitServer ServerState r
+  | NextEvent (Event -> r)
+  | PrintMsg Text r
+  deriving (Functor)
+
+type Control = Free ControlF
+
+commitUI :: UIState -> Control ()
+commitUI ui = liftF (CommitUI ui ())
+
+commitServer :: ServerState -> Control ()
+commitServer ss = liftF (CommitServer ss ())
+
+nextEvent :: Control Event
+nextEvent = liftF (NextEvent id)
+
+printMsg :: Text -> Control ()
+printMsg txt = liftF (PrintMsg txt ())
+
+-- | step interpretation
+stepControl :: Control r -> IO (Either (Control r) r)
+stepControl (Pure r) = pure (Right r)
+stepControl (Free (CommitUI _ next)) = pure (Left next)
+stepControl (Free (CommitServer _ next)) = pure (Left next)
+stepControl (Free (NextEvent cont)) = pure (Left (cont undefined))
+stepControl (Free (PrintMsg txt next)) = TIO.putStrLn txt >> pure (Left next)
+
+runControl :: Control r -> IO r
+runControl action = loopM stepControl action
+
+control :: Control ()
+control = do
+  commitUI undefined
+  printMsg "message1"
+  commitServer undefined
+  printMsg "message2"
+  _ <- nextEvent
+  printMsg "message3"

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -1,42 +1,71 @@
 module GHCSpecter.Control
   ( Control,
+    ControlRunner,
     control,
     stepControl,
+    stepControlUpToEvent,
   )
 where
 
 import Concur.Core (Widget, unsafeBlockingIO)
-import Control.Lens ((.~), (^.), _1)
+import Control.Lens ((.~), (^.), _1, _2)
 import Control.Monad (forever)
+import Control.Monad.Extra (loopM)
 import Control.Monad.Free (Free (..), liftF)
+import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.State (StateT (..), get, modify')
+import Control.Monad.Trans.State (StateT (..), get, modify', put)
+import Data.Aeson (encode)
+import Data.ByteString.Lazy qualified as BL
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import Data.Time.Clock (NominalDiffTime, UTCTime)
 import Data.Time.Clock qualified as Clock
-import GHCSpecter.Server.Types (ServerState (..))
+import GHCSpecter.Channel (SessionInfo (..))
+import GHCSpecter.Server.Types
+  ( HasServerState (..),
+    ServerState (..),
+  )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
-import GHCSpecter.UI.Types (HasUIState (..), UIState)
-import GHCSpecter.UI.Types.Event (Event)
+import GHCSpecter.UI.Types
+  ( HasModuleGraphUI (..),
+    HasSourceViewUI (..),
+    HasTimingUI (..),
+    HasUIState (..),
+    ModuleGraphUI (..),
+    UIState (..),
+  )
+import GHCSpecter.UI.Types.Event
+  ( Event (..),
+    ModuleGraphEvent (..),
+    SessionEvent (..),
+    SubModuleEvent (..),
+    Tab (..),
+    TimingEvent (..),
+  )
+import System.IO (IOMode (..), withFile)
+import System.IO.Unsafe (unsafePerformIO)
 
 data ControlF r
-  = CommitUI UIState r
-  | CommitServer ServerState r
+  = GetState ((UIState, ServerState) -> r)
+  | PutState (UIState, ServerState) r
   | NextEvent (Event -> r)
   | PrintMsg Text r
   | GetCurrentTime (UTCTime -> r)
   | GetLastUpdatedUI (UTCTime -> r)
   | ShouldUpdate Bool r
+  | SaveSession r
   deriving (Functor)
 
 type Control = Free ControlF
 
-commitUI :: UIState -> Control ()
-commitUI ui = liftF (CommitUI ui ())
+getState :: Control (UIState, ServerState)
+getState = liftF (GetState id)
 
-commitServer :: ServerState -> Control ()
-commitServer ss = liftF (CommitServer ss ())
+putState :: (UIState, ServerState) -> Control ()
+putState (ui, ss) = liftF (PutState (ui, ss) ())
 
 nextEvent :: Control Event
 nextEvent = liftF (NextEvent id)
@@ -53,14 +82,42 @@ getLastUpdatedUI = liftF (GetLastUpdatedUI id)
 shouldUpdate :: Bool -> Control ()
 shouldUpdate b = liftF (ShouldUpdate b ())
 
+saveSession :: Control ()
+saveSession = liftF (SaveSession ())
+
+-- TODO: remove this
+tempRef :: IORef Int
+tempRef = unsafePerformIO (newIORef 0)
+{-# NOINLINE tempRef #-}
+
+type ControlRunner = StateT (UIState, ServerState) (Widget IHTML)
+
 -- | step interpretation
-stepControl :: Control r -> StateT (UIState, ServerState) (Widget IHTML) (Either (Control r) r)
-stepControl (Pure r) = pure (Right r)
-stepControl (Free (CommitUI _ next)) = pure (Left next)
-stepControl (Free (CommitServer _ next)) = pure (Left next)
-stepControl (Free (NextEvent cont)) = pure (Left (cont undefined))
+stepControl ::
+  Control r ->
+  ControlRunner
+    ( Either
+        (Control r)
+        ( Either
+            (Event -> Control r)
+            r
+        )
+    )
+stepControl (Pure r) = pure (Right (Right r))
+stepControl (Free (GetState cont)) = do
+  (ui, ss) <- get
+  pure (Left (cont (ui, ss)))
+stepControl (Free (PutState (ui, ss) next)) = do
+  put (ui, ss)
+  pure (Left next)
+stepControl (Free (NextEvent cont)) =
+  pure (Right (Left cont))
 stepControl (Free (PrintMsg txt next)) = do
-  lift $ unsafeBlockingIO (TIO.putStrLn txt)
+  lift $
+    unsafeBlockingIO $ do
+      n <- readIORef tempRef
+      modifyIORef' tempRef (+ 1)
+      TIO.putStrLn $ (T.pack (show n) <> " : " <> txt)
   pure (Left next)
 stepControl (Free (GetCurrentTime cont)) = do
   now <- lift $ unsafeBlockingIO Clock.getCurrentTime
@@ -71,16 +128,126 @@ stepControl (Free (GetLastUpdatedUI cont)) = do
 stepControl (Free (ShouldUpdate b next)) = do
   modify' (_1 . uiShouldUpdate .~ b)
   pure (Left next)
+stepControl (Free (SaveSession next)) = do
+  (_, ss) <- get
+  -- TODO: use asynchronous worker
+  liftIO $
+    withFile "session.json" WriteMode $ \h ->
+      BL.hPutStr h (encode ss)
+  pure (Left next)
+
+stepControlUpToEvent ::
+  Event ->
+  (Event -> Control r) ->
+  ControlRunner (Either (Event -> Control r) r)
+stepControlUpToEvent ev cont0 = loopM stepControl (cont0 ev)
 
 uiUpdateInterval :: NominalDiffTime
 uiUpdateInterval = Clock.secondsToNominalDiffTime (fromRational (1 / 10))
 
+handleEvent ::
+  Event ->
+  UTCTime ->
+  (UIState, ServerState) ->
+  Control (UIState, ServerState)
+handleEvent topEv stepStartTime (oldUI, oldSS) =
+  case topEv of
+    TabEv tab' -> do
+      let newUI = (uiTab .~ tab') oldUI
+          newSS = (serverShouldUpdate .~ False) oldSS
+      pure (newUI, newSS)
+    ExpandModuleEv mexpandedModu' -> do
+      let newUI = (uiSourceView . srcViewExpandedModule .~ mexpandedModu') oldUI
+          newSS = (serverShouldUpdate .~ False) oldSS
+      pure (newUI, newSS)
+    MainModuleEv ev -> do
+      let mgui = oldUI ^. uiMainModuleGraph
+      (mgui', mxy) <- handleModuleGraphEv ev mgui
+      let newUI = (uiMainModuleGraph .~ mgui') oldUI
+          newUI' = handleMouseMove newUI mxy
+          newSS = (serverShouldUpdate .~ False) oldSS
+      pure (newUI', newSS)
+    SubModuleEv sev ->
+      case sev of
+        SubModuleGraphEv ev -> do
+          let mgui = oldUI ^. uiSubModuleGraph . _2
+          (mgui', mxy) <- handleModuleGraphEv ev mgui
+          let newUI = (uiSubModuleGraph . _2 .~ mgui') oldUI
+              newUI' = handleMouseMove newUI mxy
+              newSS = (serverShouldUpdate .~ False) oldSS
+          pure (newUI', newSS)
+        SubModuleLevelEv d' -> do
+          let newUI = (uiSubModuleGraph . _1 .~ d') oldUI
+              newSS = (serverShouldUpdate .~ False) oldSS
+          pure (newUI, newSS)
+    SessionEv SaveSessionEv -> do
+      saveSession
+      let newSS = (serverShouldUpdate .~ False) oldSS
+      pure (oldUI, newSS)
+    SessionEv ResumeSessionEv -> do
+      let sinfo = oldSS ^. serverSessionInfo
+          sinfo' = sinfo {sessionIsPaused = False}
+          newSS = (serverSessionInfo .~ sinfo') . (serverShouldUpdate .~ True) $ oldSS
+      pure (oldUI, newSS)
+    SessionEv PauseSessionEv -> do
+      let sinfo = oldSS ^. serverSessionInfo
+          sinfo' = sinfo {sessionIsPaused = True}
+          newSS = (serverSessionInfo .~ sinfo') . (serverShouldUpdate .~ True) $ oldSS
+      pure (oldUI, newSS)
+    TimingEv (UpdateSticky b) -> do
+      let newUI = (uiTiming . timingUISticky .~ b) oldUI
+          newSS = (serverShouldUpdate .~ False) oldSS
+      pure (newUI, newSS)
+    TimingEv (UpdatePartition b) -> do
+      let newUI = (uiTiming . timingUIPartition .~ b) oldUI
+          newSS = (serverShouldUpdate .~ False) oldSS
+      pure (newUI, newSS)
+    TimingEv (UpdateParallel b) -> do
+      let newUI = (uiTiming . timingUIHowParallel .~ b) oldUI
+          newSS = (serverShouldUpdate .~ False) oldSS
+      pure (newUI, newSS)
+    MessageChanUpdated -> do
+      let newSS = (serverShouldUpdate .~ True) oldSS
+      pure (oldUI, newSS)
+  where
+    handleModuleGraphEv ::
+      ModuleGraphEvent ->
+      ModuleGraphUI ->
+      Control (ModuleGraphUI, Maybe (UTCTime, (Double, Double)))
+    handleModuleGraphEv (HoverOnModuleEv mhovered) mgui =
+      pure ((modGraphUIHover .~ mhovered) mgui, Nothing)
+    handleModuleGraphEv (ClickOnModuleEv mclicked) mgui =
+      pure ((modGraphUIClick .~ mclicked) mgui, Nothing)
+    handleModuleGraphEv (DummyEv mxy) mgui = do
+      t <- getCurrentTime
+      printMsg (T.pack (show (stepStartTime, t, mxy)))
+      pure (mgui, (t,) <$> mxy)
+
+    handleMouseMove ::
+      UIState ->
+      Maybe (UTCTime, (Double, Double)) ->
+      UIState
+    handleMouseMove ui_ mtxy =
+      case mtxy of
+        Nothing -> ui_
+        Just (t, xy) ->
+          if ui_ ^. uiShouldUpdate
+            then (uiLastUpdated .~ t) . (uiMousePosition .~ xy) $ ui_
+            else uiMousePosition .~ xy $ ui_
+
 control :: Control ()
 control = forever $ do
-  printMsg "control message"
   lastUpdatedUI <- getLastUpdatedUI
   stepStartTime <- getCurrentTime
 
   if (stepStartTime `Clock.diffUTCTime` lastUpdatedUI > uiUpdateInterval)
     then shouldUpdate True
     else shouldUpdate False
+
+  printMsg "waiting for the next event"
+  ev <- nextEvent
+  printMsg (T.pack (show ev))
+
+  (ui, ss) <- getState
+  (ui', ss') <- handleEvent ev stepStartTime (ui, ss)
+  putState (ui', ss')

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -115,6 +115,7 @@ stepControl ::
   -- Left _: continuation in the inner loop.
   -- Right (Left _): continuation that waits for a new event in the outer loop
   -- Right (Right _): final result as the business logic reaches its end.
+  -- TODO: Use more descriptive custom types.
   Runner
     ( Either
         (Control r)

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -29,6 +29,7 @@ import GHCSpecter.Server.Types
     ServerState (..),
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import GHCSpecter.UI.Constants (uiUpdateInterval)
 import GHCSpecter.UI.Types
   ( HasModuleGraphUI (..),
     HasSourceViewUI (..),
@@ -163,9 +164,6 @@ stepControlUpToEvent ::
   (Event -> Control r) ->
   Runner (Either (Event -> Control r) r)
 stepControlUpToEvent ev cont0 = loopM stepControl (cont0 ev)
-
-uiUpdateInterval :: NominalDiffTime
-uiUpdateInterval = Clock.secondsToNominalDiffTime (fromRational (1 / 10))
 
 handleEvent :: Event -> UTCTime -> Control ()
 handleEvent topEv stepStartTime = do

--- a/daemon/src/GHCSpecter/Control/Runner.hs
+++ b/daemon/src/GHCSpecter/Control/Runner.hs
@@ -1,0 +1,113 @@
+module GHCSpecter.Control.Runner
+  ( type Runner,
+    stepControl,
+    stepControlUpToEvent,
+  )
+where
+
+import Concur.Core (Widget, unsafeBlockingIO)
+import Control.Lens ((.~), (^.), _1)
+import Control.Monad.Extra (loopM)
+import Control.Monad.Free (Free (..))
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State (StateT (..), get, modify', put)
+import Data.Aeson (encode)
+import Data.ByteString.Lazy qualified as BL
+import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import Data.Time.Clock qualified as Clock
+import GHCSpecter.Control.Types
+  ( ControlF (..),
+    type Control,
+  )
+import GHCSpecter.Server.Types (ServerState)
+import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import GHCSpecter.UI.Types
+  ( HasUIState (..),
+    UIState (..),
+  )
+import GHCSpecter.UI.Types.Event (Event (..))
+import System.IO (IOMode (..), withFile)
+import System.IO.Unsafe (unsafePerformIO)
+
+-- TODO: remove this
+tempRef :: IORef Int
+tempRef = unsafePerformIO (newIORef 0)
+{-# NOINLINE tempRef #-}
+
+type Runner = StateT (UIState, ServerState) (Widget IHTML)
+
+{-
+
+Note [Control Loops]
+~~~~~~~~~~~~~~~~~~~
+
+Control monad is embedded DSL (eDSL) which describe the program logic of the ghc-specter
+daemon. It is based on Free monad over a pattern functor that defines the allowed effects
+of the program logic.
+
+Among the effects, NextEvent is special since, at that step, the control runner yields
+its operation to the underlying Widget rendering engine or message receiver until a new
+event comes. Therefore, the control loop is defined in terms of 2-layered nested loops,
+where the outer loop is to run the event poking step interleaved with inner loop operations,
+and the inner loop is to process non-event-poking steps.
+
+-}
+
+-- | A single primitive step for the inner loop. See Note [Control Loops].
+stepControl ::
+  Control r ->
+  -- | What the result means:
+  -- Left _: continuation in the inner loop.
+  -- Right (Left _): continuation that waits for a new event in the outer loop
+  -- Right (Right _): final result as the business logic reaches its end.
+  -- TODO: Use more descriptive custom types.
+  Runner
+    ( Either
+        (Control r)
+        ( Either
+            (Event -> Control r)
+            r
+        )
+    )
+stepControl (Pure r) = pure (Right (Right r))
+stepControl (Free (GetState cont)) = do
+  (ui, ss) <- get
+  pure (Left (cont (ui, ss)))
+stepControl (Free (PutState (ui, ss) next)) = do
+  put (ui, ss)
+  pure (Left next)
+stepControl (Free (NextEvent cont)) =
+  pure (Right (Left cont))
+stepControl (Free (PrintMsg txt next)) = do
+  lift $
+    unsafeBlockingIO $ do
+      n <- readIORef tempRef
+      modifyIORef' tempRef (+ 1)
+      TIO.putStrLn $ (T.pack (show n) <> " : " <> txt)
+  pure (Left next)
+stepControl (Free (GetCurrentTime cont)) = do
+  now <- lift $ unsafeBlockingIO Clock.getCurrentTime
+  pure (Left (cont now))
+stepControl (Free (GetLastUpdatedUI cont)) = do
+  lastUpdatedUI <- (^. _1 . uiLastUpdated) <$> get
+  pure (Left (cont lastUpdatedUI))
+stepControl (Free (ShouldUpdate b next)) = do
+  modify' (_1 . uiShouldUpdate .~ b)
+  pure (Left next)
+stepControl (Free (SaveSession next)) = do
+  (_, ss) <- get
+  -- TODO: use asynchronous worker
+  liftIO $
+    withFile "session.json" WriteMode $ \h ->
+      BL.hPutStr h (encode ss)
+  pure (Left next)
+
+-- | The inner loop described in the Note [Control Loops].
+stepControlUpToEvent ::
+  Event ->
+  (Event -> Control r) ->
+  Runner (Either (Event -> Control r) r)
+stepControlUpToEvent ev cont0 = loopM stepControl (cont0 ev)

--- a/daemon/src/GHCSpecter/Control/Types.hs
+++ b/daemon/src/GHCSpecter/Control/Types.hs
@@ -1,0 +1,61 @@
+module GHCSpecter.Control.Types
+  ( -- * eDSL Types
+    ControlF (..),
+    Control,
+
+    -- * Primitive operations of eDSL
+    getState,
+    putState,
+    nextEvent,
+    printMsg,
+    getCurrentTime,
+    getLastUpdatedUI,
+    shouldUpdate,
+    saveSession,
+  )
+where
+
+import Control.Monad.Free (Free (..), liftF)
+import Data.Text (Text)
+import Data.Time.Clock (UTCTime)
+import GHCSpecter.Server.Types (ServerState)
+import GHCSpecter.UI.Types (UIState)
+import GHCSpecter.UI.Types.Event (Event)
+
+-- | Pattern functor for effects of Control DSL.
+data ControlF r
+  = GetState ((UIState, ServerState) -> r)
+  | PutState (UIState, ServerState) r
+  | NextEvent (Event -> r)
+  | PrintMsg Text r
+  | GetCurrentTime (UTCTime -> r)
+  | GetLastUpdatedUI (UTCTime -> r)
+  | ShouldUpdate Bool r
+  | SaveSession r
+  deriving (Functor)
+
+type Control = Free ControlF
+
+getState :: Control (UIState, ServerState)
+getState = liftF (GetState id)
+
+putState :: (UIState, ServerState) -> Control ()
+putState (ui, ss) = liftF (PutState (ui, ss) ())
+
+nextEvent :: Control Event
+nextEvent = liftF (NextEvent id)
+
+printMsg :: Text -> Control ()
+printMsg txt = liftF (PrintMsg txt ())
+
+getCurrentTime :: Control UTCTime
+getCurrentTime = liftF (GetCurrentTime id)
+
+getLastUpdatedUI :: Control UTCTime
+getLastUpdatedUI = liftF (GetLastUpdatedUI id)
+
+shouldUpdate :: Bool -> Control ()
+shouldUpdate b = liftF (ShouldUpdate b ())
+
+saveSession :: Control ()
+saveSession = liftF (SaveSession ())

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -112,6 +112,82 @@ tempRef :: IORef Int
 tempRef = unsafePerformIO (newIORef 0)
 {-# NOINLINE tempRef #-}
 
+handleEvent :: Event -> UTCTime -> (UIState, ServerState) -> Widget IHTML (UIState, (ServerState, Bool))
+handleEvent topEv stepStartTime (oldUI, oldSS) =
+  case topEv of
+    TabEv tab' ->
+      pure ((uiTab .~ tab') oldUI, (oldSS, False))
+    ExpandModuleEv mexpandedModu' ->
+      pure ((uiSourceView . srcViewExpandedModule .~ mexpandedModu') oldUI, (oldSS, False))
+    MainModuleEv ev -> do
+      let mgui = oldUI ^. uiMainModuleGraph
+      (mgui', mxy) <- handleModuleGraphEv ev mgui
+      let newUI = (uiMainModuleGraph .~ mgui') oldUI
+          newUI' = handleMouseMove newUI mxy
+      pure (newUI', (oldSS, False))
+    SubModuleEv sev ->
+      case sev of
+        SubModuleGraphEv ev -> do
+          let mgui = oldUI ^. uiSubModuleGraph . _2
+          (mgui', mxy) <- handleModuleGraphEv ev mgui
+          let newUI = (uiSubModuleGraph . _2 .~ mgui') oldUI
+              newUI' = handleMouseMove newUI mxy
+          pure (newUI', (oldSS, False))
+        SubModuleLevelEv d' ->
+          pure
+            ((uiSubModuleGraph . _1 .~ d') oldUI, (oldSS, False))
+    SessionEv SaveSessionEv -> do
+      -- TODO: use asynchronous worker
+      liftIO $
+        withFile "session.json" WriteMode $ \h ->
+          BL.hPutStr h (encode oldSS)
+      pure (oldUI, (oldSS, False))
+    SessionEv ResumeSessionEv -> do
+      let sinfo = oldSS ^. serverSessionInfo
+          sinfo' = sinfo {sessionIsPaused = False}
+          newSS = (serverSessionInfo .~ sinfo') oldSS
+      pure (oldUI, (newSS, True))
+    SessionEv PauseSessionEv -> do
+      let sinfo = oldSS ^. serverSessionInfo
+          sinfo' = sinfo {sessionIsPaused = True}
+          newSS = (serverSessionInfo .~ sinfo') oldSS
+      pure (oldUI, (newSS, True))
+    TimingEv (UpdateSticky b) ->
+      pure
+        ((uiTiming . timingUISticky .~ b) oldUI, (oldSS, False))
+    TimingEv (UpdatePartition b) ->
+      pure
+        ((uiTiming . timingUIPartition .~ b) oldUI, (oldSS, False))
+    TimingEv (UpdateParallel b) ->
+      pure
+        ((uiTiming . timingUIHowParallel .~ b) oldUI, (oldSS, False))
+  where
+    handleModuleGraphEv ::
+      ModuleGraphEvent ->
+      ModuleGraphUI ->
+      Widget IHTML (ModuleGraphUI, Maybe (UTCTime, (Double, Double)))
+    handleModuleGraphEv (HoverOnModuleEv mhovered) mgui =
+      pure ((modGraphUIHover .~ mhovered) mgui, Nothing)
+    handleModuleGraphEv (ClickOnModuleEv mclicked) mgui =
+      pure ((modGraphUIClick .~ mclicked) mgui, Nothing)
+    handleModuleGraphEv (DummyEv mxy) mgui = do
+      t <-
+        unsafeBlockingIO $ do
+          n <- readIORef tempRef
+          modifyIORef' tempRef (+ 1)
+          t <- getCurrentTime
+          print (n, stepStartTime, t, mxy)
+          pure t
+      pure (mgui, (t,) <$> mxy)
+
+    handleMouseMove ui_ mxy =
+      case mxy of
+        Nothing -> ui_
+        Just (t, xy) ->
+          if ui_ ^. uiShouldUpdate
+            then (uiLastUpdated .~ t) . (uiMousePosition .~ xy) $ ui_
+            else uiMousePosition .~ xy $ ui_
+
 render ::
   UTCTime ->
   (UIState, ServerState) ->
@@ -136,90 +212,14 @@ render stepStartTime (ui, ss) = do
                     ]
                 ]
             )
-
-  let handleNavbar :: Event -> UIState -> UIState
-      handleNavbar (TabEv tab') = (uiTab .~ tab')
-      handleNavbar _ = id
-
-      handleModuleGraphEv ::
-        ModuleGraphEvent ->
-        ModuleGraphUI ->
-        Widget IHTML (ModuleGraphUI, Maybe (UTCTime, (Double, Double)))
-      handleModuleGraphEv (HoverOnModuleEv mhovered) mgui =
-        pure ((modGraphUIHover .~ mhovered) mgui, Nothing)
-      handleModuleGraphEv (ClickOnModuleEv mclicked) mgui =
-        pure ((modGraphUIClick .~ mclicked) mgui, Nothing)
-      handleModuleGraphEv (DummyEv mxy) mgui = do
-        t <-
-          unsafeBlockingIO $ do
-            n <- readIORef tempRef
-            modifyIORef' tempRef (+ 1)
-            t <- getCurrentTime
-            print (n, stepStartTime, t, mxy)
-            pure t
-        pure (mgui, (t,) <$> mxy)
-
-      handleMouseMove ui_ mxy =
-        case mxy of
-          Nothing -> ui_
-          Just (t, xy) ->
-            if ui_ ^. uiShouldUpdate
-              then (uiLastUpdated .~ t) . (uiMousePosition .~ xy) $ ui_
-              else uiMousePosition .~ xy $ ui_
-
-      handleMainPanel :: (UIState, ServerState) -> Event -> Widget IHTML (UIState, (ServerState, Bool))
-      handleMainPanel (oldUI, oldSS) (ExpandModuleEv mexpandedModu') =
-        pure ((uiSourceView . srcViewExpandedModule .~ mexpandedModu') oldUI, (oldSS, False))
-      handleMainPanel (oldUI, oldSS) (MainModuleEv ev) = do
-        let mgui = oldUI ^. uiMainModuleGraph
-        (mgui', mxy) <- handleModuleGraphEv ev mgui
-        let newUI = (uiMainModuleGraph .~ mgui') oldUI
-            newUI' = handleMouseMove newUI mxy
-        pure (newUI', (oldSS, False))
-      handleMainPanel (oldUI, oldSS) (SubModuleEv sev) =
-        case sev of
-          SubModuleGraphEv ev -> do
-            let mgui = oldUI ^. uiSubModuleGraph . _2
-            (mgui', mxy) <- handleModuleGraphEv ev mgui
-            let newUI = (uiSubModuleGraph . _2 .~ mgui') oldUI
-                newUI' = handleMouseMove newUI mxy
-            pure (newUI', (oldSS, False))
-          SubModuleLevelEv d' ->
-            pure
-              ((uiSubModuleGraph . _1 .~ d') oldUI, (oldSS, False))
-      handleMainPanel (oldUI, oldSS) (SessionEv SaveSessionEv) = do
-        liftIO $
-          withFile "session.json" WriteMode $ \h ->
-            BL.hPutStr h (encode ss)
-        pure (oldUI, (oldSS, False))
-      handleMainPanel (oldUI, oldSS) (SessionEv ResumeSessionEv) = do
-        let sinfo = oldSS ^. serverSessionInfo
-            sinfo' = sinfo {sessionIsPaused = False}
-            newSS = (serverSessionInfo .~ sinfo') oldSS
-        pure (oldUI, (newSS, True))
-      handleMainPanel (oldUI, oldSS) (SessionEv PauseSessionEv) = do
-        let sinfo = oldSS ^. serverSessionInfo
-            sinfo' = sinfo {sessionIsPaused = True}
-        let newSS = (serverSessionInfo .~ sinfo') oldSS
-        pure (oldUI, (newSS, True))
-      handleMainPanel (oldUI, oldSS) (TimingEv (UpdateSticky b)) =
-        pure
-          ((uiTiming . timingUISticky .~ b) oldUI, (oldSS, False))
-      handleMainPanel (oldUI, oldSS) (TimingEv (UpdatePartition b)) =
-        pure
-          ((uiTiming . timingUIPartition .~ b) oldUI, (oldSS, False))
-      handleMainPanel (oldUI, oldSS) (TimingEv (UpdateParallel b)) =
-        pure
-          ((uiTiming . timingUIHowParallel .~ b) oldUI, (oldSS, False))
-      handleMainPanel (oldUI, oldSS) _ = pure (oldUI, (oldSS, False))
-
-  (ui', (ss', shouldUpdate)) <-
+  ev <-
     div
       [classList [("container is-fullheight is-size-7 m-4 p-4", True)]]
       [ cssLink "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
       , cssLink "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css"
-      , (,(ss, False)) <$> (`handleNavbar` ui) <$> renderNavbar (ui ^. uiTab)
-      , handleMainPanel (ui, ss) =<< mainPanel
+      , renderNavbar (ui ^. uiTab)
+      , mainPanel
       , bottomPanel
       ]
+  (ui', (ss', shouldUpdate)) <- handleEvent ev stepStartTime (ui, ss)
   pure (ui', (ss', shouldUpdate))

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -7,8 +7,7 @@ module GHCSpecter.Render
 where
 
 import Concur.Core
-  ( SuspendF (..),
-    Widget (..),
+  ( Widget (..),
     unsafeBlockingIO,
   )
 import Concur.Replica
@@ -19,7 +18,6 @@ import Concur.Replica
     textProp,
   )
 import Control.Lens (to, (.~), (^.), _1, _2)
-import Control.Monad.Free (liftF)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (encode)
 import Data.ByteString.Lazy qualified as BL
@@ -70,14 +68,13 @@ divClass :: Text -> [Props a] -> [Widget IHTML a] -> Widget IHTML a
 divClass cls props = div (classList [(cls, True)] : props)
 
 renderMainPanel ::
-  UTCTime ->
   UIState ->
   ServerState ->
   Widget IHTML Event
-renderMainPanel stepStartTime ui ss =
+renderMainPanel ui ss =
   case ui ^. uiTab of
     TabSession -> Session.render ss
-    TabModuleGraph -> ModuleGraph.render stepStartTime ui ss
+    TabModuleGraph -> ModuleGraph.render ui ss
     TabSourceView -> SourceView.render (ui ^. uiSourceView) ss
     TabTiming -> Timing.render ui ss
 
@@ -128,7 +125,7 @@ render stepStartTime (ui, ss) = do
         | otherwise =
             ( section
                 [style [("height", "85vh"), ("overflow-y", "scroll")]]
-                [renderMainPanel stepStartTime ui ss]
+                [renderMainPanel ui ss]
             , section
                 []
                 [ divClass

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -1,15 +1,11 @@
 {-# LANGUAGE LambdaCase #-}
 
 module GHCSpecter.Render
-  ( ChanModule,
-    render,
+  ( render,
   )
 where
 
-import Concur.Core
-  ( Widget (..),
-    unsafeBlockingIO,
-  )
+import Concur.Core (Widget (..))
 import Concur.Replica
   ( Props,
     classList,
@@ -17,15 +13,9 @@ import Concur.Replica
     style,
     textProp,
   )
-import Control.Lens (to, (.~), (^.), _1, _2)
-import Control.Monad.IO.Class (liftIO)
-import Data.Aeson (encode)
-import Data.ByteString.Lazy qualified as BL
-import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
+import Control.Lens (to, (^.))
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Time.Clock (UTCTime, getCurrentTime)
-import GHCSpecter.Channel (SessionInfo (..))
 import GHCSpecter.Render.ModuleGraph qualified as ModuleGraph
 import GHCSpecter.Render.Session qualified as Session
 import GHCSpecter.Render.SourceView qualified as SourceView
@@ -33,7 +23,6 @@ import GHCSpecter.Render.Timing qualified as Timing
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState (..),
-    type ChanModule,
   )
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,
@@ -45,23 +34,13 @@ import GHCSpecter.UI.ConcurReplica.DOM
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
-  ( HasModuleGraphUI (..),
-    HasSourceViewUI (..),
-    HasTimingUI (..),
-    HasUIState (..),
-    ModuleGraphUI (..),
+  ( HasUIState (..),
     UIState (..),
   )
 import GHCSpecter.UI.Types.Event
   ( Event (..),
-    ModuleGraphEvent (..),
-    SessionEvent (..),
-    SubModuleEvent (..),
     Tab (..),
-    TimingEvent (..),
   )
-import System.IO (IOMode (WriteMode), withFile)
-import System.IO.Unsafe (unsafePerformIO)
 import Prelude hiding (div, span)
 
 divClass :: Text -> [Props a] -> [Widget IHTML a] -> Widget IHTML a
@@ -109,11 +88,9 @@ renderNavbar tab =
        in el "a" [cls, onClick]
 
 render ::
-  UTCTime ->
   (UIState, ServerState) ->
-  -- Widget IHTML (UIState, (ServerState, Bool))
   Widget IHTML Event
-render stepStartTime (ui, ss) = do
+render (ui, ss) = do
   let (mainPanel, bottomPanel)
         | ss ^. serverMessageSN == 0 =
             ( div [] [text "No GHC process yet"]

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -46,11 +46,6 @@ import Data.Map qualified as M
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Time.Clock
-  ( NominalDiffTime,
-    UTCTime,
-    secondsToNominalDiffTime,
-  )
 import Data.Tuple (swap)
 import GHCSpecter.Channel
   ( ModuleGraphInfo (..),
@@ -418,8 +413,8 @@ renderDetailLevel ui =
     detail300 = mkRadioItem UpTo300 "< 300" (currLevel == UpTo300)
 
 -- | top-level render function for Module Graph tab
-render :: UTCTime -> UIState -> ServerState -> Widget IHTML Event
-render stepStartTime ui ss =
+render :: UIState -> ServerState -> Widget IHTML Event
+render ui ss =
   let sessionInfo = ss ^. serverSessionInfo
       nameMap = mginfoModuleNameMap $ sessionModuleGraph sessionInfo
       timing = ss ^. serverTiming

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -253,6 +253,7 @@ emptyHieState = HieState mempty
 
 data ServerState = ServerState
   { _serverMessageSN :: Int
+  , _serverShouldUpdate :: Bool
   , _serverLastUpdated :: UTCTime
   , _serverInbox :: Inbox
   , _serverSessionInfo :: SessionInfo
@@ -272,6 +273,7 @@ emptyServerState :: UTCTime -> ServerState
 emptyServerState now =
   ServerState
     { _serverMessageSN = 0
+    , _serverShouldUpdate = True
     , _serverLastUpdated = now
     , _serverInbox = mempty
     , _serverSessionInfo = SessionInfo Nothing emptyModuleGraphInfo False

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 -- | This module is originated from Network.Wai.Handler.Replica.
 -- When IHTML can be marked with the non-update (the Left case) directive,

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+-- NOTE: This disables the unwanted warning due to the use of forkPingThread.
+-- TODO: use withPingThread as suggested after an investigation.
 {-# OPTIONS_GHC -fno-warn-deprecations #-}
 
 -- | This module is originated from Network.Wai.Handler.Replica.

--- a/daemon/src/GHCSpecter/UI/Constants.hs
+++ b/daemon/src/GHCSpecter/UI/Constants.hs
@@ -11,4 +11,3 @@ chanUpdateInterval = secondsToNominalDiffTime (fromRational (1 / 2))
 
 uiUpdateInterval :: NominalDiffTime
 uiUpdateInterval = secondsToNominalDiffTime (fromRational (1 / 10))
-

--- a/daemon/src/GHCSpecter/UI/Constants.hs
+++ b/daemon/src/GHCSpecter/UI/Constants.hs
@@ -1,0 +1,14 @@
+module GHCSpecter.UI.Constants
+  ( chanUpdateInterval,
+    uiUpdateInterval,
+  )
+where
+
+import Data.Time.Clock (NominalDiffTime, secondsToNominalDiffTime)
+
+chanUpdateInterval :: NominalDiffTime
+chanUpdateInterval = secondsToNominalDiffTime (fromRational (1 / 2))
+
+uiUpdateInterval :: NominalDiffTime
+uiUpdateInterval = secondsToNominalDiffTime (fromRational (1 / 10))
+

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -17,7 +17,7 @@ import Data.Text (Text)
 import GHC.Generics (Generic)
 
 data Tab = TabSession | TabModuleGraph | TabSourceView | TabTiming
-  deriving (Eq)
+  deriving (Eq, Show)
 
 data DetailLevel = UpTo30 | UpTo100 | UpTo300
   deriving (Show, Eq, Ord, Generic)
@@ -30,20 +30,24 @@ data ModuleGraphEvent
   = HoverOnModuleEv (Maybe Text)
   | ClickOnModuleEv (Maybe Text)
   | DummyEv (Maybe (Double, Double))
+  deriving (Show)
 
 data SubModuleEvent
   = SubModuleGraphEv ModuleGraphEvent
   | SubModuleLevelEv DetailLevel
+  deriving (Show)
 
 data SessionEvent
   = SaveSessionEv
   | ResumeSessionEv
   | PauseSessionEv
+  deriving (Show)
 
 data TimingEvent
   = UpdateSticky Bool
   | UpdatePartition Bool
   | UpdateParallel Bool
+  deriving (Show)
 
 data Event
   = TabEv Tab
@@ -52,3 +56,5 @@ data Event
   | SubModuleEv SubModuleEvent
   | SessionEv SessionEvent
   | TimingEv TimingEvent
+  | MessageChanUpdated
+  deriving (Show)


### PR DESCRIPTION
UI rendering is strictly confined to HTML widget building and event handling and program state change is done in a separated Control monad which is a type synonym of Free over allowed effect pattern functor. 
This allows for clean and more pure implementation of dynamic program state change as business logic part is almost pure state changing automata with event receiving coroutine operation.  