### PR TITLE
Separate out Control from Widget completely

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -63,7 +63,7 @@ import GHCSpecter.UI.Types
     emptyUIState,
   )
 import GHCSpecter.UI.Types.Event
-  ( BackgroundEvent (UITick),
+  ( BackgroundEvent (RefreshUI),
     Event (BkgEv),
   )
 import GHCSpecter.Worker.Hie (hieWorker)
@@ -159,7 +159,7 @@ webServer ssRef = do
       chanState <- unsafeBlockingIO newTChanIO
       chanBkg <- unsafeBlockingIO newTChanIO
       unsafeBlockingIO $ driver (uiRef, ssRef) chanEv chanState chanBkg
-      loopM (step chanEv chanState chanBkg) (BkgEv UITick)
+      loopM (step chanEv chanState chanBkg) (BkgEv RefreshUI)
   where
     -- A single step of the outer loop (See Note [Control Loops]).
     step ::

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -40,9 +40,9 @@ import GHCSpecter.Comm
     runServer,
     sendObject,
   )
+import GHCSpecter.Data.Assets qualified as Assets
 import GHCSpecter.Driver (driver)
 import GHCSpecter.Render (render)
-import GHCSpecter.Render.Data.Assets qualified as Assets
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState (..),

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -277,13 +277,12 @@ webServer ssRef = do
       stepRender (ui, ss) <|> (Left . BkgEv <$> waitForBkgEv chanBkg)
 
     stepRender :: (UIState, ServerState) -> Widget IHTML (Either Event ())
-    stepRender (ui, ss) =
-      {- let renderUI =
+    stepRender (ui, ss) = do
+      let renderUI =
             if ui ^. uiShouldUpdate
               then unblockDOMUpdate (render (ui, ss))
               else blockDOMUpdate (render (ui, ss))
-      renderUI -}
-      Left <$> render (ui, ss)
+      Left <$> renderUI
 
     waitForBkgEv ::
       -- channel for receiving bkg event

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -60,6 +60,7 @@ handleEvent topEv stepStartTime = do
                     else newUI
         pure (newUI', newSS)
   putState (newUI, newSS)
+  printMsg "commit new state"
   where
     handleMainEvent (oldMainView, oldSS) =
       case topEv of

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -10,13 +10,13 @@ import Data.Time.Clock (UTCTime)
 import Data.Time.Clock qualified as Clock
 import GHCSpecter.Channel (SessionInfo (..))
 import GHCSpecter.Control.Types
-  ( fireUITickAfter,
-    getCurrentTime,
+  ( getCurrentTime,
     getLastUpdatedUI,
     getState,
     nextEvent,
     printMsg,
     putState,
+    refreshUIAfter,
     saveSession,
     shouldUpdate,
     type Control,
@@ -123,7 +123,7 @@ handleEvent topEv stepStartTime = do
         BkgEv MessageChanUpdated -> do
           let newSS = (serverShouldUpdate .~ True) oldSS
           pure (oldMainView, newSS, Nothing)
-        BkgEv UITick -> do
+        BkgEv RefreshUI -> do
           pure (oldMainView, oldSS, Nothing)
 
     handleModuleGraphEv ::
@@ -155,7 +155,7 @@ bannerMode startTime = do
   (ui, ss) <- getState
   let ui' = (uiView .~ BannerMode 0) ui
   putState (ui', ss)
-  fireUITickAfter 0.1
+  refreshUIAfter 0.1
   go
   where
     duration = Clock.secondsToNominalDiffTime 2.0
@@ -169,7 +169,7 @@ bannerMode startTime = do
           let r = realToFrac (diff / duration)
               ui' = (uiView .~ BannerMode r) ui
           putState (ui', ss)
-          fireUITickAfter 0.1
+          refreshUIAfter 0.1
           go
         else pure ()
 

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -34,7 +34,8 @@ import GHCSpecter.UI.Types
     emptyMainView,
   )
 import GHCSpecter.UI.Types.Event
-  ( Event (..),
+  ( BackgroundEvent (..),
+    Event (..),
     ModuleGraphEvent (..),
     SessionEvent (..),
     SubModuleEvent (..),
@@ -118,10 +119,10 @@ handleEvent topEv stepStartTime = do
           let newMainView = (mainTiming . timingUIHowParallel .~ b) oldMainView
               newSS = (serverShouldUpdate .~ False) oldSS
           pure (newMainView, newSS, Nothing)
-        MessageChanUpdated -> do
+        BkgEv MessageChanUpdated -> do
           let newSS = (serverShouldUpdate .~ True) oldSS
           pure (oldMainView, newSS, Nothing)
-        UITick -> do
+        BkgEv UITick -> do
           pure (oldMainView, oldSS, Nothing)
 
     handleModuleGraphEv ::

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -153,9 +153,6 @@ bannerMode startTime = do
   let ui' = (uiView .~ BannerMode 0.5) ui
   putState (ui', ss)
   go
-  (ui1, ss1) <- getState
-  let ui1' = (uiView .~ MainMode emptyMainView) ui1
-  putState (ui1', ss1)
   where
     duration = Clock.secondsToNominalDiffTime 2.0
     go = do
@@ -175,11 +172,15 @@ main :: Control ()
 main = do
   clientSessionStartTime <- getCurrentTime
   printMsg $ "client session starts at " <> T.pack (show clientSessionStartTime)
+  {-
+    bannerMode clientSessionStartTime
 
-  bannerMode clientSessionStartTime
-
-  bannerEndTime <- getCurrentTime
-  printMsg $ "banner mode ends at " <> T.pack (show bannerEndTime)
+    bannerEndTime <- getCurrentTime
+    printMsg $ "banner mode ends at " <> T.pack (show bannerEndTime)
+  -}
+  (ui1, ss1) <- getState
+  let ui1' = (uiView .~ MainMode emptyMainView) ui1
+  putState (ui1', ss1)
 
   forever $ do
     lastUpdatedUI <- getLastUpdatedUI

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -10,7 +10,8 @@ import Data.Time.Clock (UTCTime)
 import Data.Time.Clock qualified as Clock
 import GHCSpecter.Channel (SessionInfo (..))
 import GHCSpecter.Control.Types
-  ( getCurrentTime,
+  ( fireUITickAfter,
+    getCurrentTime,
     getLastUpdatedUI,
     getState,
     nextEvent,
@@ -152,8 +153,9 @@ handleEvent topEv stepStartTime = do
 bannerMode :: UTCTime -> Control ()
 bannerMode startTime = do
   (ui, ss) <- getState
-  let ui' = (uiView .~ BannerMode 0.5) ui
+  let ui' = (uiView .~ BannerMode 0) ui
   putState (ui', ss)
+  fireUITickAfter 0.1
   go
   where
     duration = Clock.secondsToNominalDiffTime 2.0
@@ -167,6 +169,7 @@ bannerMode startTime = do
           let r = realToFrac (diff / duration)
               ui' = (uiView .~ BannerMode r) ui
           putState (ui', ss)
+          fireUITickAfter 0.1
           go
         else pure ()
 
@@ -174,12 +177,12 @@ main :: Control ()
 main = do
   clientSessionStartTime <- getCurrentTime
   printMsg $ "client session starts at " <> T.pack (show clientSessionStartTime)
-  {-
-    bannerMode clientSessionStartTime
 
-    bannerEndTime <- getCurrentTime
-    printMsg $ "banner mode ends at " <> T.pack (show bannerEndTime)
-  -}
+  bannerMode clientSessionStartTime
+
+  bannerEndTime <- getCurrentTime
+  printMsg $ "banner mode ends at " <> T.pack (show bannerEndTime)
+
   (ui1, ss1) <- getState
   let ui1' = (uiView .~ MainMode emptyMainView) ui1
   putState (ui1', ss1)

--- a/daemon/src/GHCSpecter/Control/Runner.hs
+++ b/daemon/src/GHCSpecter/Control/Runner.hs
@@ -5,7 +5,6 @@ module GHCSpecter.Control.Runner
   )
 where
 
-import Concur.Core (Widget, unsafeBlockingIO)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
   ( TChan,
@@ -19,7 +18,6 @@ import Control.Lens ((.~), (^.), _1)
 import Control.Monad.Extra (loopM)
 import Control.Monad.Free (Free (..))
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask)
 import Data.Aeson (encode)
 import Data.ByteString.Lazy qualified as BL
@@ -32,7 +30,6 @@ import GHCSpecter.Control.Types
     type Control,
   )
 import GHCSpecter.Server.Types (ServerState)
-import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
   ( HasUIState (..),
     UIState (..),
@@ -136,11 +133,11 @@ stepControl (Free (SaveSession next)) = do
     withFile "session.json" WriteMode $ \h ->
       BL.hPutStr h (encode ss)
   pure (Left next)
-stepControl (Free (FireUITickAfter nSec next)) = do
+stepControl (Free (RefreshUIAfter nSec next)) = do
   (_, _, chanBkg) <- ask
   liftIO $ do
     threadDelay (floor (nSec * 1_000_000))
-    atomically $ writeTChan chanBkg UITick
+    atomically $ writeTChan chanBkg RefreshUI
   pure (Left next)
 
 -- | The inner loop described in the Note [Control Loops].

--- a/daemon/src/GHCSpecter/Control/Runner.hs
+++ b/daemon/src/GHCSpecter/Control/Runner.hs
@@ -6,12 +6,19 @@ module GHCSpecter.Control.Runner
 where
 
 import Concur.Core (Widget, unsafeBlockingIO)
+import Control.Concurrent.STM
+  ( TVar,
+    atomically,
+    readTVar,
+    writeTVar,
+  )
 import Control.Lens ((.~), (^.), _1)
 import Control.Monad.Extra (loopM)
 import Control.Monad.Free (Free (..))
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.State (StateT (..), get, modify', put)
+import Control.Monad.Trans.Reader (ReaderT, ask)
+-- import Control.Monad.Trans.State (StateT (..), get, modify', put)
 import Data.Aeson (encode)
 import Data.ByteString.Lazy qualified as BL
 import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
@@ -37,7 +44,28 @@ tempRef :: IORef Int
 tempRef = unsafePerformIO (newIORef 0)
 {-# NOINLINE tempRef #-}
 
-type Runner = StateT (UIState, ServerState) (Widget IHTML)
+type Runner = ReaderT (TVar UIState, TVar ServerState) IO
+
+getState' :: Runner (UIState, ServerState)
+getState' = do
+  (uiRef, ssRef) <- ask
+  liftIO $
+    atomically $
+      (,) <$> readTVar uiRef <*> readTVar ssRef
+
+putState' :: (UIState, ServerState) -> Runner ()
+putState' (ui, ss) = do
+  (uiRef, ssRef) <- ask
+  liftIO $
+    atomically $ do
+      writeTVar uiRef ui
+      writeTVar ssRef ss
+
+modifyState' :: ((UIState, ServerState) -> (UIState, ServerState)) -> Runner ()
+modifyState' f = do
+  s <- getState'
+  let s' = f s
+  s' `seq` putState' s'
 
 {-
 
@@ -74,31 +102,30 @@ stepControl ::
     )
 stepControl (Pure r) = pure (Right (Right r))
 stepControl (Free (GetState cont)) = do
-  (ui, ss) <- get
+  (ui, ss) <- getState'
   pure (Left (cont (ui, ss)))
 stepControl (Free (PutState (ui, ss) next)) = do
-  put (ui, ss)
+  putState' (ui, ss)
   pure (Left next)
 stepControl (Free (NextEvent cont)) =
   pure (Right (Left cont))
 stepControl (Free (PrintMsg txt next)) = do
-  lift $
-    unsafeBlockingIO $ do
-      n <- readIORef tempRef
-      modifyIORef' tempRef (+ 1)
-      TIO.putStrLn $ (T.pack (show n) <> " : " <> txt)
+  liftIO $ do
+    n <- readIORef tempRef
+    modifyIORef' tempRef (+ 1)
+    TIO.putStrLn $ (T.pack (show n) <> " : " <> txt)
   pure (Left next)
 stepControl (Free (GetCurrentTime cont)) = do
-  now <- lift $ unsafeBlockingIO Clock.getCurrentTime
+  now <- liftIO Clock.getCurrentTime
   pure (Left (cont now))
 stepControl (Free (GetLastUpdatedUI cont)) = do
-  lastUpdatedUI <- (^. _1 . uiLastUpdated) <$> get
+  lastUpdatedUI <- (^. _1 . uiLastUpdated) <$> getState'
   pure (Left (cont lastUpdatedUI))
 stepControl (Free (ShouldUpdate b next)) = do
-  modify' (_1 . uiShouldUpdate .~ b)
+  modifyState' (_1 . uiShouldUpdate .~ b)
   pure (Left next)
 stepControl (Free (SaveSession next)) = do
-  (_, ss) <- get
+  (_, ss) <- getState'
   -- TODO: use asynchronous worker
   liftIO $
     withFile "session.json" WriteMode $ \h ->

--- a/daemon/src/GHCSpecter/Control/Types.hs
+++ b/daemon/src/GHCSpecter/Control/Types.hs
@@ -4,13 +4,13 @@ module GHCSpecter.Control.Types
     Control,
 
     -- * Primitive operations of eDSL
-    fireUITickAfter,
     getState,
     putState,
     nextEvent,
     printMsg,
     getCurrentTime,
     getLastUpdatedUI,
+    refreshUIAfter,
     shouldUpdate,
     saveSession,
   )
@@ -33,7 +33,7 @@ data ControlF r
   | GetLastUpdatedUI (UTCTime -> r)
   | ShouldUpdate Bool r
   | SaveSession r
-  | FireUITickAfter Double r
+  | RefreshUIAfter Double r
   deriving (Functor)
 
 type Control = Free ControlF
@@ -62,5 +62,5 @@ shouldUpdate b = liftF (ShouldUpdate b ())
 saveSession :: Control ()
 saveSession = liftF (SaveSession ())
 
-fireUITickAfter :: Double -> Control ()
-fireUITickAfter nSec = liftF (FireUITickAfter nSec ())
+refreshUIAfter :: Double -> Control ()
+refreshUIAfter nSec = liftF (RefreshUIAfter nSec ())

--- a/daemon/src/GHCSpecter/Control/Types.hs
+++ b/daemon/src/GHCSpecter/Control/Types.hs
@@ -4,6 +4,7 @@ module GHCSpecter.Control.Types
     Control,
 
     -- * Primitive operations of eDSL
+    fireUITickAfter,
     getState,
     putState,
     nextEvent,
@@ -32,6 +33,7 @@ data ControlF r
   | GetLastUpdatedUI (UTCTime -> r)
   | ShouldUpdate Bool r
   | SaveSession r
+  | FireUITickAfter Double r
   deriving (Functor)
 
 type Control = Free ControlF
@@ -59,3 +61,6 @@ shouldUpdate b = liftF (ShouldUpdate b ())
 
 saveSession :: Control ()
 saveSession = liftF (SaveSession ())
+
+fireUITickAfter :: Double -> Control ()
+fireUITickAfter nSec = liftF (FireUITickAfter nSec ())

--- a/daemon/src/GHCSpecter/Data/Assets.hs
+++ b/daemon/src/GHCSpecter/Data/Assets.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module GHCSpecter.Render.Data.Assets
+module GHCSpecter.Data.Assets
   ( Assets (..),
     HasAssets (..),
     loadAssets,

--- a/daemon/src/GHCSpecter/Driver.hs
+++ b/daemon/src/GHCSpecter/Driver.hs
@@ -1,0 +1,79 @@
+module GHCSpecter.Driver
+  ( driver,
+  )
+where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.STM
+  ( TChan,
+    TVar,
+    atomically,
+    readTChan,
+    readTVar,
+    retry,
+    writeTChan,
+  )
+import Control.Lens ((^.))
+import Control.Monad.Extra (loopM)
+import Control.Monad.Trans.Reader (ReaderT (runReaderT))
+import Data.Time.Clock (nominalDiffTimeToSeconds)
+import GHCSpecter.Control qualified as Control (main)
+import GHCSpecter.Control.Runner (stepControlUpToEvent)
+import GHCSpecter.Server.Types
+  ( HasServerState (..),
+    ServerState (..),
+  )
+import GHCSpecter.UI.Constants (chanUpdateInterval)
+import GHCSpecter.UI.Types (UIState)
+import GHCSpecter.UI.Types.Event
+  ( BackgroundEvent (MessageChanUpdated),
+    Event,
+  )
+
+driver ::
+  (TVar UIState, TVar ServerState) ->
+  TChan Event ->
+  TChan (UIState, ServerState) ->
+  TChan BackgroundEvent ->
+  IO ()
+driver (uiRef, ssRef) chanEv chanState chanBkg = do
+  -- start chanDriver
+  lastMessageSN <-
+    (^. serverMessageSN) <$> atomically (readTVar ssRef)
+  _ <- forkIO $ chanDriver lastMessageSN
+  -- start controlDriver
+  _ <- forkIO $ controlDriver
+  pure ()
+  where
+    blockUntilNewMessage lastSN = do
+      ss <- readTVar ssRef
+      if (ss ^. serverMessageSN == lastSN)
+        then retry
+        else pure (ss ^. serverMessageSN)
+
+    -- background connector between server channel and UI frame
+    chanDriver lastMessageSN = do
+      -- wait for next poll
+      threadDelay (floor (nominalDiffTimeToSeconds chanUpdateInterval * 1_000_000))
+      -- blocked until a new message comes
+      newMessageSN <-
+        atomically $
+          blockUntilNewMessage lastMessageSN
+      atomically $
+        writeTChan chanBkg MessageChanUpdated
+      chanDriver newMessageSN
+
+    -- connector between driver and Control frame
+    controlDriver = loopM step (\_ -> Control.main)
+      where
+        step c = do
+          ev <- atomically $ readTChan chanEv
+          ec' <-
+            runReaderT
+              (stepControlUpToEvent ev c)
+              (uiRef, ssRef, chanBkg)
+          atomically $ do
+            ui <- readTVar uiRef
+            ss <- readTVar ssRef
+            writeTChan chanState (ui, ss)
+          pure ec'

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -17,7 +17,7 @@ import Concur.Replica
 import Control.Lens (to, (^.))
 import Data.Text (Text)
 import Data.Text qualified as T
-import GHCSpecter.Render.Data.Assets (HasAssets (..))
+import GHCSpecter.Data.Assets (HasAssets (..))
 import GHCSpecter.Render.ModuleGraph qualified as ModuleGraph
 import GHCSpecter.Render.Session qualified as Session
 import GHCSpecter.Render.SourceView qualified as SourceView

--- a/daemon/src/GHCSpecter/Render/Data/Assets.hs
+++ b/daemon/src/GHCSpecter/Render/Data/Assets.hs
@@ -26,8 +26,7 @@ loadAssets = do
   pngFile <- getDataFileName "assets/ghc-specter.png"
   bs <- B.readFile pngFile
   let b64 = B64.encode bs
-      assets =
-        Assets
-          { _assetsGhcSpecterPng = "data:image/png;base64," <> TE.decodeUtf8 b64
-          }
-  pure assets
+  pure
+    Assets
+      { _assetsGhcSpecterPng = "data:image/png;base64," <> TE.decodeUtf8 b64
+      }

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -50,7 +50,6 @@ import Control.Lens (makeClassy, (%~))
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
-import Data.Time.Clock (UTCTime)
 import GHC.Generics (Generic)
 import GHCSpecter.Channel
   ( Channel,
@@ -254,7 +253,6 @@ emptyHieState = HieState mempty
 data ServerState = ServerState
   { _serverMessageSN :: Int
   , _serverShouldUpdate :: Bool
-  , _serverLastUpdated :: UTCTime
   , _serverInbox :: Inbox
   , _serverSessionInfo :: SessionInfo
   , _serverTiming :: Map ModuleName Timer
@@ -269,12 +267,11 @@ instance FromJSON ServerState
 
 instance ToJSON ServerState
 
-emptyServerState :: UTCTime -> ServerState
-emptyServerState now =
+emptyServerState :: ServerState
+emptyServerState =
   ServerState
     { _serverMessageSN = 0
     , _serverShouldUpdate = True
-    , _serverLastUpdated = now
     , _serverInbox = mempty
     , _serverSessionInfo = SessionInfo Nothing emptyModuleGraphInfo False
     , _serverTiming = mempty

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -25,7 +25,7 @@ where
 import Control.Lens (makeClassy)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
-import GHCSpecter.Render.Data.Assets (Assets)
+import GHCSpecter.Data.Assets (Assets)
 import GHCSpecter.UI.Types.Event (DetailLevel (..), Tab (..))
 
 data ModuleGraphUI = ModuleGraphUI

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -30,24 +30,24 @@ data ModuleGraphEvent
   = HoverOnModuleEv (Maybe Text)
   | ClickOnModuleEv (Maybe Text)
   | DummyEv (Maybe (Double, Double))
-  deriving (Show)
+  deriving (Show, Eq)
 
 data SubModuleEvent
   = SubModuleGraphEv ModuleGraphEvent
   | SubModuleLevelEv DetailLevel
-  deriving (Show)
+  deriving (Show, Eq)
 
 data SessionEvent
   = SaveSessionEv
   | ResumeSessionEv
   | PauseSessionEv
-  deriving (Show)
+  deriving (Show, Eq)
 
 data TimingEvent
   = UpdateSticky Bool
   | UpdatePartition Bool
   | UpdateParallel Bool
-  deriving (Show)
+  deriving (Show, Eq)
 
 data Event
   = TabEv Tab
@@ -58,4 +58,4 @@ data Event
   | TimingEv TimingEvent
   | MessageChanUpdated
   | UITick
-  deriving (Show)
+  deriving (Show, Eq)

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -8,6 +8,7 @@ module GHCSpecter.UI.Types.Event
     ModuleGraphEvent (..),
     SessionEvent (..),
     TimingEvent (..),
+    BackgroundEvent (..),
     Event (..),
   )
 where
@@ -49,6 +50,11 @@ data TimingEvent
   | UpdateParallel Bool
   deriving (Show, Eq)
 
+data BackgroundEvent
+  = MessageChanUpdated
+  | UITick
+  deriving (Show, Eq)
+
 data Event
   = TabEv Tab
   | ExpandModuleEv (Maybe Text)
@@ -56,6 +62,5 @@ data Event
   | SubModuleEv SubModuleEvent
   | SessionEv SessionEvent
   | TimingEv TimingEvent
-  | MessageChanUpdated
-  | UITick
+  | BkgEv BackgroundEvent
   deriving (Show, Eq)

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -52,7 +52,7 @@ data TimingEvent
 
 data BackgroundEvent
   = MessageChanUpdated
-  | UITick
+  | RefreshUI
   deriving (Show, Eq)
 
 data Event


### PR DESCRIPTION
Now Control and its runner is completely separated from UI monad (Widget IHTML), which guarantees the separation of state changing control process and UI rendering.
In that vein, message channel update and forcing UI refresh signal (previously called UITick, and now renamed to RefreshUI) are now separated out from Widget monad. 