### PR TITLE
Driver module reorg and server session type

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -1,61 +1,25 @@
 module Main (main) where
 
-import Concur.Core (Widget, liftSTM, unsafeBlockingIO)
-import Control.Applicative ((<|>))
 import Control.Concurrent (forkOS)
 import Control.Concurrent.STM
-  ( TChan,
-    atomically,
+  ( atomically,
     newTChanIO,
     newTQueueIO,
     newTVar,
-    newTVarIO,
-    readTChan,
-    writeTChan,
   )
-import Control.Lens ((.~), (^.))
-import Control.Monad.Extra (loopM)
 import Data.Aeson (eitherDecode')
 import Data.ByteString.Lazy qualified as BL
 import Data.Maybe (fromMaybe)
-import Data.Text (Text)
-import Data.Time.Clock (getCurrentTime)
 import GHCSpecter.Config
   ( Config (..),
     defaultGhcSpecterConfigFile,
     loadConfig,
   )
-import GHCSpecter.Data.Assets qualified as Assets
+import GHCSpecter.Driver (webServer)
 import GHCSpecter.Driver.Comm qualified as Comm
-import GHCSpecter.Driver.Session qualified as Session
-import GHCSpecter.Driver.Session.Types
-  ( ClientSession (..),
-    ServerSession (..),
-    UIChannel (..),
-  )
+import GHCSpecter.Driver.Session.Types (ServerSession (..))
 import GHCSpecter.Driver.Worker qualified as Worker
-import GHCSpecter.Render (render)
-import GHCSpecter.Server.Types
-  ( ServerState (..),
-    emptyServerState,
-  )
-import GHCSpecter.UI.ConcurReplica.Run (runDefaultWithStyle)
-import GHCSpecter.UI.ConcurReplica.Types
-  ( IHTML,
-    blockDOMUpdate,
-    unblockDOMUpdate,
-  )
-import GHCSpecter.UI.Types
-  ( HasUIState (..),
-    UIState,
-    UIView (..),
-    emptyMainView,
-    emptyUIState,
-  )
-import GHCSpecter.UI.Types.Event
-  ( BackgroundEvent (RefreshUI),
-    Event (BkgEv),
-  )
+import GHCSpecter.Server.Types (emptyServerState)
 import Options.Applicative qualified as OA
 
 data CLIMode
@@ -87,63 +51,6 @@ optsParser =
   OA.info
     (OA.subparser (onlineMode <> viewMode) OA.<**> OA.helper)
     OA.fullDesc
-
--- NOTE:
--- server state: shared across the session
--- ui state: per web view.
--- control: per web view
-
-styleText :: Text
-styleText = "ul > li { margin-left: 10px; }"
-
-webServer :: Config -> ServerSession -> IO ()
-webServer cfg servSess = do
-  let port = configWebPort cfg
-  assets <- Assets.loadAssets
-  runDefaultWithStyle port "ghc-specter" styleText $
-    \_ -> do
-      uiRef <-
-        unsafeBlockingIO $ do
-          initTime <- getCurrentTime
-          let ui0 = emptyUIState assets initTime
-              ui0' = (uiView .~ MainMode emptyMainView) ui0
-          newTVarIO ui0'
-      chanEv <- unsafeBlockingIO newTChanIO
-      chanState <- unsafeBlockingIO newTChanIO
-      chanBkg <- unsafeBlockingIO newTChanIO
-      let newCS = ClientSession uiRef chanEv chanState chanBkg
-          newUIChan = UIChannel chanEv chanState chanBkg
-      unsafeBlockingIO $ Session.main servSess newCS
-      loopM (step newUIChan) (BkgEv RefreshUI)
-  where
-    -- A single step of the outer loop (See Note [Control Loops]).
-    step ::
-      -- UI comm channel
-      UIChannel ->
-      -- last event
-      Event ->
-      Widget IHTML (Either Event ())
-    step (UIChannel chanEv chanState chanBkg) ev = do
-      (ui, ss) <-
-        unsafeBlockingIO $ do
-          atomically $ writeTChan chanEv ev
-          (ui, ss) <- atomically $ readTChan chanState
-          pure (ui, ss)
-      stepRender (ui, ss) <|> (Left . BkgEv <$> waitForBkgEv chanBkg)
-
-    stepRender :: (UIState, ServerState) -> Widget IHTML (Either Event ())
-    stepRender (ui, ss) = do
-      let renderUI =
-            if ui ^. uiShouldUpdate
-              then unblockDOMUpdate (render (ui, ss))
-              else blockDOMUpdate (render (ui, ss))
-      Left <$> renderUI
-
-    waitForBkgEv ::
-      -- channel for receiving bkg event
-      TChan BackgroundEvent ->
-      Widget IHTML BackgroundEvent
-    waitForBkgEv chanBkg = liftSTM $ readTChan chanBkg
 
 withConfig :: Maybe FilePath -> (Config -> IO ()) -> IO ()
 withConfig mconfigFile action = do

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -1,67 +1,43 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 module Main (main) where
 
 import Concur.Core (Widget, liftSTM, unsafeBlockingIO)
 import Control.Applicative ((<|>))
-import Control.Concurrent (forkIO, forkOS, threadDelay)
+import Control.Concurrent (forkOS)
 import Control.Concurrent.STM
   ( TChan,
-    TQueue,
-    TVar,
     atomically,
-    modifyTVar',
     newTChanIO,
     newTQueueIO,
     newTVar,
     newTVarIO,
     readTChan,
-    readTQueue,
     writeTChan,
   )
-import Control.Lens ((%~), (.~), (^.))
-import Control.Monad (forever, void)
+import Control.Lens ((.~), (^.))
 import Control.Monad.Extra (loopM)
 import Data.Aeson (eitherDecode')
 import Data.ByteString.Lazy qualified as BL
-import Data.Foldable qualified as F
-import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Time.Clock (getCurrentTime)
-import GHCSpecter.Channel
-  ( ChanMessage (..),
-    ChanMessageBox (..),
-    Channel (..),
-    HsSourceInfo (..),
-    SessionInfo (..),
-    Timer (..),
-  )
-import GHCSpecter.Comm
-  ( receiveObject,
-    runServer,
-    sendObject,
-  )
 import GHCSpecter.Config
   ( Config (..),
     defaultGhcSpecterConfigFile,
     loadConfig,
   )
 import GHCSpecter.Data.Assets qualified as Assets
-import GHCSpecter.Driver qualified as Driver
+import GHCSpecter.Driver.Comm qualified as Comm
+import GHCSpecter.Driver.Session qualified as Session
 import GHCSpecter.Driver.Session.Types
   ( ClientSession (..),
-    HasServerSession (..),
     ServerSession (..),
     UIChannel (..),
   )
+import GHCSpecter.Driver.Worker qualified as Worker
 import GHCSpecter.Render (render)
 import GHCSpecter.Server.Types
-  ( HasServerState (..),
-    ServerState (..),
+  ( ServerState (..),
     emptyServerState,
-    incrementSN,
   )
 import GHCSpecter.UI.ConcurReplica.Run (runDefaultWithStyle)
 import GHCSpecter.UI.ConcurReplica.Types
@@ -80,8 +56,6 @@ import GHCSpecter.UI.Types.Event
   ( BackgroundEvent (RefreshUI),
     Event (BkgEv),
   )
-import GHCSpecter.Worker.Hie (hieWorker)
-import GHCSpecter.Worker.ModuleGraph (moduleGraphWorker)
 import Options.Applicative qualified as OA
 
 data CLIMode
@@ -114,64 +88,6 @@ optsParser =
     (OA.subparser (onlineMode <> viewMode) OA.<**> OA.helper)
     OA.fullDesc
 
-runWorkQueue :: TQueue (IO ()) -> IO ()
-runWorkQueue workQ = go 0
-  where
-    go :: Int -> IO ()
-    go n = do
-      job <- atomically $ readTQueue workQ
-      -- TODO: disabled as it's too verbose. enable with proper logging system.
-      -- putStrLn $ show n ++ "th job started"
-      job
-      -- putStrLn $ show n ++ "th job ended"
-      threadDelay 50_000
-      go (n + 1)
-
-listener ::
-  FilePath ->
-  TVar ServerState ->
-  ServerSession ->
-  TQueue (IO ()) ->
-  IO ()
-listener socketFile ssRef ssess workQ = do
-  runServer socketFile $ \sock -> do
-    _ <- forkIO $ sender sock
-    receiver sock
-  where
-    chanSignal = ssess ^. ssSubscriberSignal
-    sender sock = forever $ do
-      putStrLn $ "########"
-      newPauseState <- atomically $ readTChan chanSignal
-      putStrLn "#### sendObject ####"
-      newPauseState `seq` sendObject sock newPauseState
-    receiver sock = forever $ do
-      msgs :: [ChanMessageBox] <- receiveObject sock
-      F.for_ msgs $ \(CMBox o) -> do
-        case o of
-          CMSession s' -> do
-            let mgi = sessionModuleGraph s'
-            void $ forkIO (moduleGraphWorker ssRef mgi)
-          CMHsSource _modu (HsSourceInfo hiefile) ->
-            void $ forkIO (hieWorker ssRef workQ hiefile)
-          _ -> pure ()
-        atomically . modifyTVar' ssRef . updateInbox $ CMBox o
-
-updateInbox :: ChanMessageBox -> ServerState -> ServerState
-updateInbox chanMsg = incrementSN . updater
-  where
-    updater = case chanMsg of
-      CMBox (CMCheckImports modu msg) ->
-        (serverInbox %~ M.insert (CheckImports, modu) msg)
-      CMBox (CMTiming modu timer') ->
-        let f Nothing = Just timer'
-            f (Just timer0) =
-              Just $ Timer (unTimer timer0 ++ unTimer timer')
-         in (serverTiming %~ M.alter f modu)
-      CMBox (CMSession s') ->
-        (serverSessionInfo .~ s')
-      CMBox (CMHsSource _modu _info) ->
-        id
-
 -- NOTE:
 -- server state: shared across the session
 -- ui state: per web view.
@@ -197,7 +113,7 @@ webServer cfg servSess = do
       chanBkg <- unsafeBlockingIO newTChanIO
       let newCS = ClientSession uiRef chanEv chanState chanBkg
           newUIChan = UIChannel chanEv chanState chanBkg
-      unsafeBlockingIO $ Driver.main servSess newCS
+      unsafeBlockingIO $ Session.main servSess newCS
       loopM (step newUIChan) (BkgEv RefreshUI)
   where
     -- A single step of the outer loop (See Note [Control Loops]).
@@ -250,8 +166,8 @@ main = do
         workQ <- newTQueueIO
         chanSignal <- newTChanIO
         let servSess = ServerSession ssRef chanSignal
-        _ <- forkOS $ listener socketFile ssRef servSess workQ
-        _ <- forkOS $ runWorkQueue workQ
+        _ <- forkOS $ Comm.listener socketFile ssRef servSess workQ
+        _ <- forkOS $ Worker.runWorkQueue workQ
         webServer cfg servSess
     View mconfigFile ->
       withConfig mconfigFile $ \cfg -> do

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -49,13 +49,13 @@ import GHCSpecter.Config
     loadConfig,
   )
 import GHCSpecter.Data.Assets qualified as Assets
-import GHCSpecter.Driver
+import GHCSpecter.Driver qualified as Driver
+import GHCSpecter.Driver.Session.Types
   ( ClientSession (..),
     HasServerSession (..),
     ServerSession (..),
     UIChannel (..),
   )
-import GHCSpecter.Driver qualified as Driver
 import GHCSpecter.Render (render)
 import GHCSpecter.Server.Types
   ( HasServerState (..),

--- a/daemon/package.yaml
+++ b/daemon/package.yaml
@@ -120,18 +120,10 @@ executables:
       - -rtsopts
       - -with-rtsopts=-N
     dependencies:
-      - concur-core
-      - concur-replica
-      - containers
-      - extra
       - ghc-specter-plugin
       - ghc-specter-daemon
-      - lens
       - optparse-applicative
       - stm
-      - time
-      - transformers
-      - yaml
 
 tests:
   ghc-specter-daemon-test:

--- a/daemon/src/GHCSpecter/Driver.hs
+++ b/daemon/src/GHCSpecter/Driver.hs
@@ -1,0 +1,103 @@
+module GHCSpecter.Driver
+  ( webServer,
+  )
+where
+
+import Concur.Core (Widget, liftSTM, unsafeBlockingIO)
+import Control.Applicative ((<|>))
+import Control.Concurrent.STM
+  ( TChan,
+    atomically,
+    newTChanIO,
+    newTVarIO,
+    readTChan,
+    writeTChan,
+  )
+import Control.Lens ((.~), (^.))
+import Control.Monad.Extra (loopM)
+import Data.Text (Text)
+import Data.Time.Clock (getCurrentTime)
+import GHCSpecter.Config (Config (..))
+import GHCSpecter.Data.Assets qualified as Assets
+import GHCSpecter.Driver.Session qualified as Session
+import GHCSpecter.Driver.Session.Types
+  ( ClientSession (..),
+    ServerSession (..),
+    UIChannel (..),
+  )
+import GHCSpecter.Render (render)
+import GHCSpecter.Server.Types (ServerState)
+import GHCSpecter.UI.ConcurReplica.Run (runDefaultWithStyle)
+import GHCSpecter.UI.ConcurReplica.Types
+  ( IHTML,
+    blockDOMUpdate,
+    unblockDOMUpdate,
+  )
+import GHCSpecter.UI.Types
+  ( HasUIState (..),
+    UIState,
+    UIView (..),
+    emptyMainView,
+    emptyUIState,
+  )
+import GHCSpecter.UI.Types.Event
+  ( BackgroundEvent (RefreshUI),
+    Event (BkgEv),
+  )
+
+-- NOTE:
+-- server state: shared across the session
+-- ui state: per web view.
+-- control: per web view
+
+styleText :: Text
+styleText = "ul > li { margin-left: 10px; }"
+
+webServer :: Config -> ServerSession -> IO ()
+webServer cfg servSess = do
+  let port = configWebPort cfg
+  assets <- Assets.loadAssets
+  runDefaultWithStyle port "ghc-specter" styleText $
+    \_ -> do
+      uiRef <-
+        unsafeBlockingIO $ do
+          initTime <- getCurrentTime
+          let ui0 = emptyUIState assets initTime
+              ui0' = (uiView .~ MainMode emptyMainView) ui0
+          newTVarIO ui0'
+      chanEv <- unsafeBlockingIO newTChanIO
+      chanState <- unsafeBlockingIO newTChanIO
+      chanBkg <- unsafeBlockingIO newTChanIO
+      let newCS = ClientSession uiRef chanEv chanState chanBkg
+          newUIChan = UIChannel chanEv chanState chanBkg
+      unsafeBlockingIO $ Session.main servSess newCS
+      loopM (step newUIChan) (BkgEv RefreshUI)
+  where
+    -- A single step of the outer loop (See Note [Control Loops]).
+    step ::
+      -- UI comm channel
+      UIChannel ->
+      -- last event
+      Event ->
+      Widget IHTML (Either Event ())
+    step (UIChannel chanEv chanState chanBkg) ev = do
+      (ui, ss) <-
+        unsafeBlockingIO $ do
+          atomically $ writeTChan chanEv ev
+          (ui, ss) <- atomically $ readTChan chanState
+          pure (ui, ss)
+      stepRender (ui, ss) <|> (Left . BkgEv <$> waitForBkgEv chanBkg)
+
+    stepRender :: (UIState, ServerState) -> Widget IHTML (Either Event ())
+    stepRender (ui, ss) = do
+      let renderUI =
+            if ui ^. uiShouldUpdate
+              then unblockDOMUpdate (render (ui, ss))
+              else blockDOMUpdate (render (ui, ss))
+      Left <$> renderUI
+
+    waitForBkgEv ::
+      -- channel for receiving bkg event
+      TChan BackgroundEvent ->
+      Widget IHTML BackgroundEvent
+    waitForBkgEv chanBkg = liftSTM $ readTChan chanBkg

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE GADTs #-}
+
+module GHCSpecter.Driver.Comm
+  ( listener,
+  )
+where
+
+import Control.Concurrent (forkIO)
+import Control.Concurrent.STM
+  ( TQueue,
+    TVar,
+    atomically,
+    modifyTVar',
+    readTChan,
+  )
+import Control.Lens ((%~), (.~), (^.))
+import Control.Monad (forever, void)
+import Data.Foldable qualified as F
+import Data.Map.Strict qualified as M
+import GHCSpecter.Channel
+  ( ChanMessage (..),
+    ChanMessageBox (..),
+    Channel (..),
+    HsSourceInfo (..),
+    SessionInfo (..),
+    Timer (..),
+  )
+import GHCSpecter.Comm
+  ( receiveObject,
+    runServer,
+    sendObject,
+  )
+import GHCSpecter.Driver.Session.Types
+  ( HasServerSession (..),
+    ServerSession (..),
+  )
+import GHCSpecter.Server.Types
+  ( HasServerState (..),
+    ServerState (..),
+    incrementSN,
+  )
+import GHCSpecter.Worker.Hie (hieWorker)
+import GHCSpecter.Worker.ModuleGraph (moduleGraphWorker)
+
+updateInbox :: ChanMessageBox -> ServerState -> ServerState
+updateInbox chanMsg = incrementSN . updater
+  where
+    updater = case chanMsg of
+      CMBox (CMCheckImports modu msg) ->
+        (serverInbox %~ M.insert (CheckImports, modu) msg)
+      CMBox (CMTiming modu timer') ->
+        let f Nothing = Just timer'
+            f (Just timer0) =
+              Just $ Timer (unTimer timer0 ++ unTimer timer')
+         in (serverTiming %~ M.alter f modu)
+      CMBox (CMSession s') ->
+        (serverSessionInfo .~ s')
+      CMBox (CMHsSource _modu _info) ->
+        id
+
+listener ::
+  FilePath ->
+  TVar ServerState ->
+  ServerSession ->
+  TQueue (IO ()) ->
+  IO ()
+listener socketFile ssRef ssess workQ = do
+  runServer socketFile $ \sock -> do
+    _ <- forkIO $ sender sock
+    receiver sock
+  where
+    chanSignal = ssess ^. ssSubscriberSignal
+    sender sock = forever $ do
+      putStrLn $ "########"
+      newPauseState <- atomically $ readTChan chanSignal
+      putStrLn "#### sendObject ####"
+      newPauseState `seq` sendObject sock newPauseState
+    receiver sock = forever $ do
+      msgs :: [ChanMessageBox] <- receiveObject sock
+      F.for_ msgs $ \(CMBox o) -> do
+        case o of
+          CMSession s' -> do
+            let mgi = sessionModuleGraph s'
+            void $ forkIO (moduleGraphWorker ssRef mgi)
+          CMHsSource _modu (HsSourceInfo hiefile) ->
+            void $ forkIO (hieWorker ssRef workQ hiefile)
+          _ -> pure ()
+        atomically . modifyTVar' ssRef . updateInbox $ CMBox o

--- a/daemon/src/GHCSpecter/Driver/Session.hs
+++ b/daemon/src/GHCSpecter/Driver/Session.hs
@@ -1,5 +1,5 @@
-module GHCSpecter.Driver
-  ( -- * main driver
+module GHCSpecter.Driver.Session
+  ( -- * main session procedure
     main,
   )
 where

--- a/daemon/src/GHCSpecter/Driver/Session/Types.hs
+++ b/daemon/src/GHCSpecter/Driver/Session/Types.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module GHCSpecter.Driver.Session.Types
+  (  -- * session types for daemon
+    ServerSession (..),
+    HasServerSession (..),
+    ClientSession (..),
+    HasClientSession (..),
+
+    -- * UI Channel
+    UIChannel (..),
+    HasUIChannel (..),
+  )
+where
+
+import Control.Concurrent.STM (TChan, TVar)
+import Control.Lens (makeClassy)
+import GHCSpecter.Server.Types (ServerState (..))
+import GHCSpecter.UI.Types (UIState)
+import GHCSpecter.UI.Types.Event (BackgroundEvent, Event)
+
+-- Session = State + Channel
+
+data ServerSession = ServerSession
+  { _ssServerStateRef :: TVar ServerState
+  , _ssSubscriberSignal :: TChan Bool
+  }
+
+makeClassy ''ServerSession
+
+data ClientSession = ClientSession
+  { _csUIStateRef :: TVar UIState
+  , _csSubscriberEvent :: TChan Event
+  , _csPublisherState :: TChan (UIState, ServerState)
+  , _csPublisherBkgEvent :: TChan BackgroundEvent
+  }
+
+makeClassy ''ClientSession
+
+-- | communication channel that UI renderer needs
+-- Note that subscribe/publish is named according to UI side semantics.
+data UIChannel = UIChannel
+  { uiPublisherEvent :: TChan Event
+  -- ^ channel for sending event to control
+  , uiSubscriberState :: TChan (UIState, ServerState)
+  -- ^ channel for receiving state from control
+  , uiSubscriberBkgEvent :: TChan BackgroundEvent
+  -- ^ channel for receiving background event
+  }
+
+makeClassy ''UIChannel

--- a/daemon/src/GHCSpecter/Driver/Session/Types.hs
+++ b/daemon/src/GHCSpecter/Driver/Session/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Driver.Session.Types
-  (  -- * session types for daemon
+  ( -- * session types for daemon
     ServerSession (..),
     HasServerSession (..),
     ClientSession (..),

--- a/daemon/src/GHCSpecter/Driver/Worker.hs
+++ b/daemon/src/GHCSpecter/Driver/Worker.hs
@@ -1,0 +1,33 @@
+module GHCSpecter.Driver.Worker
+  ( runWorkQueue,
+  )
+where
+
+import Control.Concurrent (forkIO, forkOS, threadDelay)
+import Control.Concurrent.STM
+  ( TChan,
+    TQueue,
+    TVar,
+    atomically,
+    modifyTVar',
+    newTChanIO,
+    newTQueueIO,
+    newTVar,
+    newTVarIO,
+    readTChan,
+    readTQueue,
+    writeTChan,
+  )
+
+runWorkQueue :: TQueue (IO ()) -> IO ()
+runWorkQueue workQ = go 0
+  where
+    go :: Int -> IO ()
+    go n = do
+      job <- atomically $ readTQueue workQ
+      -- TODO: disabled as it's too verbose. enable with proper logging system.
+      -- putStrLn $ show n ++ "th job started"
+      job
+      -- putStrLn $ show n ++ "th job ended"
+      threadDelay 50_000
+      go (n + 1)


### PR DESCRIPTION
Top-level driver functions are moved from app/Main.hs to GHCSpecter.Driver.*.
ServerState and signal channel are packaged into a session type.