### PR TITLE
Console interface for inspecting a paused GHC session

### DIFF
--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -45,6 +45,7 @@ import GHCSpecter.UI.Types
 import GHCSpecter.UI.Types.Event
   ( BackgroundEvent (..),
     ComponentTag (..),
+    ConsoleEvent (..),
     Event (..),
     ModuleGraphEvent (..),
     MouseEvent (..),
@@ -186,7 +187,14 @@ goCommon ev (view, model) = do
   pure (view', model')
 
 goSession :: Event -> (MainView, UIModel) -> Control (MainView, UIModel)
-goSession = goCommon
+goSession ev (view0, model0) = do
+  model <-
+    case ev of
+      ConsoleEv (ConsoleTab i) -> do
+        printMsg ("console tab: " <> T.pack (show i))
+        pure (model0 & modelPausedConsole .~ Just i)
+      _ -> pure model0
+  goCommon ev (view0, model)
 
 goModuleGraph :: Event -> (MainView, UIModel) -> Control (MainView, UIModel)
 goModuleGraph = goCommon
@@ -277,7 +285,8 @@ main = do
   printMsg $ "client session starts at " <> T.pack (show clientSessionStartTime)
 
   -- show banner
-  showBanner
+  -- showBanner
+  refreshUIAfter 1.0
 
   -- initialize main view
   (view, model) <- initializeMainView

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -307,8 +307,7 @@ main = do
   printMsg $ "client session starts at " <> T.pack (show clientSessionStartTime)
 
   -- show banner
-  -- showBanner
-  refreshUIAfter 1.0
+  showBanner
 
   -- initialize main view
   (view, model) <- initializeMainView

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -7,7 +7,7 @@ import Control.Lens ((&), (.~), (^.), _1, _2)
 import Control.Monad (when)
 import Data.Text qualified as T
 import Data.Time.Clock qualified as Clock
-import GHCSpecter.Channel.Inbound.Types (Pause (..))
+import GHCSpecter.Channel.Inbound.Types (Request (..))
 import GHCSpecter.Channel.Outbound.Types (SessionInfo (..))
 import GHCSpecter.Control.Types
   ( getCurrentTime,
@@ -20,7 +20,7 @@ import GHCSpecter.Control.Types
     putUI,
     refreshUIAfter,
     saveSession,
-    sendSignal,
+    sendRequest,
     shouldUpdate,
     type Control,
   )
@@ -99,13 +99,13 @@ defaultUpdateModel topEv (oldModel, oldSS) =
               . (serverShouldUpdate .~ True)
               $ oldSS
           newModel = (modelPausedConsole .~ Nothing) oldModel
-      sendSignal (Pause False)
+      sendRequest Resume
       pure (newModel, newSS)
     SessionEv PauseSessionEv -> do
       let sinfo = oldSS ^. serverSessionInfo
           sinfo' = sinfo {sessionIsPaused = True}
           newSS = (serverSessionInfo .~ sinfo') . (serverShouldUpdate .~ True) $ oldSS
-      sendSignal (Pause True)
+      sendRequest Pause
       pure (oldModel, newSS)
     TimingEv (UpdateSticky b) -> do
       let newModel = (modelTiming . timingUISticky .~ b) oldModel

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -4,10 +4,12 @@ module GHCSpecter.Control
 where
 
 import Control.Lens ((&), (.~), (^.), _1, _2)
-import Control.Monad (when)
 import Data.Text qualified as T
 import Data.Time.Clock qualified as Clock
-import GHCSpecter.Channel.Inbound.Types (Request (..))
+import GHCSpecter.Channel.Inbound.Types
+  ( Request (..),
+    SessionRequest (..),
+  )
 import GHCSpecter.Channel.Outbound.Types (SessionInfo (..))
 import GHCSpecter.Control.Types
   ( getCurrentTime,
@@ -99,13 +101,13 @@ defaultUpdateModel topEv (oldModel, oldSS) =
               . (serverShouldUpdate .~ True)
               $ oldSS
           newModel = (modelPausedConsole .~ Nothing) oldModel
-      sendRequest Resume
+      sendRequest (SessionReq Resume)
       pure (newModel, newSS)
     SessionEv PauseSessionEv -> do
       let sinfo = oldSS ^. serverSessionInfo
           sinfo' = sinfo {sessionIsPaused = True}
           newSS = (serverSessionInfo .~ sinfo') . (serverShouldUpdate .~ True) $ oldSS
-      sendRequest Pause
+      sendRequest (SessionReq Pause)
       pure (oldModel, newSS)
     TimingEv (UpdateSticky b) -> do
       let newModel = (modelTiming . timingUISticky .~ b) oldModel

--- a/daemon/src/GHCSpecter/Control/Types.hs
+++ b/daemon/src/GHCSpecter/Control/Types.hs
@@ -8,7 +8,7 @@ module GHCSpecter.Control.Types
     putUI,
     getSS,
     putSS,
-    sendSignal,
+    sendRequest,
     nextEvent,
     printMsg,
     getCurrentTime,
@@ -22,7 +22,7 @@ where
 import Control.Monad.Free (Free (..), liftF)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
-import GHCSpecter.Channel.Inbound.Types (Pause)
+import GHCSpecter.Channel.Inbound.Types (Request)
 import GHCSpecter.Server.Types (ServerState)
 import GHCSpecter.UI.Types (UIState)
 import GHCSpecter.UI.Types.Event (Event)
@@ -33,7 +33,7 @@ data ControlF r
   | PutUI UIState r
   | GetSS (ServerState -> r)
   | PutSS ServerState r
-  | SendSignal Pause r
+  | SendRequest Request r
   | NextEvent (Event -> r)
   | PrintMsg Text r
   | GetCurrentTime (UTCTime -> r)
@@ -57,8 +57,8 @@ getSS = liftF (GetSS id)
 putSS :: ServerState -> Control ()
 putSS ss = liftF (PutSS ss ())
 
-sendSignal :: Pause -> Control ()
-sendSignal b = liftF (SendSignal b ())
+sendRequest :: Request -> Control ()
+sendRequest b = liftF (SendRequest b ())
 
 nextEvent :: Control Event
 nextEvent = liftF (NextEvent id)

--- a/daemon/src/GHCSpecter/Driver.hs
+++ b/daemon/src/GHCSpecter/Driver.hs
@@ -51,7 +51,7 @@ import GHCSpecter.UI.Types.Event
 -- control: per web view
 
 styleText :: Text
-styleText = "ul > li { margin-left: 10px; }"
+styleText = "body { overflow: hidden; }\nul > li { margin-left: 10px; }"
 
 webServer :: Config -> ServerSession -> IO ()
 webServer cfg servSess = do

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -77,6 +77,8 @@ updateInbox chanMsg = incrementSN . updater
             formatMsg Nothing = "resume"
          in (serverPaused %~ alterToKeyMap (const mloc) drvId)
               . (serverConsole %~ alterToKeyMap (appendConsoleMsg (formatMsg mloc)) drvId)
+      CMBox (CMConsole drvId txt) ->
+        (serverConsole %~ alterToKeyMap (appendConsoleMsg txt) drvId)
 
 listener ::
   FilePath ->

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -67,7 +67,8 @@ updateInbox chanMsg = incrementSN . updater
         (serverSessionInfo .~ s')
       CMBox (CMHsSource _modu _info) ->
         id
-      CMBox _ -> id
+      CMBox (CMPaused drvId mloc) ->
+        (serverPaused %~ alterToKeyMap (const mloc) drvId)
 
 listener ::
   FilePath ->

--- a/daemon/src/GHCSpecter/Driver/Session/Types.hs
+++ b/daemon/src/GHCSpecter/Driver/Session/Types.hs
@@ -15,7 +15,7 @@ where
 
 import Control.Concurrent.STM (TChan, TVar)
 import Control.Lens (makeClassy)
-import GHCSpecter.Channel.Inbound.Types (Pause)
+import GHCSpecter.Channel.Inbound.Types (Request)
 import GHCSpecter.Server.Types (ServerState (..))
 import GHCSpecter.UI.Types (UIState)
 import GHCSpecter.UI.Types.Event (BackgroundEvent, Event)
@@ -24,7 +24,7 @@ import GHCSpecter.UI.Types.Event (BackgroundEvent, Event)
 
 data ServerSession = ServerSession
   { _ssServerStateRef :: TVar ServerState
-  , _ssSubscriberSignal :: TChan Pause
+  , _ssSubscriberSignal :: TChan Request
   }
 
 makeClassy ''ServerSession

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -63,7 +63,7 @@ renderMainPanel ::
   Widget IHTML Event
 renderMainPanel view model ss =
   case view ^. mainTab of
-    TabSession -> Session.render ss
+    TabSession -> Session.render model ss
     TabModuleGraph -> ModuleGraph.render model ss
     TabSourceView -> SourceView.render (model ^. modelSourceView) ss
     TabTiming -> Timing.render model ss
@@ -123,7 +123,9 @@ renderMainView (view, model, ss) = do
                 ]
             )
   div
-    [classList [("container is-fullheight is-size-7 m-4 p-4", True)]]
+    [ classList [("container is-fullheight is-size-7 m-4 p-4", True)]
+    , style [("overflow", "hidden")]
+    ]
     [ cssLink "https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css"
     , cssLink "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.2/css/all.min.css"
     , renderNavbar (view ^. mainTab)

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -1,0 +1,92 @@
+module GHCSpecter.Render.Components.Console
+  ( render,
+  )
+where
+
+import Concur.Core (Widget)
+import Concur.Replica
+  ( Props,
+    classList,
+    onClick,
+    onInput,
+    onKeyPress,
+    style,
+    textProp,
+  )
+import Concur.Replica.DOM.Events qualified as DE
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( div,
+    el,
+    input,
+    nav,
+    pre,
+    text,
+  )
+import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import GHCSpecter.UI.Types.Event (ConsoleEvent (..))
+import GHCSpecter.Util.Map
+  ( IsKey (..),
+    KeyMap,
+    lookupKey,
+  )
+import Prelude hiding (div)
+
+render ::
+  (IsKey k, Eq k) =>
+  [k] ->
+  KeyMap k Text ->
+  Maybe k ->
+  Text ->
+  Widget IHTML (ConsoleEvent k)
+render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
+  where
+    divClass :: Text -> [Props a] -> [Widget IHTML a] -> Widget IHTML a
+    divClass cls props = div (classList [(cls, True)] : props)
+    navbarMenu = divClass "navbar-menu" []
+    navbarStart = divClass "navbar-start" []
+    navItem k =
+      let isActive = Just k == mfocus
+          clss
+            | isActive = ["navbar-item", "is-tab", "is-active", "m-0", "p-1"]
+            | otherwise = ["navbar-item", "is-tab", "m-0", "p-1"]
+          cls = classList $ map (\tag -> (tag, True)) clss
+       in el
+            "a"
+            [cls, ConsoleTab k <$ onClick]
+            [text (T.pack (show (fromKey k)))]
+    consoleTabs =
+      nav
+        [classList [("navbar m-0 p-0", True)]]
+        [navbarMenu [navbarStart (fmap navItem tabs)]]
+    consoleContent =
+      let mtxt = do
+            focus <- mfocus
+            lookupKey focus contents
+       in pre
+            [ style
+                [ ("height", "200px")
+                , ("background-color", "black")
+                , ("color", "white")
+                , ("overflow", "scroll")
+                ]
+            ]
+            [text (fromMaybe "" mtxt)]
+    consoleInput =
+      divClass
+        "control"
+        []
+        [ input
+            [ ConsoleInput . DE.targetValue . DE.target <$> onInput
+            , ConsoleKey . DE.kbdKey <$> onKeyPress
+            , classList [("input", True)]
+            , style [("font-family", "monospace")]
+            , textProp "type" "text"
+            , textProp "placeholder" "type inspection command"
+            , textProp "value" inputEntry
+            ]
+        ]
+    console =
+      div [] [consoleContent, consoleInput]

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -8,7 +8,9 @@ import Concur.Replica
   ( Props,
     classList,
     onClick,
+    onInput,
     style,
+    textProp,
   )
 import Control.Lens ((^.))
 import Data.IntMap qualified as IM
@@ -35,6 +37,7 @@ import GHCSpecter.UI.ConcurReplica.DOM
   ( button,
     div,
     el,
+    input,
     nav,
     p,
     pre,
@@ -150,7 +153,20 @@ renderConsole pausedMap consoleMap mcurrConsole = div [] [consoleTabs, console]
                 ]
             ]
             [text (fromMaybe "" mtxt)]
-    console = div [] [consoleContent]
+    consoleInput =
+      divClass
+        "control"
+        []
+        [ input
+            [ ConsoleEv ConsoleInput <$ onInput
+            , classList [("input", True)]
+            , style [("font-family", "monospace")]
+            , textProp "type" "text"
+            , textProp "placeholder" "type inspection command"
+            ]
+        ]
+    console =
+      div [] [consoleContent, consoleInput]
 
 -- | Top-level render function for the Session tab.
 render :: UIModel -> ServerState -> Widget IHTML Event

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -39,7 +39,8 @@ import GHCSpecter.UI.ConcurReplica.DOM
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types
-  ( HasUIModel (..),
+  ( HasConsoleUI (..),
+    HasUIModel (..),
     UIModel,
   )
 import GHCSpecter.UI.Types.Event
@@ -116,8 +117,8 @@ render model ss =
       drvModMap = ss ^. serverDriverModuleMap
       pausedMap = ss ^. serverPaused
       consoleMap = ss ^. serverConsole
-      mcurrConsole = model ^. modelPausedConsole
-      consoleBuffer = model ^. modelConsoleBuffer
+      mconsoleFocus = model ^. modelConsole . consoleFocus
+      inputEntry = model ^. modelConsole . consoleInputEntry
    in case sessionStartTime sessionInfo of
         Nothing ->
           pre [] [text "GHC Session has not been started"]
@@ -152,8 +153,8 @@ render model ss =
                             <$> Console.render
                               (fmap fst . keyMapToList $ pausedMap)
                               consoleMap
-                              mcurrConsole
-                              consoleBuffer
+                              mconsoleFocus
+                              inputEntry
                         ]
                       else []
                 )

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -35,7 +35,6 @@ where
 
 import Control.Lens (makeClassy, (%~))
 import Data.Aeson (FromJSON, ToJSON)
--- import Data.IntMap (IntMap)
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 import Data.Tree (Forest)

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -169,6 +169,7 @@ data ServerState = ServerState
   , _serverDriverModuleMap :: BiKeyMap DriverId ModuleName
   , _serverTiming :: KeyMap DriverId Timer
   , _serverPaused :: KeyMap DriverId BreakpointLoc
+  , _serverConsole :: KeyMap DriverId Text
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   }
@@ -190,6 +191,7 @@ emptyServerState =
     , _serverDriverModuleMap = emptyBiKeyMap
     , _serverTiming = emptyKeyMap
     , _serverPaused = emptyKeyMap
+    , _serverConsole = emptyKeyMap
     , _serverModuleGraphState = emptyModuleGraphState
     , _serverHieState = emptyHieState
     }

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -45,7 +45,8 @@ import GHCSpecter.Channel.Common.Types
     type ModuleName,
   )
 import GHCSpecter.Channel.Outbound.Types
-  ( Channel,
+  ( BreakpointLoc,
+    Channel,
     SessionInfo (..),
     Timer,
     emptyModuleGraphInfo,
@@ -168,6 +169,7 @@ data ServerState = ServerState
   , _serverSessionInfo :: SessionInfo
   , _serverDriverModuleMap :: BiKeyMap DriverId ModuleName
   , _serverTiming :: KeyMap DriverId Timer
+  , _serverPaused :: KeyMap DriverId BreakpointLoc
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   }
@@ -188,6 +190,7 @@ emptyServerState =
     , _serverSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo False
     , _serverDriverModuleMap = emptyBiKeyMap
     , _serverTiming = emptyKeyMap
+    , _serverPaused = emptyKeyMap
     , _serverModuleGraphState = emptyModuleGraphState
     , _serverHieState = emptyHieState
     }

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -27,6 +27,7 @@ where
 import Control.Lens (makeClassy)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
+import GHCSpecter.Channel.Common.Types (DriverId)
 import GHCSpecter.Data.Assets (Assets)
 import GHCSpecter.UI.Types.Event (DetailLevel (..), Tab (..))
 
@@ -91,6 +92,7 @@ data UIModel = UIModel
   -- ^ UI state of source view UI
   , _modelTiming :: TimingUI
   -- ^ UI state of Timing UI
+  , _modelPausedConsole :: Maybe DriverId
   }
 
 makeClassy ''UIModel
@@ -102,6 +104,7 @@ emptyUIModel =
     , _modelSubModuleGraph = (UpTo30, ModuleGraphUI Nothing Nothing)
     , _modelSourceView = emptySourceViewUI
     , _modelTiming = emptyTimingUI
+    , _modelPausedConsole = Nothing
     }
 
 data UIView

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -93,6 +93,9 @@ data UIModel = UIModel
   , _modelTiming :: TimingUI
   -- ^ UI state of Timing UI
   , _modelPausedConsole :: Maybe DriverId
+  -- ^ DriverId for the console
+  , _modelConsoleBuffer :: Text
+  -- ^ console buffer content
   }
 
 makeClassy ''UIModel
@@ -105,6 +108,7 @@ emptyUIModel =
     , _modelSourceView = emptySourceViewUI
     , _modelTiming = emptyTimingUI
     , _modelPausedConsole = Nothing
+    , _modelConsoleBuffer = ""
     }
 
 data UIView

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -10,6 +10,9 @@ module GHCSpecter.UI.Types
     TimingUI,
     HasTimingUI (..),
     emptyTimingUI,
+    ConsoleUI,
+    HasConsoleUI (..),
+    emptyConsoleUI,
     MainView (..),
     HasMainView (..),
     emptyMainView,
@@ -70,6 +73,18 @@ makeClassy ''TimingUI
 emptyTimingUI :: TimingUI
 emptyTimingUI = TimingUI False False False (0, 0) False
 
+data ConsoleUI = ConsoleUI
+  { _consoleFocus :: Maybe DriverId
+  -- ^ focused console tab
+  , _consoleInputEntry :: Text
+  -- ^ console input entry
+  }
+
+makeClassy ''ConsoleUI
+
+emptyConsoleUI :: ConsoleUI
+emptyConsoleUI = ConsoleUI Nothing ""
+
 data MainView = MainView
   { _mainTab :: Tab
   -- ^ current tab
@@ -92,10 +107,7 @@ data UIModel = UIModel
   -- ^ UI state of source view UI
   , _modelTiming :: TimingUI
   -- ^ UI state of Timing UI
-  , _modelPausedConsole :: Maybe DriverId
-  -- ^ DriverId for the console
-  , _modelConsoleBuffer :: Text
-  -- ^ console buffer content
+  , _modelConsole :: ConsoleUI
   }
 
 makeClassy ''UIModel
@@ -107,8 +119,7 @@ emptyUIModel =
     , _modelSubModuleGraph = (UpTo30, ModuleGraphUI Nothing Nothing)
     , _modelSourceView = emptySourceViewUI
     , _modelTiming = emptyTimingUI
-    , _modelPausedConsole = Nothing
-    , _modelConsoleBuffer = ""
+    , _modelConsole = emptyConsoleUI
     }
 
 data UIView

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -66,7 +66,8 @@ data MouseEvent
 
 data ConsoleEvent
   = ConsoleTab DriverId
-  | ConsoleInput -- Text
+  | ConsoleKey Text
+  | ConsoleInput Text
   deriving (Show, Eq)
 
 data BackgroundEvent

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -66,6 +66,7 @@ data MouseEvent
 
 data ConsoleEvent
   = ConsoleTab DriverId
+  | ConsoleInput -- Text
   deriving (Show, Eq)
 
 data BackgroundEvent

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -10,6 +10,7 @@ module GHCSpecter.UI.Types.Event
     SessionEvent (..),
     TimingEvent (..),
     MouseEvent (..),
+    ConsoleEvent (..),
     BackgroundEvent (..),
     Event (..),
   )
@@ -18,6 +19,7 @@ where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import GHCSpecter.Channel.Common.Types (DriverId)
 
 data Tab = TabSession | TabModuleGraph | TabSourceView | TabTiming
   deriving (Eq, Show)
@@ -62,6 +64,10 @@ data MouseEvent
   | MouseUp (Maybe (Double, Double))
   deriving (Show, Eq)
 
+data ConsoleEvent
+  = ConsoleTab DriverId
+  deriving (Show, Eq)
+
 data BackgroundEvent
   = MessageChanUpdated
   | RefreshUI
@@ -75,5 +81,6 @@ data Event
   | SessionEv SessionEvent
   | TimingEv TimingEvent
   | MouseEv ComponentTag MouseEvent
+  | ConsoleEv ConsoleEvent
   | BkgEv BackgroundEvent
   deriving (Show, Eq)

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -64,8 +64,8 @@ data MouseEvent
   | MouseUp (Maybe (Double, Double))
   deriving (Show, Eq)
 
-data ConsoleEvent
-  = ConsoleTab DriverId
+data ConsoleEvent k
+  = ConsoleTab k
   | ConsoleKey Text
   | ConsoleInput Text
   deriving (Show, Eq)
@@ -83,6 +83,6 @@ data Event
   | SessionEv SessionEvent
   | TimingEv TimingEvent
   | MouseEv ComponentTag MouseEvent
-  | ConsoleEv ConsoleEvent
+  | ConsoleEv (ConsoleEvent DriverId)
   | BkgEv BackgroundEvent
   deriving (Show, Eq)

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -1,5 +1,6 @@
 module GHCSpecter.Channel.Inbound.Types
-  ( Request (..),
+  ( InquireMessage (..),
+    Request (..),
   )
 where
 
@@ -7,9 +8,19 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.Binary (Binary (..))
 import GHC.Generics (Generic)
 
+data InquireMessage = ListGlobalRdrElt
+  deriving (Eq, Ord, Show, Generic)
+
+instance Binary InquireMessage
+
+instance FromJSON InquireMessage
+
+instance ToJSON InquireMessage
+
 data Request
   = Pause
   | Resume
+  --   | Inquire InquireMessage
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary Request

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -12,6 +12,7 @@ import Data.Aeson (FromJSON, ToJSON)
 import Data.Binary (Binary (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import GHCSpecter.Channel.Common.Types (DriverId)
 
 data SessionRequest
   = Pause
@@ -24,7 +25,7 @@ instance FromJSON SessionRequest
 
 instance ToJSON SessionRequest
 
-data ConsoleRequest = Ping Text
+data ConsoleRequest = Ping DriverId Text
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary ConsoleRequest

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -1,26 +1,41 @@
 module GHCSpecter.Channel.Inbound.Types
-  ( InquireMessage (..),
+  ( -- * subrequests
+    SessionRequest (..),
+    ConsoleRequest (..),
+
+    -- * top-level request
     Request (..),
   )
 where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Binary (Binary (..))
+import Data.Text (Text)
 import GHC.Generics (Generic)
 
-data InquireMessage = ListGlobalRdrElt
-  deriving (Eq, Ord, Show, Generic)
-
-instance Binary InquireMessage
-
-instance FromJSON InquireMessage
-
-instance ToJSON InquireMessage
-
-data Request
+data SessionRequest
   = Pause
   | Resume
-  --   | Inquire InquireMessage
+  deriving (Eq, Ord, Show, Generic)
+
+instance Binary SessionRequest
+
+instance FromJSON SessionRequest
+
+instance ToJSON SessionRequest
+
+data ConsoleRequest = Ping Text
+  deriving (Eq, Ord, Show, Generic)
+
+instance Binary ConsoleRequest
+
+instance FromJSON ConsoleRequest
+
+instance ToJSON ConsoleRequest
+
+data Request
+  = SessionReq SessionRequest
+  | ConsoleReq ConsoleRequest
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary Request

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -1,10 +1,19 @@
 module GHCSpecter.Channel.Inbound.Types
-  ( Pause (..),
+  ( Request (..),
   )
 where
 
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Binary (Binary (..))
+import GHC.Generics (Generic)
 
-newtype Pause = Pause {unPause :: Bool}
-  deriving (Eq, Ord, Show, Binary, FromJSON, ToJSON)
+data Request
+  = Pause
+  | Resume
+  deriving (Eq, Ord, Show, Generic)
+
+instance Binary Request
+
+instance FromJSON Request
+
+instance ToJSON Request

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -42,6 +42,7 @@ data Channel
   | Session
   | HsSource
   | Paused
+  | Console
   deriving (Enum, Eq, Ord, Show, Generic)
 
 instance FromJSON Channel
@@ -150,6 +151,7 @@ data ChanMessage (a :: Channel) where
   CMSession :: SessionInfo -> ChanMessage 'Session
   CMHsSource :: DriverId -> HsSourceInfo -> ChanMessage 'HsSource
   CMPaused :: DriverId -> Maybe BreakpointLoc -> ChanMessage 'Paused
+  CMConsole :: DriverId -> Text -> ChanMessage 'Console
 
 data ChanMessageBox = forall (a :: Channel). CMBox !(ChanMessage a)
 
@@ -180,6 +182,9 @@ instance Binary ChanMessageBox where
   put (CMBox (CMPaused i ml)) = do
     put (fromEnum Paused)
     put (i, ml)
+  put (CMBox (CMConsole i t)) = do
+    put (fromEnum Console)
+    put (i, t)
 
   get = do
     tag <- get
@@ -190,3 +195,4 @@ instance Binary ChanMessageBox where
       Session -> CMBox . CMSession <$> get
       HsSource -> CMBox . uncurry CMHsSource <$> get
       Paused -> CMBox . uncurry CMPaused <$> get
+      Console -> CMBox . uncurry CMConsole <$> get

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -149,7 +149,7 @@ data ChanMessage (a :: Channel) where
   CMTiming :: DriverId -> Timer -> ChanMessage 'Timing
   CMSession :: SessionInfo -> ChanMessage 'Session
   CMHsSource :: DriverId -> HsSourceInfo -> ChanMessage 'HsSource
-  CMPaused :: DriverId -> BreakpointLoc -> ChanMessage 'Paused
+  CMPaused :: DriverId -> Maybe BreakpointLoc -> ChanMessage 'Paused
 
 data ChanMessageBox = forall (a :: Channel). CMBox !(ChanMessage a)
 
@@ -177,9 +177,9 @@ instance Binary ChanMessageBox where
   put (CMBox (CMHsSource i h)) = do
     put (fromEnum HsSource)
     put (i, h)
-  put (CMBox (CMPaused i l)) = do
+  put (CMBox (CMPaused i ml)) = do
     put (fromEnum Paused)
-    put (i, l)
+    put (i, ml)
 
   get = do
     tag <- get

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -330,9 +330,9 @@ driver opts env0 = do
           , typeCheckResultAction = \_opts -> typecheckPlugin queue drvId
           }
       env = env0 {hsc_static_plugins = [StaticPlugin (PluginWithArgs newPlugin opts)]}
-  breakPoint queue drvId StartDriver
   startTime <- getCurrentTime
   sendModuleStart queue drvId startTime
+  breakPoint queue drvId StartDriver
   let dflags = hsc_dflags env
       hooks = hsc_hooks env
       runPhaseHook' phase fp = do

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -45,7 +45,8 @@ data PluginSession = PluginSession
   }
 
 emptyPluginSession :: PluginSession
-emptyPluginSession = PluginSession (SessionInfo 0 Nothing emptyModuleGraphInfo False) Nothing 1
+emptyPluginSession =
+  PluginSession (SessionInfo 0 Nothing emptyModuleGraphInfo False) Nothing 1
 
 -- | Global variable shared across the session
 sessionRef :: TVar PluginSession

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -35,8 +35,8 @@ data MsgQueue = MsgQueue
 initMsgQueue :: IO MsgQueue
 initMsgQueue = do
   sQ <- newTVarIO Seq.empty
-  reqRef <- newTVarIO Nothing
-  pure $ MsgQueue sQ reqRef
+  rQ <- newTVarIO Nothing
+  pure $ MsgQueue sQ rQ
 
 data PluginSession = PluginSession
   { psSessionInfo :: SessionInfo

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -29,13 +29,13 @@ import System.IO.Unsafe (unsafePerformIO)
 
 data MsgQueue = MsgQueue
   { msgSenderQueue :: TVar (Seq ChanMessageBox)
-  , msgReceiverQueue :: TVar ConsoleRequest
+  , msgReceiverQueue :: TVar (Maybe ConsoleRequest)
   }
 
 initMsgQueue :: IO MsgQueue
 initMsgQueue = do
   sQ <- newTVarIO Seq.empty
-  reqRef <- newTVarIO (Ping "hello world")
+  reqRef <- newTVarIO Nothing
   pure $ MsgQueue sQ reqRef
 
 data PluginSession = PluginSession

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -19,7 +19,7 @@ import Control.Concurrent.STM
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import GHCSpecter.Channel.Common.Types (DriverId (..))
-import GHCSpecter.Channel.Inbound.Types (Request (..))
+import GHCSpecter.Channel.Inbound.Types (ConsoleRequest (..))
 import GHCSpecter.Channel.Outbound.Types
   ( ChanMessageBox (..),
     SessionInfo (..),
@@ -29,13 +29,13 @@ import System.IO.Unsafe (unsafePerformIO)
 
 data MsgQueue = MsgQueue
   { msgSenderQueue :: TVar (Seq ChanMessageBox)
-  , msgReceiverQueue :: TVar Request
+  , msgReceiverQueue :: TVar ConsoleRequest
   }
 
 initMsgQueue :: IO MsgQueue
 initMsgQueue = do
   sQ <- newTVarIO Seq.empty
-  reqRef <- newTVarIO Resume
+  reqRef <- newTVarIO (Ping "hello world")
   pure $ MsgQueue sQ reqRef
 
 data PluginSession = PluginSession

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -19,7 +19,7 @@ import Control.Concurrent.STM
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import GHCSpecter.Channel.Common.Types (DriverId (..))
-import GHCSpecter.Channel.Inbound.Types (Pause (..))
+import GHCSpecter.Channel.Inbound.Types (Request (..))
 import GHCSpecter.Channel.Outbound.Types
   ( ChanMessageBox (..),
     SessionInfo (..),
@@ -29,14 +29,14 @@ import System.IO.Unsafe (unsafePerformIO)
 
 data MsgQueue = MsgQueue
   { msgSenderQueue :: TVar (Seq ChanMessageBox)
-  , msgReceiverQueue :: TVar Pause
+  , msgReceiverQueue :: TVar Request
   }
 
 initMsgQueue :: IO MsgQueue
 initMsgQueue = do
   sQ <- newTVarIO Seq.empty
-  pauseRef <- newTVarIO (Pause False)
-  pure $ MsgQueue sQ pauseRef
+  reqRef <- newTVarIO Resume
+  pure $ MsgQueue sQ reqRef
 
 data PluginSession = PluginSession
   { psSessionInfo :: SessionInfo


### PR DESCRIPTION
This PR introduces web console interface that enables on-demand inspection into a paused GHC session.
Made a simple message ping-pong test for the sake of test.