### PR TITLE
Call Graph data extraction from a single module

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -44,7 +44,6 @@ import GHCSpecter.Comm
 import GHCSpecter.Data.Assets qualified as Assets
 import GHCSpecter.Driver qualified as Driver
 import GHCSpecter.Render (render)
-import GHCSpecter.Render.SourceView qualified as SourceView
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState (..),
@@ -68,6 +67,7 @@ import GHCSpecter.UI.Types.Event
   ( BackgroundEvent (RefreshUI),
     Event (BkgEv),
   )
+import GHCSpecter.Worker.CallGraph qualified as CallGraph (test)
 import GHCSpecter.Worker.Hie (hieWorker)
 import GHCSpecter.Worker.ModuleGraph (moduleGraphWorker)
 import Options.Applicative qualified as OA
@@ -236,4 +236,4 @@ main = do
       case eitherDecode' lbs of
         Left err -> print err
         Right ss -> do
-          SourceView.test ss
+          CallGraph.test ss

--- a/daemon/src/GHCSpecter/Render/Components/TextView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TextView.hs
@@ -20,7 +20,7 @@ render :: Bool -> Text -> [((Int, Int), (Int, Int))] -> Widget IHTML a
 render showCharBox txt highlighted =
   S.svg
     svgProps
-    ( S.style [] [text "text { font: 8px monospace; user-select: none; }"] :
+    ( S.style [] [text "text { font: 8px monospace; user-select: none; white-space: pre; }"] :
       contents
     )
   where

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -1,7 +1,5 @@
 module GHCSpecter.Render.SourceView
   ( render,
-    splitLineColumn,
-    test,
   )
 where
 
@@ -13,14 +11,8 @@ import Concur.Replica
     onClick,
     style,
   )
-import Control.Lens (at, to, (^.), (^..), (^?), _1, _Just)
-import Control.Monad (guard)
-import Control.Monad.Trans.State (State, get, put, runState)
-import Data.Foldable (for_)
-import Data.Function (on)
-import Data.List qualified as L
-import Data.List.NonEmpty qualified as NE
-import Data.Maybe (isJust, mapMaybe)
+import Control.Lens (at, to, (^.), (^?), _1, _Just)
+import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Tree (Tree, foldTree)
@@ -31,11 +23,9 @@ import GHCSpecter.Channel
   )
 import GHCSpecter.Render.Components.TextView qualified as TextView (render)
 import GHCSpecter.Server.Types
-  ( HasDeclRow' (..),
-    HasHieState (..),
+  ( HasHieState (..),
     HasModuleGraphState (..),
     HasModuleHieInfo (..),
-    HasRefRow' (..),
     HasServerState (..),
     Inbox,
     ModuleHieInfo,
@@ -61,6 +51,7 @@ import GHCSpecter.Util.SourceTree
   ( accumPrefix,
     expandFocusOnly,
   )
+import GHCSpecter.Worker.CallGraph (getReducedTopLevelDecls)
 import Prelude hiding (div, span)
 
 iconText :: Bool -> Text -> Text -> Text -> Widget IHTML MouseEvent
@@ -85,100 +76,6 @@ renderUnqualifiedImports modu inbox =
   where
     mmsg = inbox ^? at (CheckImports, modu) . _Just
     rendered = maybe "" (\msg -> "\n----- unqualified imports -----\n" <> msg) mmsg
-
--- | splitter based on line and column
--- line and col are 1-based.
-splitLineColumn :: (Int, Int) -> State ((Int, Int), Text) Text
-splitLineColumn (lin, col) = do
-  ((currLin, currCol), remainingTxt) <- get
-  let lineSplittedTxt = T.lines remainingTxt
-      (linesBefore, linesAfter) = splitAt (lin - currLin) lineSplittedTxt
-      ((txtInBreakLineBefore, txtInBreakLineAfter), linesAfterBreakLine) =
-        case linesAfter of
-          [] -> (("", ""), [])
-          breakLine : xs ->
-            if null linesBefore
-              then (T.splitAt (col - currCol) breakLine, xs)
-              else (T.splitAt (col - 1) breakLine, xs)
-      txtBefore = T.intercalate "\n" (linesBefore ++ [txtInBreakLineBefore])
-      txtAfter = T.intercalate "\n" (txtInBreakLineAfter : linesAfterBreakLine)
-  put ((lin, col), txtAfter)
-  pure txtBefore
-
-isContainedIn :: ((Int, Int), (Int, Int)) -> ((Int, Int), (Int, Int)) -> Bool
-(s1, e1) `isContainedIn` (s2, e2) = s1 >= s2 && e1 <= e2
-
-filterTopLevel :: (Show a) => [(((Int, Int), (Int, Int)), a)] -> [(((Int, Int), (Int, Int)), a)]
-filterTopLevel items = go [] items
-  where
-    go ys [] = ys
-    go ys (x : xs) =
-      let ys' = L.nubBy ((==) `on` fst) $ L.sortBy (compare `on` fst) $ go' ys x
-       in go ys' xs
-    go' [] x = [x]
-    go' zs@(y : ys) x
-      | fst x `isContainedIn` fst y = zs
-      | fst y `isContainedIn` fst x = x : go' ys x
-      | otherwise = y : go' ys x
-
-getTopLevelDecls :: ModuleHieInfo -> [(((Int, Int), (Int, Int)), Text)]
-getTopLevelDecls modHieInfo = sortedTopLevelDecls
-  where
-    extract decl =
-      let spos = (decl ^. decl'SLine, decl ^. decl'SCol)
-          epos = (decl ^. decl'ELine, decl ^. decl'ECol)
-          name = decl ^. decl'NameOcc
-       in ((spos, epos), name)
-    decls = modHieInfo ^.. modHieDecls . traverse . to extract
-    topLevelDecls = filterTopLevel decls
-    sortedTopLevelDecls = L.sortBy (compare `on` (^. _1)) topLevelDecls
-
-sliceText :: (Int, Int) -> (Int, Int) -> State ((Int, Int), Text) Text
-sliceText start end = do
-  _ <- splitLineColumn start
-  splitLineColumn end
-
-findText :: Text -> Text -> Maybe (Int, Int)
-findText needle haystick = do
-  let (searched, remaining) = T.breakOn needle haystick
-  guard (not (T.null remaining))
-  let ls = T.lines searched
-  case NE.nonEmpty ls of
-    Nothing ->
-      Just (0, 0)
-    Just ls' ->
-      Just (NE.length ls' - 1, T.length (NE.last ls'))
-
-addRowCol :: (Int, Int) -> (Int, Int) -> (Int, Int)
-addRowCol (i, j) (di, dj)
-  | di == 0 = (i, j + dj)
-  | otherwise = (i + di, dj)
-
-reduceDeclRange :: Text -> ((Int, Int), (Int, Int)) -> Text -> Maybe ((Int, Int), (Int, Int))
-reduceDeclRange src (start, end) needle =
-  let (sliced, _) = runState (sliceText start end) ((1, 1), src)
-      mdidj = findText needle sliced
-      indexFromStart didj =
-        let startOfNeedle = addRowCol start didj
-            endOfNeedle = addRowCol startOfNeedle (0, T.length needle - 1)
-         in (startOfNeedle, endOfNeedle)
-   in fmap indexFromStart mdidj
-
-getReducedTopLevelDecls :: ModuleHieInfo -> [(((Int, Int), (Int, Int)), Text)]
-getReducedTopLevelDecls modHieInfo =
-  mapMaybe
-    (\((start, end), decl) -> (,decl) <$> reduceDeclRange src (start, end) decl)
-    topLevelDecls
-  where
-    src = modHieInfo ^. modHieSource
-    topLevelDecls = getTopLevelDecls modHieInfo
-
-breakSourceText :: ModuleHieInfo -> [Text]
-breakSourceText modHieInfo = txts ++ [txt]
-  where
-    src = modHieInfo ^. modHieSource
-    topLevelDecls = getTopLevelDecls modHieInfo
-    (txts, (_, txt)) = runState (traverse (splitLineColumn . (^. _1 . _1)) topLevelDecls) ((1, 1), src)
 
 -- | show source code with declaration positions
 renderSourceCode :: ModuleHieInfo -> Widget IHTML a
@@ -271,28 +168,3 @@ render srcUI ss =
         ]
         [renderSourceView srcUI ss]
     ]
-
-test :: ServerState -> IO ()
-test ss = do
-  putStrLn "test"
-  let modName = "Metrics"
-      mmodHieInfo = ss ^? serverHieState . hieModuleMap . at modName . _Just
-  for_ mmodHieInfo $ \modHieInfo -> do
-    let decls = getTopLevelDecls modHieInfo
-        allRefs = modHieInfo ^.. modHieRefs . traverse
-    for_ decls $ \((declStart, declEnd), name) -> do
-      putStrLn "------"
-      print (name, (declStart, declEnd))
-      let isHiddenSymbol r =
-            "$" `T.isPrefixOf` (r ^. ref'NameOcc)
-          isSelf r =
-            r ^. ref'NameOcc == name && r ^. ref'NameMod == modName
-          isDepOn r =
-            let refStart = (r ^. ref'SLine, r ^. ref'SCol)
-                refEnd = (r ^. ref'ELine, r ^. ref'ECol)
-             in (refStart, refEnd) `isContainedIn` (declStart, declEnd)
-
-      let depRefs =
-            filter (\r -> isDepOn r && not (isSelf r) && not (isHiddenSymbol r)) allRefs
-          depRefNames = L.nub $ L.sort $ fmap (\r -> (r ^. ref'NameMod, r ^. ref'NameOcc)) depRefs
-      print depRefNames

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/DOM.hs
@@ -131,7 +131,11 @@ import Control.ShiftMap (ShiftMap (shiftMap))
 import Data.Map qualified as M
 import Data.Text qualified as T
 import GHCSpecter.UI.ConcurReplica.Types (IHTML (..))
-import Replica.VDOM (Attr (ABool, AEvent, AMap, AText), Namespace, VDOM (VNode, VText))
+import Replica.VDOM
+  ( Attr (ABool, AEvent, AMap, AText),
+    Namespace,
+    VDOM (VNode, VText),
+  )
 import Prelude hiding (div, span)
 
 type WidgetConstraints m = (ShiftMap (Widget IHTML) m, Monad m, MonadSafeBlockingIO m, MonadUnsafeBlockingIO m, MultiAlternative m)

--- a/daemon/src/GHCSpecter/Util/SourceText.hs
+++ b/daemon/src/GHCSpecter/Util/SourceText.hs
@@ -1,0 +1,89 @@
+module GHCSpecter.Util.SourceText
+  ( -- * Line-Column utility
+    splitLineColumn,
+    isContainedIn,
+    sliceText,
+    findText,
+    addLineCol,
+
+    -- * Top-level declaration extraction
+    filterTopLevel,
+    reduceDeclRange,
+  )
+where
+
+import Control.Monad (guard)
+import Control.Monad.Trans.State (State, get, put, runState)
+import Data.Function (on)
+import Data.List qualified as L
+import Data.List.NonEmpty qualified as NE
+import Data.Text (Text)
+import Data.Text qualified as T
+
+-- TODO: newtype (Int, Int) to LineCol
+
+-- | splitter based on line and column
+-- line and col are 1-based.
+splitLineColumn :: (Int, Int) -> State ((Int, Int), Text) Text
+splitLineColumn (lin, col) = do
+  ((currLin, currCol), remainingTxt) <- get
+  let lineSplittedTxt = T.lines remainingTxt
+      (linesBefore, linesAfter) = splitAt (lin - currLin) lineSplittedTxt
+      ((txtInBreakLineBefore, txtInBreakLineAfter), linesAfterBreakLine) =
+        case linesAfter of
+          [] -> (("", ""), [])
+          breakLine : xs ->
+            if null linesBefore
+              then (T.splitAt (col - currCol) breakLine, xs)
+              else (T.splitAt (col - 1) breakLine, xs)
+      txtBefore = T.intercalate "\n" (linesBefore ++ [txtInBreakLineBefore])
+      txtAfter = T.intercalate "\n" (txtInBreakLineAfter : linesAfterBreakLine)
+  put ((lin, col), txtAfter)
+  pure txtBefore
+
+isContainedIn :: ((Int, Int), (Int, Int)) -> ((Int, Int), (Int, Int)) -> Bool
+(s1, e1) `isContainedIn` (s2, e2) = s1 >= s2 && e1 <= e2
+
+sliceText :: (Int, Int) -> (Int, Int) -> State ((Int, Int), Text) Text
+sliceText start end = do
+  _ <- splitLineColumn start
+  splitLineColumn end
+
+findText :: Text -> Text -> Maybe (Int, Int)
+findText needle haystick = do
+  let (searched, remaining) = T.breakOn needle haystick
+  guard (not (T.null remaining))
+  let ls = T.lines searched
+  case NE.nonEmpty ls of
+    Nothing ->
+      Just (0, 0)
+    Just ls' ->
+      Just (NE.length ls' - 1, T.length (NE.last ls'))
+
+addLineCol :: (Int, Int) -> (Int, Int) -> (Int, Int)
+addLineCol (i, j) (di, dj)
+  | di == 0 = (i, j + dj)
+  | otherwise = (i + di, dj)
+
+filterTopLevel :: (Show a) => [(((Int, Int), (Int, Int)), a)] -> [(((Int, Int), (Int, Int)), a)]
+filterTopLevel items = go [] items
+  where
+    go ys [] = ys
+    go ys (x : xs) =
+      let ys' = L.nubBy ((==) `on` fst) $ L.sortBy (compare `on` fst) $ go' ys x
+       in go ys' xs
+    go' [] x = [x]
+    go' zs@(y : ys) x
+      | fst x `isContainedIn` fst y = zs
+      | fst y `isContainedIn` fst x = x : go' ys x
+      | otherwise = y : go' ys x
+
+reduceDeclRange :: Text -> ((Int, Int), (Int, Int)) -> Text -> Maybe ((Int, Int), (Int, Int))
+reduceDeclRange src (start, end) needle =
+  let (sliced, _) = runState (sliceText start end) ((1, 1), src)
+      mdidj = findText needle sliced
+      indexFromStart didj =
+        let startOfNeedle = addLineCol start didj
+            endOfNeedle = addLineCol startOfNeedle (0, T.length needle - 1)
+         in (startOfNeedle, endOfNeedle)
+   in fmap indexFromStart mdidj

--- a/daemon/src/GHCSpecter/Worker/CallGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/CallGraph.hs
@@ -1,0 +1,98 @@
+module GHCSpecter.Worker.CallGraph
+  ( -- * top-level decl
+    getTopLevelDecls,
+    getReducedTopLevelDecls,
+    breakSourceText,
+
+    -- * call graph
+    makeCallGraph,
+
+    -- * test
+    test,
+  )
+where
+
+import Control.Lens (at, to, (^.), (^..), (^?), _1, _Just)
+import Control.Monad.Trans.State (runState)
+import Data.Foldable (for_)
+import Data.Function (on)
+import Data.List qualified as L
+import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHCSpecter.Channel (ModuleName)
+import GHCSpecter.Server.Types
+  ( HasDeclRow' (..),
+    HasHieState (..),
+    HasModuleHieInfo (..),
+    HasRefRow' (..),
+    HasServerState (..),
+    ModuleHieInfo,
+    ServerState (..),
+  )
+import GHCSpecter.Util.SourceText
+  ( filterTopLevel,
+    isContainedIn,
+    reduceDeclRange,
+    splitLineColumn,
+  )
+
+getTopLevelDecls :: ModuleHieInfo -> [(((Int, Int), (Int, Int)), Text)]
+getTopLevelDecls modHieInfo = sortedTopLevelDecls
+  where
+    extract decl =
+      let spos = (decl ^. decl'SLine, decl ^. decl'SCol)
+          epos = (decl ^. decl'ELine, decl ^. decl'ECol)
+          name = decl ^. decl'NameOcc
+       in ((spos, epos), name)
+    decls = modHieInfo ^.. modHieDecls . traverse . to extract
+    topLevelDecls = filterTopLevel decls
+    sortedTopLevelDecls = L.sortBy (compare `on` (^. _1)) topLevelDecls
+
+getReducedTopLevelDecls :: ModuleHieInfo -> [(((Int, Int), (Int, Int)), Text)]
+getReducedTopLevelDecls modHieInfo =
+  mapMaybe
+    (\((start, end), decl) -> (,decl) <$> reduceDeclRange src (start, end) decl)
+    topLevelDecls
+  where
+    src = modHieInfo ^. modHieSource
+    topLevelDecls = getTopLevelDecls modHieInfo
+
+breakSourceText :: ModuleHieInfo -> [Text]
+breakSourceText modHieInfo = txts ++ [txt]
+  where
+    src = modHieInfo ^. modHieSource
+    topLevelDecls = getTopLevelDecls modHieInfo
+    (txts, (_, txt)) = runState (traverse (splitLineColumn . (^. _1 . _1)) topLevelDecls) ((1, 1), src)
+
+makeCallGraph ::
+  ModuleName ->
+  ModuleHieInfo ->
+  [(Text, [(ModuleName, Text)])]
+makeCallGraph modName modHieInfo = fmap extract topDecls
+  where
+    topDecls = getTopLevelDecls modHieInfo
+    allRefs = modHieInfo ^.. modHieRefs . traverse
+    extract ((declStart, declEnd), declName) =
+      let isHiddenSymbol r =
+            "$" `T.isPrefixOf` (r ^. ref'NameOcc)
+          isSelf r =
+            r ^. ref'NameOcc == declName && r ^. ref'NameMod == modName
+          isDepOn r =
+            let refStart = (r ^. ref'SLine, r ^. ref'SCol)
+                refEnd = (r ^. ref'ELine, r ^. ref'ECol)
+             in (refStart, refEnd) `isContainedIn` (declStart, declEnd)
+
+          depRefs =
+            filter (\r -> isDepOn r && not (isSelf r) && not (isHiddenSymbol r)) allRefs
+          depRefNames = L.nub $ L.sort $ fmap (\r -> (r ^. ref'NameMod, r ^. ref'NameOcc)) depRefs
+       in (declName, depRefNames)
+
+test :: ServerState -> IO ()
+test ss = do
+  putStrLn "test"
+  let modName = "Metrics"
+      mmodHieInfo = ss ^? serverHieState . hieModuleMap . at modName . _Just
+  for_ mmodHieInfo $ \modHieInfo -> do
+    let callGraph = makeCallGraph modName modHieInfo
+    mapM_ print callGraph

--- a/daemon/src/GHCSpecter/Worker/Hie.hs
+++ b/daemon/src/GHCSpecter/Worker/Hie.hs
@@ -42,7 +42,7 @@ convertRefRow RefRow {..} =
   RefRow'
     { _ref'Src = refSrc
     , _ref'NameOcc = T.pack $ occNameString refNameOcc
-    , _ref'NameMod = T.pack $ show refNameMod
+    , _ref'NameMod = T.pack $ moduleNameString refNameMod
     , _ref'NameUnit = T.pack $ show refNameUnit
     , _ref'SLine = refSLine
     , _ref'SCol = refSCol


### PR DESCRIPTION
By identifying top-level declarations and references in each top-level declaration, the call graph is constructed in a given module. For the sake of usability, the call graph is restricted in a self-package, so that users can see how function-level dependencies are set in the current GHC session.