### PR TITLE
Retrieve module name from parsedResultAction plugin

### DIFF
--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -87,7 +87,7 @@ listener socketFile ssRef ssess workQ = do
           CMSession s' -> do
             let mgi = sessionModuleGraph s'
             void $ forkIO (moduleGraphWorker ssRef mgi)
-          CMHsSource _modu (HsSourceInfo hiefile) ->
+          CMHsSource _drvId (HsSourceInfo hiefile) ->
             void $ forkIO (hieWorker ssRef workQ hiefile)
           CMPaused modu ->
             TIO.putStrLn $ "paused GHC at " <> modu

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -11,7 +11,7 @@ import Concur.Replica
 import Control.Lens ((^.))
 import Data.IntMap qualified as IM
 import Data.List (partition)
-import Data.Maybe (fromMaybe, isJust, mapMaybe)
+import Data.Maybe (fromMaybe, isJust)
 import Data.Text qualified as T
 import GHCSpecter.Channel.Common.Types (DriverId (..))
 import GHCSpecter.Channel.Outbound.Types
@@ -90,10 +90,8 @@ render ss =
               messageModuleInProgress =
                 let is = fmap fst timingInProg
                     imods = fmap (\i -> (unDriverId i, forwardLookup i drvModMap)) is
-                    txt =
-                      T.intercalate "\n" $
-                        fmap (\(i, mmod) -> T.pack (show i) <> fromMaybe "" mmod) imods
-                 in txt -- (show mods)
+                 in T.intercalate "\n" $
+                      fmap (\(i, mmod) -> T.pack (show i) <> ": " <> fromMaybe "" mmod) imods
            in div
                 []
                 [ renderSessionButtons sessionInfo

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -127,7 +127,7 @@ data ChanMessage (a :: Channel) where
   CMModuleInfo :: DriverId -> ModuleName -> ChanMessage 'ModuleInfo
   CMTiming :: DriverId -> Timer -> ChanMessage 'Timing
   CMSession :: SessionInfo -> ChanMessage 'Session
-  CMHsSource :: ModuleName -> HsSourceInfo -> ChanMessage 'HsSource
+  CMHsSource :: DriverId -> HsSourceInfo -> ChanMessage 'HsSource
   CMPaused :: ModuleName -> ChanMessage 'Paused
 
 data ChanMessageBox = forall (a :: Channel). CMBox !(ChanMessage a)
@@ -153,9 +153,9 @@ instance Binary ChanMessageBox where
   put (CMBox (CMSession s)) = do
     put (fromEnum Session)
     put s
-  put (CMBox (CMHsSource m h)) = do
+  put (CMBox (CMHsSource i h)) = do
     put (fromEnum HsSource)
-    put (m, h)
+    put (i, h)
   put (CMBox (CMPaused m)) = do
     put (fromEnum Paused)
     put m

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -1,0 +1,53 @@
+module Plugin.GHCSpecter.Types
+  ( -- * Message Queue
+    MsgQueue (..),
+    initMsgQueue,
+
+    -- * PluginSession
+    PluginSession (..),
+    emptyPluginSession,
+
+    -- * global variable
+    sessionRef,
+  )
+where
+
+import Control.Concurrent.STM
+  ( TVar,
+    newTVarIO,
+  )
+import Data.Sequence (Seq)
+import Data.Sequence qualified as Seq
+import GHCSpecter.Channel.Common.Types (DriverId (..))
+import GHCSpecter.Channel.Inbound.Types (Pause (..))
+import GHCSpecter.Channel.Outbound.Types
+  ( ChanMessageBox (..),
+    SessionInfo (..),
+    emptyModuleGraphInfo,
+  )
+import System.IO.Unsafe (unsafePerformIO)
+
+data MsgQueue = MsgQueue
+  { msgSenderQueue :: TVar (Seq ChanMessageBox)
+  , msgReceiverQueue :: TVar Pause
+  }
+
+initMsgQueue :: IO MsgQueue
+initMsgQueue = do
+  sQ <- newTVarIO Seq.empty
+  pauseRef <- newTVarIO (Pause False)
+  pure $ MsgQueue sQ pauseRef
+
+data PluginSession = PluginSession
+  { psSessionInfo :: SessionInfo
+  , psMessageQueue :: Maybe MsgQueue
+  , psNextDriverId :: DriverId
+  }
+
+emptyPluginSession :: PluginSession
+emptyPluginSession = PluginSession (SessionInfo 0 Nothing emptyModuleGraphInfo False) Nothing 1
+
+-- | Global variable shared across the session
+sessionRef :: TVar PluginSession
+{-# NOINLINE sessionRef #-}
+sessionRef = unsafePerformIO (newTVarIO emptyPluginSession)

--- a/plugin/src/Plugin/GHCSpecter/Util.hs
+++ b/plugin/src/Plugin/GHCSpecter/Util.hs
@@ -1,0 +1,130 @@
+module Plugin.GHCSpecter.Util
+  ( -- * Utilities
+    getTopSortedModules,
+    extractModuleGraphInfo,
+    getModuleNameFromPipeState,
+    mkModuleNameMap,
+    formatName,
+    formatImportedNames,
+  )
+where
+
+import Data.Char (isAlpha)
+import Data.IntMap (IntMap)
+import Data.IntMap qualified as IM
+import Data.List qualified as L
+import Data.Map (Map)
+import Data.Map qualified as M
+import Data.Maybe (mapMaybe)
+import Data.Text qualified as T
+import Data.Tuple (swap)
+import GHC.Data.Graph.Directed qualified as G
+import GHC.Driver.Make
+  ( moduleGraphNodes,
+    topSortModuleGraph,
+  )
+import GHC.Driver.Pipeline
+  ( PipeState (iface),
+  )
+import GHC.Driver.Session (DynFlags)
+import GHC.Plugins
+  ( ModSummary,
+    Name,
+    localiseName,
+    showSDoc,
+  )
+import GHC.Types.Name.Reader
+  ( GlobalRdrElt (..),
+    GreName (..),
+    ImpDeclSpec (..),
+    ImportSpec (..),
+  )
+import GHC.Unit.Module.Graph
+  ( ModuleGraph,
+    ModuleGraphNode (..),
+    mgModSummaries',
+  )
+import GHC.Unit.Module.ModIface (ModIface_ (mi_module))
+import GHC.Unit.Module.ModSummary
+  ( ExtendedModSummary (..),
+    ModSummary (..),
+  )
+import GHC.Unit.Module.Name (moduleNameString)
+import GHC.Unit.Types (GenModule (moduleName))
+import GHC.Utils.Outputable (Outputable (ppr))
+import GHCSpecter.Channel.Common.Types (type ModuleName)
+import GHCSpecter.Channel.Outbound.Types (ModuleGraphInfo (..))
+
+getModuleNameText :: ModSummary -> T.Text
+getModuleNameText = T.pack . moduleNameString . moduleName . ms_mod
+
+gnode2ModSummary :: ModuleGraphNode -> Maybe ModSummary
+gnode2ModSummary InstantiationNode {} = Nothing
+gnode2ModSummary (ModuleNode emod) = Just (emsModSummary emod)
+
+-- temporary function. ignore hs-boot cycles and InstantiatedUnit for now.
+getTopSortedModules :: ModuleGraph -> [ModuleName]
+getTopSortedModules =
+  mapMaybe (fmap getModuleNameText . gnode2ModSummary)
+    . concatMap G.flattenSCC
+    . flip (topSortModuleGraph False) Nothing
+
+extractModuleGraphInfo :: ModuleGraph -> ModuleGraphInfo
+extractModuleGraphInfo modGraph = do
+  let (graph, _) = moduleGraphNodes False (mgModSummaries' modGraph)
+      vtxs = G.verticesG graph
+      modNameFromVertex =
+        fmap getModuleNameText . gnode2ModSummary . G.node_payload
+      modNameMapLst =
+        mapMaybe
+          (\v -> (G.node_key v,) <$> modNameFromVertex v)
+          vtxs
+      modNameMap :: IntMap ModuleName
+      modNameMap = IM.fromList modNameMapLst
+      modNameRevMap :: Map ModuleName Int
+      modNameRevMap = M.fromList $ fmap swap modNameMapLst
+      topSorted =
+        mapMaybe
+          (\n -> M.lookup n modNameRevMap)
+          $ getTopSortedModules modGraph
+      modDeps = IM.fromList $ fmap (\v -> (G.node_key v, G.node_dependencies v)) vtxs
+   in ModuleGraphInfo modNameMap modDeps topSorted
+
+getModuleNameFromPipeState :: PipeState -> Maybe ModuleName
+getModuleNameFromPipeState pstate =
+  let mmi = iface pstate
+      mmod = fmap mi_module mmi
+   in fmap (T.pack . moduleNameString . moduleName) mmod
+
+formatName :: DynFlags -> Name -> String
+formatName dflags name =
+  let str = showSDoc dflags . ppr . localiseName $ name
+   in case str of
+        (x : _) ->
+          -- NOTE: As we want to have resultant text directly copied and pasted to
+          --       the source code, the operator identifiers should be wrapped with
+          --       parentheses.
+          if isAlpha x
+            then str
+            else "(" ++ str ++ ")"
+        _ -> str
+
+formatImportedNames :: [String] -> String
+formatImportedNames names =
+  case fmap (++ ",\n") $ L.sort names of
+    l0 : ls ->
+      let l0' = "  ( " ++ l0
+          ls' = fmap ("    " ++) ls
+          footer = "  )"
+       in concat ([l0'] ++ ls' ++ [footer])
+    _ -> "  ()"
+
+mkModuleNameMap :: GlobalRdrElt -> [(ModuleName, Name)]
+mkModuleNameMap gre = do
+  spec <- gre_imp gre
+  case gre_name gre of
+    NormalGreName name -> do
+      let modName = T.pack . moduleNameString . is_mod . is_decl $ spec
+      pure (modName, name)
+    -- TODO: Handle the record field name case correctly.
+    FieldGreName _ -> []


### PR DESCRIPTION
Module name is retrieved in a more reliable and simplified way using parsedResultAction plugin.