### PR TITLE
Introducing DriverId

### DIFF
--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -49,14 +49,21 @@ updateInbox chanMsg = incrementSN . updater
     updater = case chanMsg of
       CMBox (CMCheckImports modu msg) ->
         (serverInbox %~ M.insert (CheckImports, modu) msg)
-      CMBox (CMTiming _drvId mmodu timer') ->
-        case mmodu of
-          Nothing -> id
-          Just modu ->
-            let f Nothing = Just timer'
-                f (Just timer0) =
-                  Just $ Timer (unTimer timer0 ++ unTimer timer')
-             in (serverTiming %~ M.alter f modu)
+      CMBox (CMModuleInfo drvId modu) ->
+        -- for now
+        id
+      CMBox (CMTiming drvId timer') ->
+        id
+      -- for now
+      {-
+      case mmodu of
+        Nothing -> id
+        Just modu ->
+          let f Nothing = Just timer'
+              f (Just timer0) =
+                Just $ Timer (unTimer timer0 ++ unTimer timer')
+           in (serverTiming %~ M.alter f modu)
+      -}
       CMBox (CMSession s') ->
         (serverSessionInfo .~ s')
       CMBox (CMHsSource _modu _info) ->

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -49,11 +49,14 @@ updateInbox chanMsg = incrementSN . updater
     updater = case chanMsg of
       CMBox (CMCheckImports modu msg) ->
         (serverInbox %~ M.insert (CheckImports, modu) msg)
-      CMBox (CMTiming modu timer') ->
-        let f Nothing = Just timer'
-            f (Just timer0) =
-              Just $ Timer (unTimer timer0 ++ unTimer timer')
-         in (serverTiming %~ M.alter f modu)
+      CMBox (CMTiming _drvId mmodu timer') ->
+        case mmodu of
+          Nothing -> id
+          Just modu ->
+            let f Nothing = Just timer'
+                f (Just timer0) =
+                  Just $ Timer (unTimer timer0 ++ unTimer timer')
+             in (serverTiming %~ M.alter f modu)
       CMBox (CMSession s') ->
         (serverSessionInfo .~ s')
       CMBox (CMHsSource _modu _info) ->

--- a/daemon/src/GHCSpecter/Render/Components/GraphView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GraphView.hs
@@ -45,7 +45,7 @@ import GHCSpecter.UI.ConcurReplica.DOM (div, text)
 import GHCSpecter.UI.ConcurReplica.SVG qualified as S
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types.Event (ModuleGraphEvent (..))
-import GHCSpecter.Util.Timing (isCompiled)
+import GHCSpecter.Util.Timing (isModuleCompilationDone)
 import Text.Printf (printf)
 import Prelude hiding (div)
 
@@ -147,7 +147,7 @@ renderModuleGraphSVG
                 if nTot == 0
                   then Nothing
                   else do
-                    let compiled = filter (isCompiled modDrvMap timing) cluster
+                    let compiled = filter (isModuleCompilationDone modDrvMap timing) cluster
                         nCompiled = length compiled
                     pure (fromIntegral nCompiled / fromIntegral nTot)
               w' = ratio * w

--- a/daemon/src/GHCSpecter/Render/Components/GraphView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GraphView.hs
@@ -20,7 +20,6 @@ import Control.Lens ((^.), _1)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IM
 import Data.List qualified as L
-import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -45,6 +44,7 @@ import GHCSpecter.UI.ConcurReplica.DOM (div, text)
 import GHCSpecter.UI.ConcurReplica.SVG qualified as S
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types.Event (ModuleGraphEvent (..))
+import GHCSpecter.Util.Map (BiKeyMap, KeyMap)
 import GHCSpecter.Util.Timing (isModuleCompilationDone)
 import Text.Printf (printf)
 import Prelude hiding (div)
@@ -58,10 +58,8 @@ makePolylineText (p0, p1) xys =
 renderModuleGraphSVG ::
   -- | key = graph id
   IntMap ModuleName ->
-  -- | (module name -> driver id) map
-  Map ModuleName DriverId ->
-  -- | key = driver id
-  IntMap Timer ->
+  BiKeyMap DriverId ModuleName ->
+  KeyMap DriverId Timer ->
   [(Text, [Text])] ->
   GraphVisInfo ->
   -- | (focused (clicked), hinted (hovered))
@@ -69,7 +67,7 @@ renderModuleGraphSVG ::
   Widget IHTML ModuleGraphEvent
 renderModuleGraphSVG
   nameMap
-  modDrvMap
+  drvModMap
   timing
   clustering
   grVisInfo
@@ -147,7 +145,7 @@ renderModuleGraphSVG
                 if nTot == 0
                   then Nothing
                   else do
-                    let compiled = filter (isModuleCompilationDone modDrvMap timing) cluster
+                    let compiled = filter (isModuleCompilationDone drvModMap timing) cluster
                         nCompiled = length compiled
                     pure (fromIntegral nCompiled / fromIntegral nTot)
               w' = ratio * w

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -33,6 +33,7 @@ import GHCSpecter.UI.Types.Event
   ( Event (..),
     SessionEvent (..),
   )
+import GHCSpecter.Util.Map (keyMapToList)
 import Prelude hiding (div)
 
 renderSessionButtons :: SessionInfo -> Widget IHTML Event
@@ -70,7 +71,7 @@ render ss =
         Just sessionStartTime -> do
           let mgi = sessionModuleGraph sessionInfo
               nTot = IM.size (mginfoModuleNameMap mgi)
-              timingList = IM.toList timing
+              timingList = keyMapToList timing
               (timingDone, timingInProg) =
                 partition (\(_, t) -> isJust (getEndTime t)) timingList
               nDone = length timingDone

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -11,7 +11,6 @@ import Concur.Replica
 import Control.Lens ((^.))
 import Data.IntMap qualified as IM
 import Data.List (partition)
-import Data.Map qualified as M
 import Data.Maybe (isJust)
 import Data.Text qualified as T
 import GHCSpecter.Channel.Outbound.Types
@@ -71,7 +70,7 @@ render ss =
         Just sessionStartTime -> do
           let mgi = sessionModuleGraph sessionInfo
               nTot = IM.size (mginfoModuleNameMap mgi)
-              timingList = M.toList timing
+              timingList = IM.toList timing
               (timingDone, timingInProg) =
                 partition (\(_, t) -> isJust (getEndTime t)) timingList
               nDone = length timingDone

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -50,7 +50,7 @@ import GHCSpecter.Util.SourceTree
   ( accumPrefix,
     expandFocusOnly,
   )
-import GHCSpecter.Util.Timing (isCompiled)
+import GHCSpecter.Util.Timing (isModuleCompilationDone)
 import GHCSpecter.Worker.CallGraph (getReducedTopLevelDecls)
 import Prelude hiding (div, span)
 
@@ -117,7 +117,7 @@ renderModuleTree srcUI ss =
     eachRender :: ModuleName -> Widget IHTML Event
     eachRender modu =
       let colorTxt
-            | isCompiled modDrvMap timing modu = "has-text-success-dark"
+            | isModuleCompilationDone modDrvMap timing modu = "has-text-success-dark"
             | otherwise = "has-text-grey"
           modItem =
             case mexpandedModu of

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -96,7 +96,7 @@ renderModuleTree srcUI ss =
     [ul [] contents]
   where
     timing = ss ^. serverTiming
-    modDrvMap = ss ^. serverDriverModuleRevMap
+    drvModMap = ss ^. serverDriverModuleMap
     mexpandedModu = srcUI ^. srcViewExpandedModule
     expanded = maybe [] (T.splitOn ".") mexpandedModu
     displayedForest =
@@ -117,7 +117,7 @@ renderModuleTree srcUI ss =
     eachRender :: ModuleName -> Widget IHTML Event
     eachRender modu =
       let colorTxt
-            | isModuleCompilationDone modDrvMap timing modu = "has-text-success-dark"
+            | isModuleCompilationDone drvModMap timing modu = "has-text-success-dark"
             | otherwise = "has-text-grey"
           modItem =
             case mexpandedModu of

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -18,7 +18,6 @@ import Concur.Replica
 import Concur.Replica.DOM.Props qualified as DP (checked, name, type_)
 import Concur.Replica.SVG.Props qualified as SP
 import Control.Lens (to, (^.), _1, _2)
-import Data.Maybe (maybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time.Clock
@@ -63,7 +62,7 @@ import GHCSpecter.UI.Types.Event
 import GHCSpecter.Util.Timing
   ( HasTimingInfo (..),
     TimingInfo,
-    isInProgress,
+    isTimeInTimerRange,
     makeTimingTable,
   )
 import Prelude hiding (div)
@@ -96,7 +95,7 @@ renderRules showParallel table totalHeight totalTime =
     ranges = zip ruleTimes (tail ruleTimes)
     getParallelCompilation (sec1, sec2) =
       let avg = secondsToNominalDiffTime $ realToFrac $ 0.5 * (sec1 + sec2)
-          filtered = filter (\x -> x ^. _2 . to (isInProgress avg)) table
+          filtered = filter (\x -> x ^. _2 . to (isTimeInTimerRange avg)) table
        in length filtered
     rangesWithCPUUsage =
       fmap (\range -> (range, getParallelCompilation range)) ranges

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -35,11 +35,15 @@ where
 
 import Control.Lens (makeClassy, (%~))
 import Data.Aeson (FromJSON, ToJSON)
+import Data.IntMap (IntMap)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Data.Tree (Forest)
 import GHC.Generics (Generic)
-import GHCSpecter.Channel.Common.Types (type ModuleName)
+import GHCSpecter.Channel.Common.Types
+  ( DriverId,
+    type ModuleName,
+  )
 import GHCSpecter.Channel.Outbound.Types
   ( Channel,
     SessionInfo (..),
@@ -161,7 +165,12 @@ data ServerState = ServerState
   , _serverShouldUpdate :: Bool
   , _serverInbox :: Inbox
   , _serverSessionInfo :: SessionInfo
-  , _serverTiming :: Map ModuleName Timer
+  , _serverDriverModuleMap :: IntMap ModuleName
+  -- ^ here the key = DriverId
+  -- TODO: wrap this raw IntMap with access functions using DriverId for safety
+  , _serverDriverModuleRevMap :: Map ModuleName DriverId
+  , _serverTiming :: IntMap Timer
+  -- ^ here the key = DriverId
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   }
@@ -180,6 +189,8 @@ emptyServerState =
     , _serverShouldUpdate = True
     , _serverInbox = mempty
     , _serverSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo False
+    , _serverDriverModuleMap = mempty
+    , _serverDriverModuleRevMap = mempty
     , _serverTiming = mempty
     , _serverModuleGraphState = emptyModuleGraphState
     , _serverHieState = emptyHieState

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -35,7 +35,7 @@ where
 
 import Control.Lens (makeClassy, (%~))
 import Data.Aeson (FromJSON, ToJSON)
-import Data.IntMap (IntMap)
+-- import Data.IntMap (IntMap)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Data.Tree (Forest)
@@ -52,6 +52,7 @@ import GHCSpecter.Channel.Outbound.Types
   )
 import GHCSpecter.GraphLayout.Types (GraphVisInfo)
 import GHCSpecter.UI.Types.Event (DetailLevel)
+import GHCSpecter.Util.Map (BiKeyMap, KeyMap, emptyBiKeyMap, emptyKeyMap)
 
 type ChanModule = (Channel, Text)
 
@@ -165,11 +166,12 @@ data ServerState = ServerState
   , _serverShouldUpdate :: Bool
   , _serverInbox :: Inbox
   , _serverSessionInfo :: SessionInfo
-  , _serverDriverModuleMap :: IntMap ModuleName
-  -- ^ here the key = DriverId
-  -- TODO: wrap this raw IntMap with access functions using DriverId for safety
-  , _serverDriverModuleRevMap :: Map ModuleName DriverId
-  , _serverTiming :: IntMap Timer
+  , _serverDriverModuleMap :: BiKeyMap DriverId ModuleName
+  , -- , _serverDriverModuleMap :: IntMap ModuleName
+    -- -- ^ here the key = DriverId
+    --  -- TODO: wrap this raw IntMap with access functions using DriverId for safety
+    -- , _serverDriverModuleRevMap :: Map ModuleName DriverId
+    _serverTiming :: KeyMap DriverId Timer
   -- ^ here the key = DriverId
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
@@ -189,9 +191,8 @@ emptyServerState =
     , _serverShouldUpdate = True
     , _serverInbox = mempty
     , _serverSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo False
-    , _serverDriverModuleMap = mempty
-    , _serverDriverModuleRevMap = mempty
-    , _serverTiming = mempty
+    , _serverDriverModuleMap = emptyBiKeyMap
+    , _serverTiming = emptyKeyMap
     , _serverModuleGraphState = emptyModuleGraphState
     , _serverHieState = emptyHieState
     }

--- a/daemon/src/GHCSpecter/Util/Map.hs
+++ b/daemon/src/GHCSpecter/Util/Map.hs
@@ -1,0 +1,48 @@
+module GHCSpecter.Util.Map
+  ( IsKey (..),
+    BiIntMap,
+    mkEmptyBiIntMap,
+    forwardLookup,
+    backwardLookup,
+    insert,
+  )
+where
+
+import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.IntMap (IntMap)
+import Data.IntMap qualified as IM
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
+import GHC.Generics (Generic)
+
+class IsKey k where
+  fromKey :: k -> Int
+  toKey :: Int -> k
+
+data BiIntMap k v = BiIntMap
+  { forwardMap :: IntMap v
+  , backwardMap :: Map v k
+  }
+  deriving (Generic)
+
+instance (FromJSON k, FromJSON v, FromJSONKey v, Ord v) => FromJSON (BiIntMap k v)
+
+instance (ToJSON k, ToJSON v, ToJSONKey v) => ToJSON (BiIntMap k v)
+
+mkEmptyBiIntMap :: (IsKey k, Ord v) => BiIntMap k v
+mkEmptyBiIntMap = BiIntMap mempty mempty
+
+forwardLookup :: (IsKey k) => k -> BiIntMap k v -> Maybe v
+forwardLookup k m = IM.lookup (fromKey k) (forwardMap m)
+
+backwardLookup :: (IsKey k, Ord v) => v -> BiIntMap k v -> Maybe k
+backwardLookup v m = M.lookup v (backwardMap m)
+
+insert :: (IsKey k, Ord v) => (k, v) -> BiIntMap k v -> BiIntMap k v
+insert (k, v) m =
+  let fwdmap = forwardMap m
+      bwdmap = backwardMap m
+   in m
+        { forwardMap = IM.insert (fromKey k) v fwdmap
+        , backwardMap = M.insert v k bwdmap
+        }

--- a/daemon/src/GHCSpecter/Util/Map.hs
+++ b/daemon/src/GHCSpecter/Util/Map.hs
@@ -1,45 +1,88 @@
 module GHCSpecter.Util.Map
-  ( IsKey (..),
-    BiIntMap,
-    mkEmptyBiIntMap,
+  ( -- * IsKey class
+    IsKey (..),
+
+    -- * KeyMap
+    KeyMap,
+    emptyKeyMap,
+    keyMapToList,
+    lookupKey,
+    insertToKeyMap,
+    alterToKeyMap,
+
+    -- * BiKeyMap
+    BiKeyMap,
+    emptyBiKeyMap,
+    biKeyMapToList,
     forwardLookup,
     backwardLookup,
-    insert,
+    insertToBiKeyMap,
   )
 where
 
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
+import Data.Bifunctor (first)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IM
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as M
 import GHC.Generics (Generic)
+import GHCSpecter.Channel.Common.Types (DriverId (..))
 
 class IsKey k where
   fromKey :: k -> Int
   toKey :: Int -> k
 
-data BiIntMap k v = BiIntMap
+instance IsKey DriverId where
+  fromKey = unDriverId
+  toKey = DriverId
+
+newtype KeyMap k v = KeyMap {unKeyMap :: IntMap v}
+  deriving (Show, Generic)
+
+instance (FromJSON v) => FromJSON (KeyMap k v)
+
+instance (ToJSON v) => ToJSON (KeyMap k v)
+
+emptyKeyMap :: (IsKey k) => KeyMap k v
+emptyKeyMap = KeyMap mempty
+
+keyMapToList :: (IsKey k) => KeyMap k v -> [(k, v)]
+keyMapToList = fmap (first toKey) . IM.toList . unKeyMap
+
+lookupKey :: (IsKey k) => k -> KeyMap k v -> Maybe v
+lookupKey k = IM.lookup (fromKey k) . unKeyMap
+
+insertToKeyMap :: (IsKey k) => (k, v) -> KeyMap k v -> KeyMap k v
+insertToKeyMap (k, v) = KeyMap . IM.insert (fromKey k) v . unKeyMap
+
+alterToKeyMap :: (IsKey k) => (Maybe v -> Maybe v) -> k -> KeyMap k v -> KeyMap k v
+alterToKeyMap f k = KeyMap . IM.alter f (fromKey k) . unKeyMap
+
+data BiKeyMap k v = BiKeyMap
   { forwardMap :: IntMap v
   , backwardMap :: Map v k
   }
-  deriving (Generic)
+  deriving (Show, Generic)
 
-instance (FromJSON k, FromJSON v, FromJSONKey v, Ord v) => FromJSON (BiIntMap k v)
+instance (FromJSON k, FromJSON v, FromJSONKey v, Ord v) => FromJSON (BiKeyMap k v)
 
-instance (ToJSON k, ToJSON v, ToJSONKey v) => ToJSON (BiIntMap k v)
+instance (ToJSON k, ToJSON v, ToJSONKey v) => ToJSON (BiKeyMap k v)
 
-mkEmptyBiIntMap :: (IsKey k, Ord v) => BiIntMap k v
-mkEmptyBiIntMap = BiIntMap mempty mempty
+emptyBiKeyMap :: (IsKey k, Ord v) => BiKeyMap k v
+emptyBiKeyMap = BiKeyMap mempty mempty
 
-forwardLookup :: (IsKey k) => k -> BiIntMap k v -> Maybe v
+biKeyMapToList :: (IsKey k) => BiKeyMap k v -> [(k, v)]
+biKeyMapToList = fmap (first toKey) . IM.toList . forwardMap
+
+forwardLookup :: (IsKey k) => k -> BiKeyMap k v -> Maybe v
 forwardLookup k m = IM.lookup (fromKey k) (forwardMap m)
 
-backwardLookup :: (IsKey k, Ord v) => v -> BiIntMap k v -> Maybe k
+backwardLookup :: (IsKey k, Ord v) => v -> BiKeyMap k v -> Maybe k
 backwardLookup v m = M.lookup v (backwardMap m)
 
-insert :: (IsKey k, Ord v) => (k, v) -> BiIntMap k v -> BiIntMap k v
-insert (k, v) m =
+insertToBiKeyMap :: (IsKey k, Ord v) => (k, v) -> BiKeyMap k v -> BiKeyMap k v
+insertToBiKeyMap (k, v) m =
   let fwdmap = forwardMap m
       bwdmap = backwardMap m
    in m

--- a/daemon/src/GHCSpecter/Util/Timing.hs
+++ b/daemon/src/GHCSpecter/Util/Timing.hs
@@ -7,8 +7,8 @@ module GHCSpecter.Util.Timing
     HasTimingInfo (..),
 
     -- * timing info utilities
-    isInProgress,
-    isCompiled,
+    isTimeInTimerRange,
+    isModuleCompilationDone,
 
     -- * construct timing info table
     makeTimingTable,
@@ -54,12 +54,12 @@ data TimingInfo a = TimingInfo
 
 makeClassy ''TimingInfo
 
-isInProgress :: (Ord a) => a -> TimingInfo a -> Bool
-isInProgress x tinfo =
+isTimeInTimerRange :: (Ord a) => a -> TimingInfo a -> Bool
+isTimeInTimerRange x tinfo =
   x >= (tinfo ^. timingStart) && x <= (tinfo ^. timingEnd)
 
-isCompiled :: Map ModuleName DriverId -> IntMap Timer -> ModuleName -> Bool
-isCompiled modDrvMap timing modu =
+isModuleCompilationDone :: Map ModuleName DriverId -> IntMap Timer -> ModuleName -> Bool
+isModuleCompilationDone modDrvMap timing modu =
   isJust $ do
     DriverId i <- M.lookup modu modDrvMap
     timing ^? at i . _Just . to getEndTime . _Just

--- a/plugin/src/GHCSpecter/Channel/Common/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Common/Types.hs
@@ -1,8 +1,14 @@
 module GHCSpecter.Channel.Common.Types
   ( type ModuleName,
+    DriverId (..),
   )
 where
 
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Binary (Binary)
 import Data.Text (Text)
 
 type ModuleName = Text
+
+newtype DriverId = DriverId {unDriverId :: Int}
+  deriving (Show, Eq, Ord, Num, Binary, FromJSON, ToJSON)

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -3,7 +3,6 @@
 
 module GHCSpecter.Channel.Outbound.Types
   ( -- * information types
-    type ModuleName,
     SessionInfo (..),
     TimerTag (..),
     Timer (..),

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -30,7 +30,10 @@ import Data.List qualified as L
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import GHC.Generics (Generic)
-import GHCSpecter.Channel.Common.Types (type ModuleName)
+import GHCSpecter.Channel.Common.Types
+  ( DriverId (..),
+    type ModuleName,
+  )
 
 data Channel = CheckImports | Timing | Session | HsSource | Paused
   deriving (Enum, Eq, Ord, Show, Generic)
@@ -124,7 +127,7 @@ data ChanMessage (a :: Channel) where
   CMCheckImports :: ModuleName -> Text -> ChanMessage 'CheckImports
   CMTiming ::
     -- | driver id
-    Int ->
+    DriverId ->
     Maybe ModuleName ->
     Timer ->
     ChanMessage 'Timing

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -98,6 +98,7 @@ import GHC.Unit.Module.ModSummary
 import GHC.Unit.Module.Name (moduleNameString)
 import GHC.Unit.Types (GenModule (moduleName))
 import GHC.Utils.Outputable (Outputable (ppr))
+import GHCSpecter.Channel.Common.Types (DriverId (..))
 import GHCSpecter.Channel.Inbound.Types (Pause (..))
 import GHCSpecter.Channel.Outbound.Types
   ( ChanMessage (..),
@@ -142,7 +143,7 @@ plugin = defaultPlugin {driverPlugin = driver}
 data PluginSession = PluginSession
   { psSessionInfo :: SessionInfo
   , psMessageQueue :: Maybe MsgQueue
-  , psNextDriverId :: Int
+  , psNextDriverId :: DriverId
   }
 
 emptyPluginSession :: PluginSession
@@ -254,7 +255,7 @@ startSession ::
   [CommandLineOption] ->
   HscEnv ->
   -- | (driver id, message queue)
-  IO (Int, MsgQueue)
+  IO (DriverId, MsgQueue)
 startSession opts env = do
   startTime <- getCurrentTime
   pid <- fromInteger . toInteger <$> getCurrentPid
@@ -293,7 +294,7 @@ startSession opts env = do
 
 sendModuleStart ::
   MsgQueue ->
-  Int ->
+  DriverId ->
   IORef (Maybe ModuleName) ->
   UTCTime ->
   CompPipeline (Maybe ModuleName)
@@ -313,7 +314,7 @@ sendModuleStart queue drvId modNameRef startTime = do
 sendCompStateOnPhase ::
   MsgQueue ->
   DynFlags ->
-  (Int, Maybe ModuleName) ->
+  (DriverId, Maybe ModuleName) ->
   PhasePlus ->
   CompPipeline ()
 sendCompStateOnPhase queue dflags (drvId, mmodName) phase = do

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -98,14 +98,16 @@ import GHC.Unit.Module.ModSummary
 import GHC.Unit.Module.Name (moduleNameString)
 import GHC.Unit.Types (GenModule (moduleName))
 import GHC.Utils.Outputable (Outputable (ppr))
-import GHCSpecter.Channel.Common.Types (DriverId (..))
+import GHCSpecter.Channel.Common.Types
+  ( DriverId (..),
+    type ModuleName,
+  )
 import GHCSpecter.Channel.Inbound.Types (Pause (..))
 import GHCSpecter.Channel.Outbound.Types
   ( ChanMessage (..),
     ChanMessageBox (..),
     HsSourceInfo (..),
     ModuleGraphInfo (..),
-    ModuleName,
     SessionInfo (..),
     Timer (..),
     TimerTag (..),


### PR DESCRIPTION
Previously, ModuleName is used as a key for inspecting on each module unit compilation. Unfortunately, the ModuleName info was not available at the start time of module compilation (this is the limitation of driverPlugin, though. GHC compileOne function invocation already has module summary info when initializing the plugin for the compilation unit), so the previous method was ad hoc to keep the module start time information until the module name info is available and send together. 
Now, DriverId is assigned for each instance of driver, and send start time right at the start time and then later module name information is separately sent. This simplifies the internal logic and enable inspection before the module name arrives.