### PR TITLE
Multiple breakpoints and send back the info where the module compilations are paused

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -73,7 +73,7 @@ main = do
         workQ <- newTQueueIO
         chanSignal <- newTChanIO
         let servSess = ServerSession ssRef chanSignal
-        _ <- forkOS $ Comm.listener socketFile ssRef servSess workQ
+        _ <- forkOS $ Comm.listener socketFile servSess workQ
         _ <- forkOS $ Worker.runWorkQueue workQ
         webServer cfg servSess
     View mconfigFile ->

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -95,7 +95,7 @@ listener socketFile ssess workQ = do
             void $ forkIO (moduleGraphWorker ssRef mgi)
           CMHsSource _drvId (HsSourceInfo hiefile) ->
             void $ forkIO (hieWorker ssRef workQ hiefile)
-          CMPaused drvId msg -> do
+          CMPaused drvId loc -> do
             mmodu <-
               atomically $ do
                 ss <- readTVar ssRef
@@ -103,8 +103,16 @@ listener socketFile ssess workQ = do
                 pure $ forwardLookup drvId drvModMap
             case mmodu of
               Nothing -> do
-                TIO.putStrLn $ "paused GHC at driverId = " <> T.pack (show (unDriverId drvId)) <> ": " <> msg
+                TIO.putStrLn $
+                  "paused GHC at driverId = "
+                    <> T.pack (show (unDriverId drvId))
+                    <> ": "
+                    <> T.pack (show loc)
               Just modu ->
-                TIO.putStrLn $ "paused GHC at moduleName = " <> modu <> ": " <> msg
+                TIO.putStrLn $
+                  "paused GHC at moduleName = "
+                    <> modu
+                    <> ": "
+                    <> T.pack (show loc)
           _ -> pure ()
         atomically . modifyTVar' ssRef . updateInbox $ CMBox o

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -167,12 +167,7 @@ data ServerState = ServerState
   , _serverInbox :: Inbox
   , _serverSessionInfo :: SessionInfo
   , _serverDriverModuleMap :: BiKeyMap DriverId ModuleName
-  , -- , _serverDriverModuleMap :: IntMap ModuleName
-    -- -- ^ here the key = DriverId
-    --  -- TODO: wrap this raw IntMap with access functions using DriverId for safety
-    -- , _serverDriverModuleRevMap :: Map ModuleName DriverId
-    _serverTiming :: KeyMap DriverId Timer
-  -- ^ here the key = DriverId
+  , _serverTiming :: KeyMap DriverId Timer
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   }

--- a/daemon/src/GHCSpecter/Util/Timing.hs
+++ b/daemon/src/GHCSpecter/Util/Timing.hs
@@ -18,7 +18,6 @@ where
 import Control.Lens (makeClassy, to, (^.), (^?), _2, _Just)
 import Data.Bifunctor (first)
 import Data.List qualified as L
-import Data.Map.Strict (Map)
 import Data.Maybe (isJust, mapMaybe)
 import Data.Time.Clock
   ( NominalDiffTime,

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -134,7 +134,7 @@ data ChanMessage (a :: Channel) where
   CMTiming :: DriverId -> Timer -> ChanMessage 'Timing
   CMSession :: SessionInfo -> ChanMessage 'Session
   CMHsSource :: DriverId -> HsSourceInfo -> ChanMessage 'HsSource
-  CMPaused :: DriverId -> ChanMessage 'Paused
+  CMPaused :: DriverId -> Text -> ChanMessage 'Paused
 
 data ChanMessageBox = forall (a :: Channel). CMBox !(ChanMessage a)
 
@@ -162,9 +162,9 @@ instance Binary ChanMessageBox where
   put (CMBox (CMHsSource i h)) = do
     put (fromEnum HsSource)
     put (i, h)
-  put (CMBox (CMPaused i)) = do
+  put (CMBox (CMPaused i t)) = do
     put (fromEnum Paused)
-    put i
+    put (i, t)
 
   get = do
     tag <- get
@@ -174,4 +174,4 @@ instance Binary ChanMessageBox where
       Timing -> CMBox . uncurry CMTiming <$> get
       Session -> CMBox . CMSession <$> get
       HsSource -> CMBox . uncurry CMHsSource <$> get
-      Paused -> CMBox . CMPaused <$> get
+      Paused -> CMBox . uncurry CMPaused <$> get

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -34,7 +34,13 @@ import GHCSpecter.Channel.Common.Types
     type ModuleName,
   )
 
-data Channel = CheckImports | ModuleInfo | Timing | Session | HsSource | Paused
+data Channel
+  = CheckImports
+  | ModuleInfo
+  | Timing
+  | Session
+  | HsSource
+  | Paused
   deriving (Enum, Eq, Ord, Show, Generic)
 
 instance FromJSON Channel
@@ -128,7 +134,7 @@ data ChanMessage (a :: Channel) where
   CMTiming :: DriverId -> Timer -> ChanMessage 'Timing
   CMSession :: SessionInfo -> ChanMessage 'Session
   CMHsSource :: DriverId -> HsSourceInfo -> ChanMessage 'HsSource
-  CMPaused :: ModuleName -> ChanMessage 'Paused
+  CMPaused :: DriverId -> ChanMessage 'Paused
 
 data ChanMessageBox = forall (a :: Channel). CMBox !(ChanMessage a)
 
@@ -156,9 +162,9 @@ instance Binary ChanMessageBox where
   put (CMBox (CMHsSource i h)) = do
     put (fromEnum HsSource)
     put (i, h)
-  put (CMBox (CMPaused m)) = do
+  put (CMBox (CMPaused i)) = do
     put (fromEnum Paused)
-    put m
+    put i
 
   get = do
     tag <- get

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -30,7 +30,6 @@ import Data.Sequence ((|>))
 import Data.Sequence qualified as Seq
 import Data.Set (Set)
 import Data.Set qualified as S
-import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import GHC.Driver.Env (Hsc, HscEnv (..))
@@ -70,7 +69,8 @@ import GHCSpecter.Channel.Common.Types
   )
 import GHCSpecter.Channel.Inbound.Types (Pause (..))
 import GHCSpecter.Channel.Outbound.Types
-  ( ChanMessage (..),
+  ( BreakpointLoc (..),
+    ChanMessage (..),
     ChanMessageBox (..),
     HsSourceInfo (..),
     SessionInfo (..),
@@ -150,20 +150,20 @@ queueMessage queue !msg =
   atomically $
     modifyTVar' (msgSenderQueue queue) (|> CMBox msg)
 
-breakPoint :: MsgQueue -> DriverId -> Text -> IO ()
-breakPoint queue drvId msg = do
-  tid <- forkIO $ sessionInPause queue drvId msg
+breakPoint :: MsgQueue -> DriverId -> BreakpointLoc -> IO ()
+breakPoint queue drvId loc = do
+  tid <- forkIO $ sessionInPause queue drvId loc
   atomically $ do
     p <- readTVar (msgReceiverQueue queue)
     STM.check (not (unPause p))
   killThread tid
 
-sessionInPause :: MsgQueue -> DriverId -> Text -> IO ()
-sessionInPause queue drvId msg = do
+sessionInPause :: MsgQueue -> DriverId -> BreakpointLoc -> IO ()
+sessionInPause queue drvId loc = do
   atomically $ do
     p <- readTVar (msgReceiverQueue queue)
     STM.check (unPause p)
-  queueMessage queue (CMPaused drvId msg)
+  queueMessage queue (CMPaused drvId loc)
   -- idling
   forever $ do
     threadDelay 1_000_000
@@ -304,7 +304,7 @@ typecheckPlugin queue drvId modsummary tc = do
           [T.unpack modu, formatImportedNames imported]
 
       modName = T.pack $ moduleNameString $ moduleName $ ms_mod modsummary
-  liftIO $ breakPoint queue drvId "typecheck"
+  liftIO $ breakPoint queue drvId Typecheck
   liftIO $ queueMessage queue (CMCheckImports modName (T.pack rendered))
   pure tc
 
@@ -329,19 +329,19 @@ driver opts env0 = do
           , typeCheckResultAction = \_opts -> typecheckPlugin queue drvId
           }
       env = env0 {hsc_static_plugins = [StaticPlugin (PluginWithArgs newPlugin opts)]}
-  breakPoint queue drvId "driver starting point"
+  breakPoint queue drvId StartDriver
   startTime <- getCurrentTime
   sendModuleStart queue drvId startTime
   let dflags = hsc_dflags env
       hooks = hsc_hooks env
       runPhaseHook' phase fp = do
         -- pre phase timing
-        liftIO $ breakPoint queue drvId ("timingA-" <> T.pack (showPpr dflags phase))
+        liftIO $ breakPoint queue drvId (PreRunPhase (T.pack (showPpr dflags phase)))
         sendCompStateOnPhase queue dflags drvId phase
         -- actual runPhase
         (phase', fp') <- runPhase phase fp
         -- post phase timing
-        liftIO $ breakPoint queue drvId ("timingB-" <> T.pack (showPpr dflags phase'))
+        liftIO $ breakPoint queue drvId (PostRunPhase (T.pack (showPpr dflags phase')))
         sendCompStateOnPhase queue dflags drvId phase'
         pure (phase', fp')
       hooks' = hooks {runPhaseHook = Just runPhaseHook'}

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -95,6 +95,7 @@ import Plugin.GHCSpecter.Types
   )
 import Plugin.GHCSpecter.Util
   ( extractModuleGraphInfo,
+    getModuleName,
     formatImportedNames,
     formatName,
     mkModuleNameMap,
@@ -257,7 +258,7 @@ parsedResultActionPlugin ::
   HsParsedModule ->
   Hsc HsParsedModule
 parsedResultActionPlugin queue drvId modNameRef modSummary parsedMod = do
-  let modName = T.pack . moduleNameString . moduleName . ms_mod $ modSummary
+  let modName = getModuleName modSummary
   liftIO $ do
     writeIORef modNameRef (Just modName)
     sendModuleName queue drvId modName


### PR DESCRIPTION
When the GHC session is paused, the plugin sends back the info where each paused module compilation is at.
New breakpoint positions were also introduced, such as typecheck, pre-runPhase, post-runPhase etc.