### PR TITLE
Scrolling on Timing Graph directly by custom mouse dragging control loop 

### DIFF
--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -120,19 +120,6 @@ updateModel topEv (oldModel, oldSS) =
     handleModuleGraphEv (HoverOnModuleEv mhovered) = (modGraphUIHover .~ mhovered)
     handleModuleGraphEv (ClickOnModuleEv mclicked) = (modGraphUIClick .~ mclicked)
 
-{-
-    handleMouseMove ::
-      UIModel ->
-      Maybe (UTCTime, (Double, Double)) ->
-      (UIModel, Maybe UTCTime)
-    handleMouseMove model mtxy =
-      case mtxy of
-        Nothing -> (model, Nothing)
-        Just (t, xy) ->
-          let model' = (modelMousePosition .~ xy) model
-           in (model', Just t)
--}
-
 -- | showing ghc-specter banner in the beginning
 showBanner :: Control ()
 showBanner = do

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -217,7 +217,7 @@ branchTab tab (view, model) =
   where
     branchLoop go = do
       let view1 = (mainTab .~ tab) view
-      (view', model')  <- go (TabEv tab) (view1, model)
+      (view', model') <- go (TabEv tab) (view1, model)
       loop (view', model')
       where
         loop (v, m) = do
@@ -237,7 +237,6 @@ initializeMainView = do
   let ui1' = (uiView .~ MainMode emptyMainView) ui1
   putState (ui1', ss1)
   pure (emptyMainView, ui1' ^. uiModel)
-
 
 -- | main loop
 mainLoop :: (MainView, UIModel) -> Control ()

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -3,9 +3,8 @@ module GHCSpecter.Control
   )
 where
 
-import Control.Lens ((%~), (&), (.~), (^.), _1, _2)
+import Control.Lens ((&), (.~), (^.), _1, _2)
 import Data.Text qualified as T
-import Data.Time.Clock (UTCTime)
 import Data.Time.Clock qualified as Clock
 import GHCSpecter.Channel (SessionInfo (..))
 import GHCSpecter.Control.Types

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -193,16 +193,7 @@ goTiming ev (view, model0) = do
         let (tx, ty) = model0 ^. modelTiming . timingUIXY
         onDragging (x, y) (tx, ty)
       _ -> pure model0
-  (ui, ss) <- getState
-  (model', ss') <- defaultUpdateModel ev (model, ss)
-  let -- just placeholder
-      view' = view
-      ui' =
-        ui
-          & (uiView .~ MainMode view')
-            . (uiModel .~ model')
-  putState (ui', ss')
-  pure (view', model')
+  goCommon ev (view, model)
   where
     addDelta :: (Double, Double) -> (Double, Double) -> (Double, Double) -> UIModel -> UIModel
     addDelta (x, y) (x', y') (tx, ty) =

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -216,11 +216,11 @@ branchTab tab (view, model) =
     TabTiming -> branchLoop goTiming
   where
     branchLoop go = do
-      let view' = (mainTab .~ tab) view
-      model' <- go (TabEv tab) (view', model)
-      go' model'
+      let view1 = (mainTab .~ tab) view
+      (view', model')  <- go (TabEv tab) (view1, model)
+      loop (view', model')
       where
-        go' (v, m) = do
+        loop (v, m) = do
           checkIfUpdatable
           printMsg "wait for the next event"
           ev <- nextEvent
@@ -229,7 +229,7 @@ branchTab tab (view, model) =
             TabEv tab' -> branchTab tab' (v, m)
             _ -> do
               (v', m') <- go ev (v, m)
-              go' (v', m')
+              loop (v', m')
 
 initializeMainView :: Control (MainView, UIModel)
 initializeMainView = do

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -115,7 +115,6 @@ renderMainView (view, model, ss) = do
                     "box"
                     []
                     [ text $ "message: " <> (ss ^. serverMessageSN . to (T.pack . show))
-                    , text $ "(x,y): " <> (model ^. modelMousePosition . to (T.pack . show))
                     ]
                 ]
             )
@@ -125,7 +124,7 @@ renderMainView (view, model, ss) = do
     , cssLink "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css"
     , renderNavbar (view ^. mainTab)
     , mainPanel
-    -- , bottomPanel
+    , bottomPanel
     ]
 
 render ::

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -125,7 +125,7 @@ renderMainView (view, model, ss) = do
     , cssLink "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css"
     , renderNavbar (view ^. mainTab)
     , mainPanel
-    , bottomPanel
+    -- , bottomPanel
     ]
 
 render ::

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -323,7 +323,8 @@ renderModuleGraphSVG
                 , SP.version "1.1"
                 , xmlns
                 ]
-           in (DummyEv <$> onMouseMove) : svgProps0
+           in -- (DummyEv <$> onMouseMove) :
+              svgProps0
         svgElement =
           S.svg
             svgProps

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -260,12 +260,9 @@ renderModuleGraphSVG
                 , SP.fill color
                 ]
                 []
-        box1 (NodeLayout (_, name) (Point x y) (Dim w h)) =
+        box1 (NodeLayout _ (Point x y) (Dim w h)) =
           S.rect
-            [ HoverOnModuleEv (Just name) <$ onMouseEnter
-            , HoverOnModuleEv Nothing <$ onMouseLeave
-            , ClickOnModuleEv (Just name) <$ onClick
-            , SP.x (T.pack $ show (x + offX))
+            [ SP.x (T.pack $ show (x + offX))
             , SP.y (T.pack $ show (y + h * offYFactor + h + 3))
             , width (T.pack $ show (w * aFactor))
             , height "4"
@@ -285,10 +282,7 @@ renderModuleGraphSVG
                     pure (fromIntegral nCompiled / fromIntegral nTot)
               w' = ratio * w
            in S.rect
-                [ HoverOnModuleEv (Just name) <$ onMouseEnter
-                , HoverOnModuleEv Nothing <$ onMouseLeave
-                , ClickOnModuleEv (Just name) <$ onClick
-                , SP.x (T.pack $ show (x + offX))
+                [ SP.x (T.pack $ show (x + offX))
                 , SP.y (T.pack $ show (y + h * offYFactor + h + 3))
                 , width (T.pack $ show (w' * aFactor))
                 , height "4"
@@ -311,23 +305,20 @@ renderModuleGraphSVG
           concatMap (\x -> [box0 x, box1 x, box2 x, moduleText x]) (grVisInfo ^. gviNodes)
 
         svgProps =
-          let svgProps0 =
-                [ width (T.pack (show (canvasWidth + 100)))
-                , SP.viewBox
-                    ( "0 0 "
-                        <> T.pack (show (canvasWidth + 100)) -- i don't understand why it's incorrect
-                        <> " "
-                        <> T.pack (show (canvasHeight + 100))
-                    )
-                , SP.version "1.1"
-                , xmlns
-                ]
-           in -- (DummyEv <$> onMouseMove) :
-              svgProps0
+          [ width (T.pack (show (canvasWidth + 100)))
+          , SP.viewBox
+              ( "0 0 "
+                  <> T.pack (show (canvasWidth + 100))
+                  <> " "
+                  <> T.pack (show (canvasHeight + 100))
+              )
+          , SP.version "1.1"
+          , xmlns
+          ]
         svgElement =
           S.svg
             svgProps
-            (S.style [] [text ".small { font: 6px sans-serif; }"] : (edges ++ nodes))
+            (S.style [] [text ".small { font: 6px sans-serif; } text { user-select: none; }"] : (edges ++ nodes))
      in div [classList [("is-fullwidth", True)]] [svgElement]
 
 renderMainModuleGraph ::

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -74,7 +74,6 @@ import GHCSpecter.UI.ConcurReplica.DOM
     pre,
     text,
   )
-import GHCSpecter.UI.ConcurReplica.DOM.Events (onMouseMove)
 import GHCSpecter.UI.ConcurReplica.SVG qualified as S
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -189,20 +189,38 @@ renderTimingChart tui timingInfos =
             , moduleText x
             ]
         | otherwise = [box x, moduleText x]
+      svgProps =
+        let viewboxProp
+              | tui ^. timingUISticky =
+                  let x = T.pack $ show (maxWidth - 800 :: Int)
+                      y = T.pack $ show (totalHeight - 600 :: Int)
+                      w = T.pack $ show (800 :: Int)
+                      h = T.pack $ show (600 :: Int)
+                   in SP.viewBox (T.intercalate " " [x, y, w, h])
+              | otherwise = SP.viewBox "0 0 800 600"
+         in [ width "1024px" -- (T.pack $ show (maxWidth :: Int))
+            , height "768px" -- (T.pack $ show totalHeight)
+            , viewboxProp
+            , SP.version "1.1"
+            , xmlns
+            ]
+
+      {- if tui ^. timingUISticky
+          then svgProps0
+          else
+            let viewboxProp = SP.viewBox "0 0 1024 768"
+             in viewboxProp : svgProps0 -}
       svgElement =
         S.svg
-          [width (T.pack $ show (maxWidth :: Int)), height (T.pack $ show totalHeight), SP.version "1.1", xmlns]
+          svgProps
           ( S.style [] [text ".small { font: 5px sans-serif; }"] :
             ( renderRules (tui ^. timingUIHowParallel) timingInfos totalHeight totalTime
                 ++ (concatMap makeItems $ zip [0 ..] timingInfos)
             )
           )
-   in if tui ^. timingUISticky
-        then
-          div
-            [style [("position", "absolute"), ("bottom", "0"), ("right", "0")]]
-            [svgElement]
-        else div [] [svgElement]
+   in div
+        [style [("width", "800px"), ("height", "600px"), ("overflow", "hidden")]]
+        [svgElement]
 
 renderCheckbox :: TimingUI -> Widget IHTML Event
 renderCheckbox tui = div [] [checkSticky, checkPartition, checkHowParallel]

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/DOM/Events.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/DOM/Events.hs
@@ -1,5 +1,7 @@
 module GHCSpecter.UI.ConcurReplica.DOM.Events
   ( onMouseMove,
+    onMouseDown,
+    onMouseUp,
   )
 where
 
@@ -9,9 +11,33 @@ import Data.Aeson.KeyMap qualified as A
 import Data.Scientific (toRealFloat)
 import Replica.VDOM.Types (DOMEvent (getDOMEvent))
 
--- | MouseEvent has a bug since "value" can be missing
+-- | @Concur.Replica.DOM.Event.MouseEvent@ has a bug since "value" can be missing
 onMouseMove :: Props (Maybe (Double, Double))
 onMouseMove = Props "onMouseMove" (PropEvent (getClientXY . getDOMEvent))
+  where
+    getClientXY (A.Object m) = do
+      cX <- A.lookup "clientX" m
+      cY <- A.lookup "clientY" m
+      case (cX, cY) of
+        (A.Number x, A.Number y) -> pure (toRealFloat x, toRealFloat y)
+        _ -> Nothing
+    getClientXY _ = Nothing
+
+-- | @Concur.Replica.DOM.Event.MouseEvent@ has a bug since "value" can be missing
+onMouseDown :: Props (Maybe (Double, Double))
+onMouseDown = Props "onMouseDown" (PropEvent (getClientXY . getDOMEvent))
+  where
+    getClientXY (A.Object m) = do
+      cX <- A.lookup "clientX" m
+      cY <- A.lookup "clientY" m
+      case (cX, cY) of
+        (A.Number x, A.Number y) -> pure (toRealFloat x, toRealFloat y)
+        _ -> Nothing
+    getClientXY _ = Nothing
+
+-- | @Concur.Replica.DOM.Event.MouseEvent@ has a bug since "value" can be missing
+onMouseUp :: Props (Maybe (Double, Double))
+onMouseUp = Props "onMouseUp" (PropEvent (getClientXY . getDOMEvent))
   where
     getClientXY (A.Object m) = do
       cX <- A.lookup "clientX" m

--- a/daemon/src/GHCSpecter/UI/Constants.hs
+++ b/daemon/src/GHCSpecter/UI/Constants.hs
@@ -2,6 +2,8 @@ module GHCSpecter.UI.Constants
   ( chanUpdateInterval,
     uiUpdateInterval,
     tickInterval,
+    timingWidth,
+    timingHeight,
   )
 where
 
@@ -15,3 +17,9 @@ uiUpdateInterval = secondsToNominalDiffTime (fromRational (1 / 10))
 
 tickInterval :: NominalDiffTime
 tickInterval = secondsToNominalDiffTime 1
+
+timingWidth :: Int
+timingWidth = 800
+
+timingHeight :: Int
+timingHeight = 600

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -89,8 +89,6 @@ data UIModel = UIModel
   -- ^ UI state of source view UI
   , _modelTiming :: TimingUI
   -- ^ UI state of Timing UI
-  , _modelMousePosition :: (Double, Double)
-  -- ^ mouse position
   }
 
 makeClassy ''UIModel
@@ -102,7 +100,6 @@ emptyUIModel =
     , _modelSubModuleGraph = (UpTo30, ModuleGraphUI Nothing Nothing)
     , _modelSourceView = emptySourceViewUI
     , _modelTiming = emptyTimingUI
-    , _modelMousePosition = (0, 0)
     }
 
 data UIView

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -59,12 +59,13 @@ data TimingUI = TimingUI
   -- ^ Whether each module timing is partitioned into division
   , _timingUIHowParallel :: Bool
   -- ^ Whether showing color-coded parallel processes
+  , _timingUIXY :: (Double, Double)
   }
 
 makeClassy ''TimingUI
 
 emptyTimingUI :: TimingUI
-emptyTimingUI = TimingUI False False False
+emptyTimingUI = TimingUI False False False (0, 0)
 
 data MainView = MainView
   { _mainTab :: Tab

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -8,6 +8,7 @@ module GHCSpecter.UI.Types.Event
     ModuleGraphEvent (..),
     SessionEvent (..),
     TimingEvent (..),
+    MouseEvent (..),
     BackgroundEvent (..),
     Event (..),
   )
@@ -30,7 +31,6 @@ instance ToJSON DetailLevel
 data ModuleGraphEvent
   = HoverOnModuleEv (Maybe Text)
   | ClickOnModuleEv (Maybe Text)
-  | DummyEv (Maybe (Double, Double))
   deriving (Show, Eq)
 
 data SubModuleEvent
@@ -50,6 +50,12 @@ data TimingEvent
   | UpdateParallel Bool
   deriving (Show, Eq)
 
+data MouseEvent
+  = MouseMove (Maybe (Double, Double))
+  | MouseDown (Maybe (Double, Double))
+  | MouseUp (Maybe (Double, Double))
+  deriving (Show, Eq)
+
 data BackgroundEvent
   = MessageChanUpdated
   | RefreshUI
@@ -62,5 +68,6 @@ data Event
   | SubModuleEv SubModuleEvent
   | SessionEv SessionEvent
   | TimingEv TimingEvent
+  | MouseEv MouseEvent
   | BkgEv BackgroundEvent
   deriving (Show, Eq)


### PR DESCRIPTION
Now scrolling events  on the timing graph panel are handled directly by control routine.