### PR TITLE
Outbound/Inbound channel module separation

### DIFF
--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -6,6 +6,7 @@ where
 import Control.Lens ((&), (.~), (^.), _1, _2)
 import Data.Text qualified as T
 import Data.Time.Clock qualified as Clock
+import GHCSpecter.Channel.Inbound.Types (Pause (..))
 import GHCSpecter.Channel.Outbound.Types (SessionInfo (..))
 import GHCSpecter.Control.Types
   ( getCurrentTime,
@@ -92,13 +93,13 @@ defaultUpdateModel topEv (oldModel, oldSS) =
       let sinfo = oldSS ^. serverSessionInfo
           sinfo' = sinfo {sessionIsPaused = False}
           newSS = (serverSessionInfo .~ sinfo') . (serverShouldUpdate .~ True) $ oldSS
-      sendSignal False
+      sendSignal (Pause False)
       pure (oldModel, newSS)
     SessionEv PauseSessionEv -> do
       let sinfo = oldSS ^. serverSessionInfo
           sinfo' = sinfo {sessionIsPaused = True}
           newSS = (serverSessionInfo .~ sinfo') . (serverShouldUpdate .~ True) $ oldSS
-      sendSignal True
+      sendSignal (Pause True)
       pure (oldModel, newSS)
     TimingEv (UpdateSticky b) -> do
       let newModel = (modelTiming . timingUISticky .~ b) oldModel

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -6,7 +6,7 @@ where
 import Control.Lens ((&), (.~), (^.), _1, _2)
 import Data.Text qualified as T
 import Data.Time.Clock qualified as Clock
-import GHCSpecter.Channel (SessionInfo (..))
+import GHCSpecter.Channel.Outbound.Types (SessionInfo (..))
 import GHCSpecter.Control.Types
   ( getCurrentTime,
     getLastUpdatedUI,

--- a/daemon/src/GHCSpecter/Control/Runner.hs
+++ b/daemon/src/GHCSpecter/Control/Runner.hs
@@ -14,7 +14,7 @@ import Control.Concurrent.STM
     writeTChan,
     writeTVar,
   )
-import Control.Lens ((.~), (^.), _1)
+import Control.Lens ((.~), (^.))
 import Control.Monad.Extra (loopM)
 import Control.Monad.Free (Free (..))
 import Control.Monad.IO.Class (liftIO)

--- a/daemon/src/GHCSpecter/Control/Runner.hs
+++ b/daemon/src/GHCSpecter/Control/Runner.hs
@@ -25,6 +25,7 @@ import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import Data.Time.Clock qualified as Clock
+import GHCSpecter.Channel.Inbound.Types (Pause)
 import GHCSpecter.Control.Types
   ( ControlF (..),
     type Control,
@@ -46,7 +47,8 @@ tempRef :: IORef Int
 tempRef = unsafePerformIO (newIORef 0)
 {-# NOINLINE tempRef #-}
 
-type Runner = ReaderT (TVar UIState, TVar ServerState, TChan BackgroundEvent, TChan Bool) IO
+type Runner =
+  ReaderT (TVar UIState, TVar ServerState, TChan BackgroundEvent, TChan Pause) IO
 
 getUI' :: Runner UIState
 getUI' = do
@@ -80,7 +82,7 @@ modifySS' f = do
   let s' = f s
   s' `seq` putSS' s'
 
-sendSignal' :: Bool -> Runner ()
+sendSignal' :: Pause -> Runner ()
 sendSignal' b = do
   (_, _, _, signalChan) <- ask
   liftIO $ atomically $ writeTChan signalChan b

--- a/daemon/src/GHCSpecter/Control/Types.hs
+++ b/daemon/src/GHCSpecter/Control/Types.hs
@@ -22,6 +22,7 @@ where
 import Control.Monad.Free (Free (..), liftF)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
+import GHCSpecter.Channel.Inbound.Types (Pause)
 import GHCSpecter.Server.Types (ServerState)
 import GHCSpecter.UI.Types (UIState)
 import GHCSpecter.UI.Types.Event (Event)
@@ -32,7 +33,7 @@ data ControlF r
   | PutUI UIState r
   | GetSS (ServerState -> r)
   | PutSS ServerState r
-  | SendSignal Bool r
+  | SendSignal Pause r
   | NextEvent (Event -> r)
   | PrintMsg Text r
   | GetCurrentTime (UTCTime -> r)
@@ -56,7 +57,7 @@ getSS = liftF (GetSS id)
 putSS :: ServerState -> Control ()
 putSS ss = liftF (PutSS ss ())
 
-sendSignal :: Bool -> Control ()
+sendSignal :: Pause -> Control ()
 sendSignal b = liftF (SendSignal b ())
 
 nextEvent :: Control Event

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -17,7 +17,7 @@ import Control.Lens ((%~), (.~), (^.))
 import Control.Monad (forever, void)
 import Data.Foldable qualified as F
 import Data.Map.Strict qualified as M
-import GHCSpecter.Channel
+import GHCSpecter.Channel.Outbound.Types
   ( ChanMessage (..),
     ChanMessageBox (..),
     Channel (..),

--- a/daemon/src/GHCSpecter/Driver/Session/Types.hs
+++ b/daemon/src/GHCSpecter/Driver/Session/Types.hs
@@ -15,6 +15,7 @@ where
 
 import Control.Concurrent.STM (TChan, TVar)
 import Control.Lens (makeClassy)
+import GHCSpecter.Channel.Inbound.Types (Pause)
 import GHCSpecter.Server.Types (ServerState (..))
 import GHCSpecter.UI.Types (UIState)
 import GHCSpecter.UI.Types.Event (BackgroundEvent, Event)
@@ -23,7 +24,7 @@ import GHCSpecter.UI.Types.Event (BackgroundEvent, Event)
 
 data ServerSession = ServerSession
   { _ssServerStateRef :: TVar ServerState
-  , _ssSubscriberSignal :: TChan Bool
+  , _ssSubscriberSignal :: TChan Pause
   }
 
 makeClassy ''ServerSession

--- a/daemon/src/GHCSpecter/Driver/Worker.hs
+++ b/daemon/src/GHCSpecter/Driver/Worker.hs
@@ -3,20 +3,11 @@ module GHCSpecter.Driver.Worker
   )
 where
 
-import Control.Concurrent (forkIO, forkOS, threadDelay)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM
-  ( TChan,
-    TQueue,
-    TVar,
+  ( TQueue,
     atomically,
-    modifyTVar',
-    newTChanIO,
-    newTQueueIO,
-    newTVar,
-    newTVarIO,
-    readTChan,
     readTQueue,
-    writeTChan,
   )
 
 runWorkQueue :: TQueue (IO ()) -> IO ()

--- a/daemon/src/GHCSpecter/Render/Components/GraphView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GraphView.hs
@@ -26,10 +26,8 @@ import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Tuple (swap)
-import GHCSpecter.Channel
-  ( ModuleName,
-    Timer,
-  )
+import GHCSpecter.Channel.Common.Types (type ModuleName)
+import GHCSpecter.Channel.Outbound.Types (Timer)
 import GHCSpecter.GraphLayout.Types
   ( Dimension (..),
     EdgeLayout (..),

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -32,7 +32,7 @@ import Data.Map (Map)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
-import GHCSpecter.Channel
+import GHCSpecter.Channel.Outbound.Types
   ( ModuleGraphInfo (..),
     ModuleName,
     SessionInfo (..),

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -14,7 +14,7 @@ import Data.List (partition)
 import Data.Map qualified as M
 import Data.Maybe (isJust)
 import Data.Text qualified as T
-import GHCSpecter.Channel
+import GHCSpecter.Channel.Outbound.Types
   ( ModuleGraphInfo (..),
     SessionInfo (..),
     getEndTime,

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -17,7 +17,7 @@ import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Tree (Tree, foldTree)
-import GHCSpecter.Channel
+import GHCSpecter.Channel.Outbound.Types
   ( Channel (..),
     ModuleName,
     getEndTime,

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -25,7 +25,7 @@ import Data.Time.Clock
     nominalDiffTimeToSeconds,
     secondsToNominalDiffTime,
   )
-import GHCSpecter.Channel (type ModuleName)
+import GHCSpecter.Channel.Common.Types (type ModuleName)
 import GHCSpecter.Render.Util (xmlns)
 import GHCSpecter.Server.Types (ServerState (..))
 import GHCSpecter.UI.ConcurReplica.DOM

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -39,12 +39,12 @@ import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Data.Tree (Forest)
 import GHC.Generics (Generic)
-import GHCSpecter.Channel
+import GHCSpecter.Channel.Common.Types (type ModuleName)
+import GHCSpecter.Channel.Outbound.Types
   ( Channel,
     SessionInfo (..),
     Timer,
     emptyModuleGraphInfo,
-    type ModuleName,
   )
 import GHCSpecter.GraphLayout.Types (GraphVisInfo)
 import GHCSpecter.UI.Types.Event (DetailLevel)

--- a/daemon/src/GHCSpecter/Util/SourceTree.hs
+++ b/daemon/src/GHCSpecter/Util/SourceTree.hs
@@ -9,10 +9,8 @@ import Control.Lens (to, (^..))
 import Data.List qualified as L
 import Data.Text qualified as T
 import Data.Tree (Forest, Tree (..))
-import GHCSpecter.Channel
-  ( ModuleGraphInfo (..),
-    type ModuleName,
-  )
+import GHCSpecter.Channel.Common.Types (type ModuleName)
+import GHCSpecter.Channel.Outbound.Types (ModuleGraphInfo (..))
 
 appendTo :: [ModuleName] -> Forest ModuleName -> Forest ModuleName
 appendTo [] ts = ts

--- a/daemon/src/GHCSpecter/Util/Timing.hs
+++ b/daemon/src/GHCSpecter/Util/Timing.hs
@@ -22,13 +22,13 @@ import Data.Time.Clock
   ( NominalDiffTime,
     diffUTCTime,
   )
-import GHCSpecter.Channel
+import GHCSpecter.Channel.Common.Types (type ModuleName)
+import GHCSpecter.Channel.Outbound.Types
   ( SessionInfo (..),
     getAsTime,
     getEndTime,
     getHscOutTime,
     getStartTime,
-    type ModuleName,
   )
 import GHCSpecter.Server.Types
   ( HasServerState (..),

--- a/daemon/src/GHCSpecter/Worker/CallGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/CallGraph.hs
@@ -25,17 +25,14 @@ where
 
 import Control.Concurrent.STM (TVar, atomically, modifyTVar')
 import Control.Lens
-  ( at,
-    makeClassy,
+  ( makeClassy,
     to,
     (%~),
     (^.),
     (^..),
-    (^?),
     _1,
     _2,
     _3,
-    _Just,
   )
 import Control.Monad.Trans.State (runState)
 import Data.Function (on)
@@ -49,7 +46,7 @@ import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Tuple (swap)
-import GHCSpecter.Channel (ModuleName)
+import GHCSpecter.Channel.Common.Types (ModuleName)
 import GHCSpecter.GraphLayout.Algorithm.Builder (makeRevDep)
 import GHCSpecter.GraphLayout.Sugiyama qualified as Sugiyama
 import GHCSpecter.GraphLayout.Types (GraphVisInfo)

--- a/daemon/src/GHCSpecter/Worker/Hie.hs
+++ b/daemon/src/GHCSpecter/Worker/Hie.hs
@@ -5,7 +5,6 @@ module GHCSpecter.Worker.Hie
   )
 where
 
-import Control.Concurrent (forkIO)
 import Control.Concurrent.STM
   ( TQueue,
     TVar,
@@ -14,7 +13,6 @@ import Control.Concurrent.STM
     writeTQueue,
   )
 import Control.Lens ((%~), (.~))
-import Control.Monad (void)
 import Data.Map qualified as M
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8With)

--- a/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
@@ -17,9 +17,9 @@ import Data.IntMap qualified as IM
 import Data.List qualified as L
 import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
-import GHCSpecter.Channel
+import GHCSpecter.Channel.Common.Types (type ModuleName)
+import GHCSpecter.Channel.Outbound.Types
   ( ModuleGraphInfo (..),
-    ModuleName,
   )
 import GHCSpecter.GraphLayout.Algorithm.BFS (runMultiseedStagedBFS)
 import GHCSpecter.GraphLayout.Algorithm.Builder

--- a/daemon/test/GHCSpecter/GraphLayout/Algorithm/BFSSpec.hs
+++ b/daemon/test/GHCSpecter/GraphLayout/Algorithm/BFSSpec.hs
@@ -1,12 +1,12 @@
-module GHCSpecter.Util.Graph.BFSSpec (spec) where
+module GHCSpecter.GraphLayout.Algorithm.BFSSpec (spec) where
 
 import Data.Functor.Identity (runIdentity)
 import Data.IntMap qualified as IM
-import GHCSpecter.Util.Graph.BFS
+import GHCSpecter.GraphLayout.Algorithm.BFS
   ( runMultiseedStagedBFS,
     runStagedBFS,
   )
-import GHCSpecter.Util.Graph.Builder (makeBiDep)
+import GHCSpecter.GraphLayout.Algorithm.Builder (makeBiDep)
 import Test.Hspec
   ( Spec,
     describe,

--- a/daemon/test/GHCSpecter/GraphLayout/Algorithm/ClusterSpec.hs
+++ b/daemon/test/GHCSpecter/GraphLayout/Algorithm/ClusterSpec.hs
@@ -1,10 +1,10 @@
-module GHCSpecter.Util.Graph.ClusterSpec (spec) where
+module GHCSpecter.GraphLayout.Algorithm.ClusterSpec (spec) where
 
 import Data.IntMap qualified as IM
 import Data.List qualified as L
 import GHCSpecter.Channel.Outbound.Types (ModuleGraphInfo (..))
-import GHCSpecter.Util.Graph.Builder (makeBiDep)
-import GHCSpecter.Util.Graph.Cluster
+import GHCSpecter.GraphLayout.Algorithm.Builder (makeBiDep)
+import GHCSpecter.GraphLayout.Algorithm.Cluster
   ( ClusterState (..),
     ClusterVertex (..),
     degreeInvariant,

--- a/daemon/test/GHCSpecter/Util/Graph/ClusterSpec.hs
+++ b/daemon/test/GHCSpecter/Util/Graph/ClusterSpec.hs
@@ -2,7 +2,7 @@ module GHCSpecter.Util.Graph.ClusterSpec (spec) where
 
 import Data.IntMap qualified as IM
 import Data.List qualified as L
-import GHCSpecter.Channel (ModuleGraphInfo (..))
+import GHCSpecter.Channel.Outbound.Types (ModuleGraphInfo (..))
 import GHCSpecter.Util.Graph.Builder (makeBiDep)
 import GHCSpecter.Util.Graph.Cluster
   ( ClusterState (..),

--- a/plugin/src/GHCSpecter/Channel/Common/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Common/Types.hs
@@ -1,0 +1,8 @@
+module GHCSpecter.Channel.Common.Types
+  ( type ModuleName,
+  )
+where
+
+import Data.Text (Text)
+
+type ModuleName = Text

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -1,0 +1,10 @@
+module GHCSpecter.Channel.Inbound.Types
+  ( Pause (..),
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Binary (Binary (..))
+
+newtype Pause = Pause {unPause :: Bool}
+  deriving (Eq, Ord, Show, Binary, FromJSON, ToJSON)

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -153,7 +153,6 @@ instance Binary ChanMessageBox where
     put (fromEnum Paused)
     put m
 
-
   get = do
     tag <- get
     case toEnum tag of

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
-module GHCSpecter.Channel
+module GHCSpecter.Channel.Outbound.Types
   ( -- * information types
     type ModuleName,
     SessionInfo (..),
@@ -30,6 +30,7 @@ import Data.List qualified as L
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import GHC.Generics (Generic)
+import GHCSpecter.Channel.Common.Types (type ModuleName)
 
 data Channel = CheckImports | Timing | Session | HsSource
   deriving (Enum, Eq, Ord, Show, Generic)
@@ -37,8 +38,6 @@ data Channel = CheckImports | Timing | Session | HsSource
 instance FromJSON Channel
 
 instance ToJSON Channel
-
-type ModuleName = Text
 
 data ModuleGraphInfo = ModuleGraphInfo
   { mginfoModuleNameMap :: IntMap ModuleName

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -128,7 +128,7 @@ import System.Process (getCurrentPid)
 
 data MsgQueue = MsgQueue
   { msgSenderQueue :: TVar (Seq ChanMessageBox)
-  , msgIsPaused :: TVar Pause
+  , msgReceiverQueue :: TVar Pause
   }
 
 initMsgQueue :: IO MsgQueue
@@ -234,7 +234,7 @@ runMessageQueue opts queue = do
       putStrLn $ "message received: " ++ show msg
       putStrLn "################"
       atomically $
-        writeTVar (msgIsPaused queue) msg
+        writeTVar (msgReceiverQueue queue) msg
 
 queueMessage :: MsgQueue -> ChanMessage a -> IO ()
 queueMessage queue !msg =
@@ -244,7 +244,7 @@ queueMessage queue !msg =
 breakPoint :: MsgQueue -> IO ()
 breakPoint queue = do
   atomically $ do
-    p <- readTVar (msgIsPaused queue)
+    p <- readTVar (msgReceiverQueue queue)
     STM.check (not (unPause p))
 
 -- | Called only once for sending session information

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -99,7 +99,7 @@ import GHC.Unit.Module.ModSummary
 import GHC.Unit.Module.Name (moduleNameString)
 import GHC.Unit.Types (GenModule (moduleName))
 import GHC.Utils.Outputable (Outputable (ppr))
-import GHCSpecter.Channel
+import GHCSpecter.Channel.Outbound.Types
   ( ChanMessage (..),
     ChanMessageBox (..),
     HsSourceInfo (..),

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -126,15 +126,16 @@ import System.Directory (canonicalizePath, doesFileExist)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Process (getCurrentPid)
 
-data MsgQueueState = MsgQueueState
-  { msgSenderQueue :: Seq ChanMessageBox
-  , msgIsPaused :: Pause
+data MsgQueue = MsgQueue
+  { msgSenderQueue :: TVar (Seq ChanMessageBox)
+  , msgIsPaused :: TVar Pause
   }
 
-emptyMsgQueueState :: MsgQueueState
-emptyMsgQueueState = MsgQueueState Seq.empty (Pause False)
-
-type MsgQueue = TVar MsgQueueState
+initMsgQueue :: IO MsgQueue
+initMsgQueue = do
+  sQ <- newTVarIO Seq.empty
+  pauseRef <- newTVarIO (Pause False)
+  pure $ MsgQueue sQ pauseRef
 
 plugin :: Plugin
 plugin =
@@ -215,12 +216,11 @@ runMessageQueue opts queue = do
     sender :: Socket -> IO ()
     sender sock = forever $ do
       msgs <- atomically $ do
-        s <- readTVar queue
-        let queued = msgSenderQueue s
+        queued <- readTVar (msgSenderQueue queue)
         if Seq.null queued
           then retry
           else do
-            writeTVar queue s {msgSenderQueue = Seq.empty}
+            writeTVar (msgSenderQueue queue) Seq.empty
             pure queued
       let msgList = F.toList msgs
       msgList `seq` sendObject sock msgList
@@ -234,20 +234,18 @@ runMessageQueue opts queue = do
       putStrLn $ "message received: " ++ show msg
       putStrLn "################"
       atomically $
-        modifyTVar' queue $ \s -> s {msgIsPaused = msg}
+        writeTVar (msgIsPaused queue) msg
 
 queueMessage :: MsgQueue -> ChanMessage a -> IO ()
 queueMessage queue !msg =
   atomically $
-    modifyTVar' queue $ \s ->
-      let q = msgSenderQueue s
-       in s {msgSenderQueue = q |> CMBox msg}
+    modifyTVar' (msgSenderQueue queue) (|> CMBox msg)
 
 breakPoint :: MsgQueue -> IO ()
 breakPoint queue = do
   atomically $ do
-    s <- readTVar queue
-    STM.check (not (unPause (msgIsPaused s)))
+    p <- readTVar (msgIsPaused queue)
+    STM.check (not (unPause p))
 
 -- | Called only once for sending session information
 startSession :: [CommandLineOption] -> HscEnv -> IO MsgQueue
@@ -259,7 +257,7 @@ startSession opts env = do
       startedSession =
         modGraphInfo `seq` SessionInfo pid (Just startTime) modGraphInfo False
   -- NOTE: return Nothing if session info is already initiated
-  queue' <- newTVarIO emptyMsgQueueState
+  queue' <- initMsgQueue
   (mNewStartedSession, queue, willStartMsgQueue) <-
     startedSession `seq` atomically $ do
       (SessionInfo _ msessionStart _ _, mqueue) <- readTVar sessionRef


### PR DESCRIPTION
Separate Channel.Outbound (ghc -> daemon) and Channel.Inbound (daemon -> ghc) modules. Also MsgQueue is splitted into two TVar's (one for outbound, and one for inbound)