### PR TITLE
Serial work queue. Ctrl-C workaround

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -5,7 +5,7 @@ module Main (main) where
 
 import Concur.Core (Widget, liftSTM, unsafeBlockingIO)
 import Control.Applicative ((<|>))
-import Control.Concurrent (forkIO, forkOS)
+import Control.Concurrent (forkIO, forkOS, threadDelay)
 import Control.Concurrent.STM
   ( TChan,
     TQueue,
@@ -120,6 +120,7 @@ runWorkQueue workQ = go 0
       -- putStrLn $ show n ++ "th job started"
       job
       -- putStrLn $ show n ++ "th job ended"
+      threadDelay 50_000
       go (n + 1)
 
 listener :: FilePath -> TVar ServerState -> TQueue (IO ()) -> IO ()

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1661452640,
-        "narHash": "sha256-5fPqMa8GDad9xIKr2LeglP4jPmrO6OdPuGukbz9qioI=",
+        "lastModified": 1664079829,
+        "narHash": "sha256-qEmIkvoCThRV9Eh51hvgtf8hDfBX2vjEXmh2ejqZOt0=",
         "owner": "wavewave",
         "repo": "fficxx",
-        "rev": "030de8107b1d9c2027e454c67ec1e7d9e6463b38",
+        "rev": "819aa9caefab1c58381dd4ba274fe7e7fd4a3d90",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Massive calls to C++ graph layouter caused unresponsive Ctrl+C. It's unclear what exactly causes this issue. As a workaround, this PR introduces arranging the jobs serially (which is desirable after all as we want to minimize interference with GHC compilation performance) and giving a little time room (50 ms) between jobs.