### PR TITLE
Show module tree structure in SourceView and paned view

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -26,6 +26,7 @@ import Data.Aeson (eitherDecode')
 import Data.ByteString.Lazy qualified as BL
 import Data.Foldable qualified as F
 import Data.Map.Strict qualified as M
+import Data.Text (Text)
 import Data.Time.Clock (getCurrentTime)
 import GHCSpecter.Channel
   ( ChanMessage (..),
@@ -49,7 +50,7 @@ import GHCSpecter.Server.Types
     emptyServerState,
     incrementSN,
   )
-import GHCSpecter.UI.ConcurReplica.Run (runDefault)
+import GHCSpecter.UI.ConcurReplica.Run (runDefaultWithStyle)
 import GHCSpecter.UI.ConcurReplica.Types
   ( IHTML,
     blockDOMUpdate,
@@ -164,10 +165,13 @@ data UIChannel = UIChannel
   -- ^ channel for receiving background event
   }
 
+styleText :: Text
+styleText = "ul > li { margin-left: 10px; }"
+
 webServer :: TVar ServerState -> IO ()
 webServer ssRef = do
   assets <- Assets.loadAssets
-  runDefault 8080 "ghc-specter" $
+  runDefaultWithStyle 8080 "ghc-specter" styleText $
     \_ -> do
       uiRef <-
         unsafeBlockingIO $ do

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -66,6 +66,7 @@ import GHCSpecter.UI.Types.Event
   ( BackgroundEvent (RefreshUI),
     Event (BkgEv),
   )
+import GHCSpecter.Util.SourceTree (test)
 import GHCSpecter.Worker.Hie (hieWorker)
 import GHCSpecter.Worker.ModuleGraph (moduleGraphWorker)
 import Options.Applicative qualified as OA
@@ -73,6 +74,7 @@ import Options.Applicative qualified as OA
 data CLIMode
   = Online FilePath
   | View FilePath
+  | Temp FilePath
 
 onlineMode :: OA.Mod OA.CommandFields CLIMode
 onlineMode =
@@ -88,10 +90,17 @@ viewMode =
       (View <$> OA.strOption (OA.long "session-file" <> OA.short 'f' <> OA.help "session file"))
       (OA.progDesc "viewing saved session")
 
+tempMode :: OA.Mod OA.CommandFields CLIMode
+tempMode =
+  OA.command "temp" $
+    OA.info
+      (Temp <$> OA.strOption (OA.long "session-file" <> OA.short 'f' <> OA.help "session file"))
+      (OA.progDesc "temp")
+
 optsParser :: OA.ParserInfo CLIMode
 optsParser =
   OA.info
-    (OA.subparser (onlineMode <> viewMode) OA.<**> OA.helper)
+    (OA.subparser (onlineMode <> viewMode <> tempMode) OA.<**> OA.helper)
     OA.fullDesc
 
 listener :: FilePath -> TVar ServerState -> IO ()
@@ -218,3 +227,9 @@ main = do
         Right ss -> do
           serverSessionRef <- atomically $ newTVar ss
           webServer serverSessionRef
+    Temp sessionFile -> do
+      lbs <- BL.readFile sessionFile
+      case eitherDecode' lbs of
+        Left err -> print err
+        Right ss -> do
+          test ss

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -67,7 +67,6 @@ import GHCSpecter.UI.Types.Event
   ( BackgroundEvent (RefreshUI),
     Event (BkgEv),
   )
-import GHCSpecter.Util.SourceTree (test)
 import GHCSpecter.Worker.Hie (hieWorker)
 import GHCSpecter.Worker.ModuleGraph (moduleGraphWorker)
 import Options.Applicative qualified as OA
@@ -75,7 +74,6 @@ import Options.Applicative qualified as OA
 data CLIMode
   = Online FilePath
   | View FilePath
-  | Temp FilePath
 
 onlineMode :: OA.Mod OA.CommandFields CLIMode
 onlineMode =
@@ -91,17 +89,10 @@ viewMode =
       (View <$> OA.strOption (OA.long "session-file" <> OA.short 'f' <> OA.help "session file"))
       (OA.progDesc "viewing saved session")
 
-tempMode :: OA.Mod OA.CommandFields CLIMode
-tempMode =
-  OA.command "temp" $
-    OA.info
-      (Temp <$> OA.strOption (OA.long "session-file" <> OA.short 'f' <> OA.help "session file"))
-      (OA.progDesc "temp")
-
 optsParser :: OA.ParserInfo CLIMode
 optsParser =
   OA.info
-    (OA.subparser (onlineMode <> viewMode <> tempMode) OA.<**> OA.helper)
+    (OA.subparser (onlineMode <> viewMode) OA.<**> OA.helper)
     OA.fullDesc
 
 listener :: FilePath -> TVar ServerState -> IO ()
@@ -231,9 +222,3 @@ main = do
         Right ss -> do
           serverSessionRef <- atomically $ newTVar ss
           webServer serverSessionRef
-    Temp sessionFile -> do
-      lbs <- BL.readFile sessionFile
-      case eitherDecode' lbs of
-        Left err -> print err
-        Right ss -> do
-          test ss

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -266,8 +266,7 @@ main = do
   printMsg $ "client session starts at " <> T.pack (show clientSessionStartTime)
 
   -- show banner
-  -- showBanner
-  refreshUIAfter 0.1
+  showBanner
 
   -- initialize main view
   (view, model) <- initializeMainView

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -266,7 +266,8 @@ main = do
   printMsg $ "client session starts at " <> T.pack (show clientSessionStartTime)
 
   -- show banner
-  showBanner
+  -- showBanner
+  refreshUIAfter 0.1
 
   -- initialize main view
   (view, model) <- initializeMainView

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -107,7 +107,12 @@ renderMainView (view, model, ss) = do
             )
         | otherwise =
             ( section
-                [style [("height", "85vh"), ("overflow-y", "scroll")]]
+                [ style
+                    [ ("max-height", "80vh")
+                    , ("overflow-y", "hidden")
+                    , ("overflow-x", "hidden")
+                    ]
+                ]
                 [renderMainPanel view model ss]
             , section
                 []
@@ -134,7 +139,9 @@ render (ui, ss) =
   case ui ^. uiView of
     BannerMode v ->
       div
-        [classList [("container is-fullheight is-size-7 m-4 p-4", True)]]
+        [ classList [("container is-fullheight is-size-7 m-4 p-4", True)]
+        , style [("overflow", "hidden")]
+        ]
         [ cssLink "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
         , cssLink "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css"
         , section

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -109,8 +109,7 @@ renderMainView (view, model, ss) = do
             ( section
                 [ style
                     [ ("max-height", "80vh")
-                    , ("overflow-y", "hidden")
-                    , ("overflow-x", "hidden")
+                    , ("overflow", "hidden")
                     ]
                 ]
                 [renderMainPanel view model ss]

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -26,6 +26,7 @@ import Concur.Replica
     onInput,
     onMouseEnter,
     onMouseLeave,
+    style,
     width,
   )
 import Concur.Replica.DOM.Props qualified as DP (checked, name, type_)
@@ -416,7 +417,7 @@ render model ss =
           pre [] [text "GHC Session has not been started"]
         Just _ ->
           div
-            []
+            [style [("overflow", "scroll"), ("height", "75vh")]]
             ( case mgs ^. mgsClusterGraph of
                 Nothing -> []
                 Just grVisInfo ->

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -170,10 +170,6 @@ renderModuleTree srcUI ss =
     ]
     [ul [] contents]
   where
-    -- [ ul []
-    --   [ li [] [text "A", ul [] [li [] [text "B"]]] ]
-    -- ]
-
     inbox = ss ^. serverInbox
     hie = ss ^. serverHieState
     timing = ss ^. serverTiming
@@ -275,12 +271,12 @@ render srcUI ss =
     , height "100%"
     ]
     [ div
-        [ classList [("column is-half", True)]
+        [ classList [("column is-one-quarter", True)]
         , style [("overflow", "scroll")]
         ]
         [renderModuleTree srcUI ss]
     , div
-        [ classList [("column is-half", True)]
+        [ classList [("column is-three-quarters", True)]
         , style [("overflow", "scroll")]
         ]
         [renderSourceView srcUI ss]

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -50,6 +50,7 @@ import Control.Lens (makeClassy, (%~))
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
+import Data.Tree (Forest)
 import GHC.Generics (Generic)
 import GHCSpecter.Channel
   ( Channel,
@@ -150,7 +151,8 @@ transposeGraphVis (GraphVisInfo dim nodLayout edgLayout) =
     edgLayout' = fmap xposeEdge edgLayout
 
 data ModuleGraphState = ModuleGraphState
-  { _mgsClusterGraph :: Maybe GraphVisInfo
+  { _mgsModuleForest :: Forest ModuleName
+  , _mgsClusterGraph :: Maybe GraphVisInfo
   , _mgsClustering :: [(ModuleName, [ModuleName])]
   , _mgsSubgraph :: [(DetailLevel, [(ModuleName, GraphVisInfo)])]
   }
@@ -163,7 +165,7 @@ instance FromJSON ModuleGraphState
 instance ToJSON ModuleGraphState
 
 emptyModuleGraphState :: ModuleGraphState
-emptyModuleGraphState = ModuleGraphState Nothing [] []
+emptyModuleGraphState = ModuleGraphState [] Nothing [] []
 
 -- | RefRow has OccName and Unit which are not JSON-serializable.
 data RefRow' = RefRow'

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
@@ -2,6 +2,7 @@
 module GHCSpecter.UI.ConcurReplica.Run
   ( run,
     runDefault,
+    runDefaultWithStyle,
   )
 where
 
@@ -15,7 +16,7 @@ import Network.Wai (Middleware)
 import Network.Wai.Handler.Warp qualified as W
 import Network.WebSockets.Connection (ConnectionOptions, defaultConnectionOptions)
 import Replica.VDOM (defaultIndex, fireEvent)
-import Replica.VDOM.Types (DOMEvent (DOMEvent), HTML)
+import Replica.VDOM.Types (DOMEvent (DOMEvent), HTML, VDOM (..))
 
 run :: Int -> HTML -> ConnectionOptions -> Middleware -> (R.Context -> Widget IHTML a) -> IO ()
 run port index connectionOptions middleware widget =
@@ -26,6 +27,13 @@ runDefault :: Int -> T.Text -> (R.Context -> Widget IHTML a) -> IO ()
 runDefault port title widget =
   W.run port $
     R.app (defaultIndex title []) defaultConnectionOptions id (step <$> widget) stepWidget
+
+runDefaultWithStyle :: Int -> T.Text -> T.Text -> (R.Context -> Widget IHTML a) -> IO ()
+runDefaultWithStyle port title style widget =
+  W.run port $
+    R.app (defaultIndex title [styleNode]) defaultConnectionOptions id (step <$> widget) stepWidget
+  where
+    styleNode = VNode "style" mempty Nothing [VRawText style]
 
 -- | No need to use this directly if you're using 'run' or 'runDefault'.
 stepWidget ::

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
@@ -8,48 +8,14 @@ where
 import Concur.Core (SuspendF (Forever, StepBlock, StepIO, StepSTM, StepView), Widget, step)
 import Control.Concurrent.STM (atomically)
 import Control.Monad.Free (Free (Free, Pure))
-import Data.Map qualified as M
 import Data.Text qualified as T
-import Data.Text.Encoding qualified as T
 import GHCSpecter.UI.ConcurReplica.Types (IHTML (..), project)
 import GHCSpecter.UI.ConcurReplica.WaiHandler qualified as R
 import Network.Wai (Middleware)
 import Network.Wai.Handler.Warp qualified as W
 import Network.WebSockets.Connection (ConnectionOptions, defaultConnectionOptions)
-import Replica.VDOM (clientDriver, fireEvent)
-import Replica.VDOM.Types
-  ( Attr (..),
-    DOMEvent (DOMEvent),
-    HTML,
-    VDOM (..),
-  )
-
-customDefaultIndex :: T.Text -> HTML -> HTML
-customDefaultIndex title header =
-  [ VLeaf "!doctype" (fl [("html", ABool True)]) Nothing
-  , VNode
-      "html"
-      mempty
-      Nothing
-      [ VNode "head" mempty Nothing $
-          [ VLeaf "meta" (fl [("charset", AText "utf-8")]) Nothing
-          , VNode "title" mempty Nothing [VText title]
-          ]
-            <> header
-      , VNode
-          "body"
-          (fl [("style", AText "height: 100vh;")])
-          Nothing
-          [ VNode
-              "script"
-              (fl [("language", AText "javascript")])
-              Nothing
-              [VRawText $ T.decodeUtf8 clientDriver]
-          ]
-      ]
-  ]
-  where
-    fl = M.fromList
+import Replica.VDOM (defaultIndex, fireEvent)
+import Replica.VDOM.Types (DOMEvent (DOMEvent), HTML)
 
 run :: Int -> HTML -> ConnectionOptions -> Middleware -> (R.Context -> Widget IHTML a) -> IO ()
 run port index connectionOptions middleware widget =
@@ -59,7 +25,7 @@ run port index connectionOptions middleware widget =
 runDefault :: Int -> T.Text -> (R.Context -> Widget IHTML a) -> IO ()
 runDefault port title widget =
   W.run port $
-    R.app (customDefaultIndex title []) defaultConnectionOptions id (step <$> widget) stepWidget
+    R.app (defaultIndex title []) defaultConnectionOptions id (step <$> widget) stepWidget
 
 -- | No need to use this directly if you're using 'run' or 'runDefault'.
 stepWidget ::

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/Run.hs
@@ -8,14 +8,48 @@ where
 import Concur.Core (SuspendF (Forever, StepBlock, StepIO, StepSTM, StepView), Widget, step)
 import Control.Concurrent.STM (atomically)
 import Control.Monad.Free (Free (Free, Pure))
+import Data.Map qualified as M
 import Data.Text qualified as T
+import Data.Text.Encoding qualified as T
 import GHCSpecter.UI.ConcurReplica.Types (IHTML (..), project)
 import GHCSpecter.UI.ConcurReplica.WaiHandler qualified as R
 import Network.Wai (Middleware)
 import Network.Wai.Handler.Warp qualified as W
 import Network.WebSockets.Connection (ConnectionOptions, defaultConnectionOptions)
-import Replica.VDOM (defaultIndex, fireEvent)
-import Replica.VDOM.Types (DOMEvent (DOMEvent), HTML)
+import Replica.VDOM (clientDriver, fireEvent)
+import Replica.VDOM.Types
+  ( Attr (..),
+    DOMEvent (DOMEvent),
+    HTML,
+    VDOM (..),
+  )
+
+customDefaultIndex :: T.Text -> HTML -> HTML
+customDefaultIndex title header =
+  [ VLeaf "!doctype" (fl [("html", ABool True)]) Nothing
+  , VNode
+      "html"
+      mempty
+      Nothing
+      [ VNode "head" mempty Nothing $
+          [ VLeaf "meta" (fl [("charset", AText "utf-8")]) Nothing
+          , VNode "title" mempty Nothing [VText title]
+          ]
+            <> header
+      , VNode
+          "body"
+          (fl [("style", AText "height: 100vh;")])
+          Nothing
+          [ VNode
+              "script"
+              (fl [("language", AText "javascript")])
+              Nothing
+              [VRawText $ T.decodeUtf8 clientDriver]
+          ]
+      ]
+  ]
+  where
+    fl = M.fromList
 
 run :: Int -> HTML -> ConnectionOptions -> Middleware -> (R.Context -> Widget IHTML a) -> IO ()
 run port index connectionOptions middleware widget =
@@ -25,7 +59,7 @@ run port index connectionOptions middleware widget =
 runDefault :: Int -> T.Text -> (R.Context -> Widget IHTML a) -> IO ()
 runDefault port title widget =
   W.run port $
-    R.app (defaultIndex title []) defaultConnectionOptions id (step <$> widget) stepWidget
+    R.app (customDefaultIndex title []) defaultConnectionOptions id (step <$> widget) stepWidget
 
 -- | No need to use this directly if you're using 'run' or 'runDefault'.
 stepWidget ::

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -27,8 +27,6 @@ where
 import Control.Lens (makeClassy)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
-import Data.Tree (Forest)
-import GHCSpecter.Channel (type ModuleName)
 import GHCSpecter.Data.Assets (Assets)
 import GHCSpecter.UI.Types.Event (DetailLevel (..), Tab (..))
 

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -27,6 +27,8 @@ where
 import Control.Lens (makeClassy)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
+import Data.Tree (Forest)
+import GHCSpecter.Channel (type ModuleName)
 import GHCSpecter.Data.Assets (Assets)
 import GHCSpecter.UI.Types.Event (DetailLevel (..), Tab (..))
 
@@ -44,7 +46,7 @@ emptyModuleGraphUI = ModuleGraphUI Nothing Nothing
 
 newtype SourceViewUI = SourceViewUI
   { _srcViewExpandedModule :: Maybe Text
-  -- ^ expanded module in CheckImports
+  -- ^ expanded module in SourceView
   }
 
 makeClassy ''SourceViewUI

--- a/daemon/src/GHCSpecter/Util/SourceTree.hs
+++ b/daemon/src/GHCSpecter/Util/SourceTree.hs
@@ -1,0 +1,45 @@
+module GHCSpecter.Util.SourceTree
+  ( test,
+  )
+where
+
+import Control.Lens (to, (^..))
+import Data.Foldable qualified as F
+import Data.List qualified as L
+import Data.Text qualified as T
+import Data.Tree
+  ( Forest,
+    Tree (..),
+    drawForest,
+  )
+import GHCSpecter.Channel
+  ( ModuleGraphInfo (..),
+    SessionInfo (..),
+    type ModuleName,
+  )
+import GHCSpecter.Server.Types
+  ( HasServerState (..),
+    ServerState,
+  )
+
+appendTo :: [ModuleName] -> Forest ModuleName -> Forest ModuleName
+appendTo [] ts = ts
+appendTo (x : xs) [] = [Node x (appendTo xs [])]
+appendTo (x : xs) (t : ts)
+  | x == rootLabel t = Node x (appendTo xs (subForest t)) : ts
+  | otherwise = t : appendTo (x : xs) ts
+
+test :: ServerState -> IO ()
+test ss = do
+  let modNames =
+        L.sort $
+          ss
+            ^.. serverSessionInfo
+              . to sessionModuleGraph
+              . to mginfoModuleNameMap
+              . traverse
+              . to (T.splitOn ".")
+      forest = L.foldl' (\(!ts) m -> appendTo m ts) [] modNames
+  mapM_ print modNames
+  putStrLn $
+    drawForest (fmap (fmap T.unpack) forest)

--- a/daemon/src/GHCSpecter/Util/SourceTree.hs
+++ b/daemon/src/GHCSpecter/Util/SourceTree.hs
@@ -1,27 +1,17 @@
 module GHCSpecter.Util.SourceTree
-  ( test,
-    makeSourceTree,
+  ( makeSourceTree,
     accumPrefix,
     expandFocusOnly,
   )
 where
 
-import Control.Lens (to, (^.), (^..))
+import Control.Lens (to, (^..))
 import Data.List qualified as L
 import Data.Text qualified as T
-import Data.Tree
-  ( Forest,
-    Tree (..),
-    drawForest,
-  )
+import Data.Tree (Forest, Tree (..))
 import GHCSpecter.Channel
   ( ModuleGraphInfo (..),
-    SessionInfo (..),
     type ModuleName,
-  )
-import GHCSpecter.Server.Types
-  ( HasServerState (..),
-    ServerState,
   )
 
 appendTo :: [ModuleName] -> Forest ModuleName -> Forest ModuleName
@@ -54,13 +44,3 @@ expandFocusOnly _ [] = []
 expandFocusOnly (x : xs) (t : ts)
   | x == rootLabel t = Node x (expandFocusOnly xs (subForest t)) : fmap stripSubTree ts
   | otherwise = Node (rootLabel t) [] : expandFocusOnly (x : xs) ts
-
-test :: ServerState -> IO ()
-test ss = do
-  let forest = makeSourceTree (ss ^. serverSessionInfo . to sessionModuleGraph)
-      printForest f =
-        putStrLn $
-          drawForest (fmap (fmap show) f)
-      testForest = expandFocusOnly ["Client", "Bank"] forest
-      testForest' = fmap (accumPrefix []) testForest
-  printForest testForest'


### PR DESCRIPTION
For user's convenience and for a better performance, the module tree is used as the TOC and only the selected sub-tree is expanded. The SourceView is also organized as horizontal dual pane.
For nested list indentation, setting a style text globally is needed, so I introduced runDefaultWithStyle function.