### PR TITLE
GraphLayout module reorganization 

### DIFF
--- a/daemon/src/GHCSpecter/GraphLayout/Algorithm/BFS.hs
+++ b/daemon/src/GHCSpecter/GraphLayout/Algorithm/BFS.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 
 -- | Breadth-First-Search (BFS)
-module GHCSpecter.Util.Graph.BFS
+module GHCSpecter.GraphLayout.Algorithm.BFS
   ( -- * internal state for BFS
     BFSState (..),
     BFSPath (..),

--- a/daemon/src/GHCSpecter/GraphLayout/Algorithm/Builder.hs
+++ b/daemon/src/GHCSpecter/GraphLayout/Algorithm/Builder.hs
@@ -1,4 +1,4 @@
-module GHCSpecter.Util.Graph.Builder
+module GHCSpecter.GraphLayout.Algorithm.Builder
   ( makeEdges,
     makeRevDep,
     makeBiDep,

--- a/daemon/src/GHCSpecter/GraphLayout/Algorithm/Cluster.hs
+++ b/daemon/src/GHCSpecter/GraphLayout/Algorithm/Cluster.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE LambdaCase #-}
 
-module GHCSpecter.Util.Graph.Cluster
+module GHCSpecter.GraphLayout.Algorithm.Cluster
   ( ClusterState (..),
     ClusterVertex (..),
     GraphState (..),
@@ -34,7 +34,7 @@ import Data.IntMap qualified as IM
 import Data.List qualified as L
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Monoid (First (..))
-import GHCSpecter.Util.Graph.Builder (makeBiDep)
+import GHCSpecter.GraphLayout.Algorithm.Builder (makeBiDep)
 
 -- | representative vertex, other vertices that belong to this cluster
 newtype ClusterVertex = Cluster {unCluster :: Int}

--- a/daemon/src/GHCSpecter/GraphLayout/OGDF.hs
+++ b/daemon/src/GHCSpecter/GraphLayout/OGDF.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module GHCSpecter.Util.OGDF
+module GHCSpecter.GraphLayout.OGDF
   ( nodeGraphics,
     edgeGraphics,
     edgeIntWeight,

--- a/daemon/src/GHCSpecter/GraphLayout/Types.hs
+++ b/daemon/src/GHCSpecter/GraphLayout/Types.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module GHCSpecter.GraphLayout.Types
+  ( -- * graph visualization information
+    Point (..),
+    HasPoint (..),
+    Dimension (..),
+    HasDimension (..),
+    NodeLayout (..),
+    HasNodeLayout (..),
+    EdgeLayout (..),
+    HasEdgeLayout (..),
+    GraphVisInfo (..),
+    HasGraphVisInfo (..),
+    transposeGraphVis,
+  )
+where
+
+import Control.Lens (makeClassy)
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+data Point = Point
+  { _pointX :: Double
+  , _pointY :: Double
+  }
+  deriving (Show, Generic)
+
+makeClassy ''Point
+
+instance FromJSON Point
+
+instance ToJSON Point
+
+data Dimension = Dim
+  { _dimWidth :: Double
+  , _dimHeight :: Double
+  }
+  deriving (Show, Generic)
+
+makeClassy ''Dimension
+
+instance FromJSON Dimension
+
+instance ToJSON Dimension
+
+data NodeLayout a = NodeLayout
+  { _nodePayload :: a
+  -- ^ information in node
+  , _nodePosition :: Point
+  -- ^ node center position
+  , _nodeSize :: Dimension
+  -- ^ node width and height
+  }
+  deriving (Show, Generic)
+
+makeClassy ''NodeLayout
+
+instance FromJSON a => FromJSON (NodeLayout a)
+
+instance ToJSON a => ToJSON (NodeLayout a)
+
+data EdgeLayout = EdgeLayout
+  { _edgeId :: Int
+  -- ^ edge id from the graph layouter
+  , _edgeEndNodes :: (Int, Int)
+  -- ^ (source node, target node)
+  , _edgeStartEndPoints :: (Point, Point)
+  -- ^ edge start point, end point
+  , _edgeBendPoints :: [Point]
+  -- ^ edge bend points
+  }
+  deriving (Show, Generic)
+
+makeClassy ''EdgeLayout
+
+instance FromJSON EdgeLayout
+
+instance ToJSON EdgeLayout
+
+data GraphVisInfo = GraphVisInfo
+  { _gviCanvasDim :: Dimension
+  , _gviNodes :: [NodeLayout (Int, Text)]
+  , _gviEdges :: [EdgeLayout]
+  }
+  deriving (Show, Generic)
+
+makeClassy ''GraphVisInfo
+
+instance FromJSON GraphVisInfo
+
+instance ToJSON GraphVisInfo
+
+-- | swap horizontal and vertical directions.
+transposeGraphVis :: GraphVisInfo -> GraphVisInfo
+transposeGraphVis (GraphVisInfo dim nodLayout edgLayout) =
+  GraphVisInfo dim' nodLayout' edgLayout'
+  where
+    xposeDim (Dim w h) = Dim h w
+    xposePt (Point x y) = Point y x
+    xposeNode (NodeLayout p xy d) = NodeLayout p (xposePt xy) (xposeDim d)
+    xposeEdge (EdgeLayout i (j, k) (start, end) pts) =
+      EdgeLayout i (j, k) (xposePt start, xposePt end) (fmap xposePt pts)
+    dim' = xposeDim dim
+    nodLayout' = fmap xposeNode nodLayout
+    edgLayout' = fmap xposeEdge edgLayout

--- a/daemon/src/GHCSpecter/Render/Components/TextView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TextView.hs
@@ -18,6 +18,7 @@ import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 
 render :: Bool -> Text -> [((Int, Int), (Int, Int))] -> Widget IHTML a
 render showCharBox txt highlighted =
+  -- NOTE: white-space: pre to preserve white-space occurrences in the source code.
   S.svg
     svgProps
     ( S.style [] [text "text { font: 8px monospace; user-select: none; white-space: pre; }"] :

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -47,6 +47,8 @@ import GHCSpecter.Channel
     SessionInfo (..),
     Timer,
   )
+import GHCSpecter.GraphLayout.Algorithm.Builder (makeRevDep)
+import GHCSpecter.GraphLayout.Algorithm.Cluster (filterOutSmallNodes)
 import GHCSpecter.GraphLayout.Types
   ( Dimension (..),
     EdgeLayout (..),
@@ -83,8 +85,6 @@ import GHCSpecter.UI.Types.Event
     ModuleGraphEvent (..),
     SubModuleEvent (..),
   )
-import GHCSpecter.Util.Graph.Builder (makeRevDep)
-import GHCSpecter.Util.Graph.Cluster (filterOutSmallNodes)
 import Text.Printf (printf)
 import Prelude hiding (div)
 

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -47,17 +47,19 @@ import GHCSpecter.Channel
     SessionInfo (..),
     Timer,
   )
-import GHCSpecter.Render.Util (xmlns)
-import GHCSpecter.Server.Types
+import GHCSpecter.GraphLayout.Types
   ( Dimension (..),
     EdgeLayout (..),
     GraphVisInfo (..),
     HasGraphVisInfo (..),
-    HasModuleGraphState (..),
     HasNodeLayout (..),
-    HasServerState (..),
     NodeLayout (..),
     Point (..),
+  )
+import GHCSpecter.Render.Util (xmlns)
+import GHCSpecter.Server.Types
+  ( HasModuleGraphState (..),
+    HasServerState (..),
     ServerState (..),
   )
 import GHCSpecter.UI.ConcurReplica.DOM

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -30,19 +30,6 @@ module GHCSpecter.Server.Types
     HasServerState (..),
     emptyServerState,
     incrementSN,
-
-    -- * graph visualization information
-    Point (..),
-    HasPoint (..),
-    Dimension (..),
-    HasDimension (..),
-    NodeLayout (..),
-    HasNodeLayout (..),
-    EdgeLayout (..),
-    HasEdgeLayout (..),
-    GraphVisInfo (..),
-    HasGraphVisInfo (..),
-    transposeGraphVis,
   )
 where
 
@@ -59,96 +46,12 @@ import GHCSpecter.Channel
     emptyModuleGraphInfo,
     type ModuleName,
   )
+import GHCSpecter.GraphLayout.Types (GraphVisInfo)
 import GHCSpecter.UI.Types.Event (DetailLevel)
 
 type ChanModule = (Channel, Text)
 
 type Inbox = Map ChanModule Text
-
-data Point = Point
-  { _pointX :: Double
-  , _pointY :: Double
-  }
-  deriving (Show, Generic)
-
-makeClassy ''Point
-
-instance FromJSON Point
-
-instance ToJSON Point
-
-data Dimension = Dim
-  { _dimWidth :: Double
-  , _dimHeight :: Double
-  }
-  deriving (Show, Generic)
-
-makeClassy ''Dimension
-
-instance FromJSON Dimension
-
-instance ToJSON Dimension
-
-data NodeLayout a = NodeLayout
-  { _nodePayload :: a
-  -- ^ information in node
-  , _nodePosition :: Point
-  -- ^ node center position
-  , _nodeSize :: Dimension
-  -- ^ node width and height
-  }
-  deriving (Show, Generic)
-
-makeClassy ''NodeLayout
-
-instance FromJSON a => FromJSON (NodeLayout a)
-
-instance ToJSON a => ToJSON (NodeLayout a)
-
-data EdgeLayout = EdgeLayout
-  { _edgeId :: Int
-  -- ^ edge id from the graph layouter
-  , _edgeEndNodes :: (Int, Int)
-  -- ^ (source node, target node)
-  , _edgeStartEndPoints :: (Point, Point)
-  -- ^ edge start point, end point
-  , _edgeBendPoints :: [Point]
-  -- ^ edge bend points
-  }
-  deriving (Show, Generic)
-
-makeClassy ''EdgeLayout
-
-instance FromJSON EdgeLayout
-
-instance ToJSON EdgeLayout
-
-data GraphVisInfo = GraphVisInfo
-  { _gviCanvasDim :: Dimension
-  , _gviNodes :: [NodeLayout (Int, Text)]
-  , _gviEdges :: [EdgeLayout]
-  }
-  deriving (Show, Generic)
-
-makeClassy ''GraphVisInfo
-
-instance FromJSON GraphVisInfo
-
-instance ToJSON GraphVisInfo
-
--- | swap horizontal and vertical directions.
-transposeGraphVis :: GraphVisInfo -> GraphVisInfo
-transposeGraphVis (GraphVisInfo dim nodLayout edgLayout) =
-  GraphVisInfo dim' nodLayout' edgLayout'
-  where
-    xposeDim (Dim w h) = Dim h w
-    xposePt (Point x y) = Point y x
-    xposeNode (NodeLayout p xy d) = NodeLayout p (xposePt xy) (xposeDim d)
-    xposeEdge (EdgeLayout i (j, k) (start, end) pts) =
-      EdgeLayout i (j, k) (xposePt start, xposePt end) (fmap xposePt pts)
-    dim' = xposeDim dim
-    nodLayout' = fmap xposeNode nodLayout
-    edgLayout' = fmap xposeEdge edgLayout
 
 data ModuleGraphState = ModuleGraphState
   { _mgsModuleForest :: Forest ModuleName

--- a/daemon/src/GHCSpecter/Util/OGDF.hs
+++ b/daemon/src/GHCSpecter/Util/OGDF.hs
@@ -56,7 +56,7 @@ import FFICXX.Runtime.TH (IsCPrimitive (..), TemplateParamInfo (..))
 import Foreign.C.Types (CBool (..), CLong)
 import Foreign.Ptr (nullPtr)
 import Foreign.Storable (Storable (peek, poke))
-import GHCSpecter.Server.Types
+import GHCSpecter.GraphLayout.Types
   ( Dimension (..),
     EdgeLayout (..),
     NodeLayout (..),

--- a/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
@@ -27,6 +27,30 @@ import GHCSpecter.Channel
   ( ModuleGraphInfo (..),
     ModuleName,
   )
+import GHCSpecter.GraphLayout.Algorithm.BFS (runMultiseedStagedBFS)
+import GHCSpecter.GraphLayout.Algorithm.Builder
+  ( makeBiDep,
+    makeEdges,
+    makeRevDep,
+  )
+import GHCSpecter.GraphLayout.Algorithm.Cluster
+  ( filterOutSmallNodes,
+    makeDivisionsInOrder,
+    reduceGraphByPath,
+  )
+import GHCSpecter.GraphLayout.OGDF
+  ( appendText,
+    doSugiyamaLayout,
+    edgeGraphics,
+    getAllEdgeLayout,
+    getAllNodeLayout,
+    getCanvasDim,
+    newGraphNodeWithSize,
+    nodeGraphics,
+    nodeLabel,
+    nodeStyle,
+    runGraphLayouter,
+  )
 import GHCSpecter.GraphLayout.Types
   ( EdgeLayout (..),
     GraphVisInfo (..),
@@ -40,30 +64,6 @@ import GHCSpecter.Server.Types
     incrementSN,
   )
 import GHCSpecter.UI.Types.Event (DetailLevel (..))
-import GHCSpecter.Util.Graph.BFS (runMultiseedStagedBFS)
-import GHCSpecter.Util.Graph.Builder
-  ( makeBiDep,
-    makeEdges,
-    makeRevDep,
-  )
-import GHCSpecter.Util.Graph.Cluster
-  ( filterOutSmallNodes,
-    makeDivisionsInOrder,
-    reduceGraphByPath,
-  )
-import GHCSpecter.Util.OGDF
-  ( appendText,
-    doSugiyamaLayout,
-    edgeGraphics,
-    getAllEdgeLayout,
-    getAllNodeLayout,
-    getCanvasDim,
-    newGraphNodeWithSize,
-    nodeGraphics,
-    nodeLabel,
-    nodeStyle,
-    runGraphLayouter,
-  )
 import GHCSpecter.Util.SourceTree (makeSourceTree)
 import OGDF.Graph
   ( Graph,

--- a/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
@@ -27,15 +27,17 @@ import GHCSpecter.Channel
   ( ModuleGraphInfo (..),
     ModuleName,
   )
-import GHCSpecter.Server.Types
+import GHCSpecter.GraphLayout.Types
   ( EdgeLayout (..),
     GraphVisInfo (..),
-    HasModuleGraphState (..),
-    HasServerState (..),
     NodeLayout (..),
+    transposeGraphVis,
+  )
+import GHCSpecter.Server.Types
+  ( HasModuleGraphState (..),
+    HasServerState (..),
     ServerState (..),
     incrementSN,
-    transposeGraphVis,
   )
 import GHCSpecter.UI.Types.Event (DetailLevel (..))
 import GHCSpecter.Util.Graph.BFS (runMultiseedStagedBFS)


### PR DESCRIPTION
Change the prefix Util to GraphLayout to be specific for those modules. GraphLayout.Types are also separated out.