### PR TITLE
Console command for proceed to next breakpoint (:next)

### DIFF
--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -209,7 +209,9 @@ goSession ev (view0, model0) = do
             Just drvId -> do
               let msg = model0 ^. modelConsole . consoleInputEntry
                   model = (modelConsole . consoleInputEntry .~ "") model0
-              sendRequest $ ConsoleReq drvId (Ping msg)
+              if msg == ":next"
+                then sendRequest $ ConsoleReq drvId NextBreakpoint
+                else sendRequest $ ConsoleReq drvId (Ping msg)
               pure model
           else pure model0
       ConsoleEv (ConsoleInput content) -> do

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -209,7 +209,7 @@ goSession ev (view0, model0) = do
             Just drvId -> do
               let msg = model0 ^. modelConsole . consoleInputEntry
                   model = (modelConsole . consoleInputEntry .~ "") model0
-              sendRequest $ ConsoleReq (Ping drvId msg)
+              sendRequest $ ConsoleReq drvId (Ping msg)
               pure model
           else pure model0
       ConsoleEv (ConsoleInput content) -> do

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -27,6 +27,7 @@ instance ToJSON SessionRequest
 
 data ConsoleRequest
   = Ping Text
+  | NextBreakpoint
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary ConsoleRequest

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -25,7 +25,8 @@ instance FromJSON SessionRequest
 
 instance ToJSON SessionRequest
 
-data ConsoleRequest = Ping DriverId Text
+data ConsoleRequest
+  = Ping Text
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary ConsoleRequest
@@ -36,7 +37,7 @@ instance ToJSON ConsoleRequest
 
 data Request
   = SessionReq SessionRequest
-  | ConsoleReq ConsoleRequest
+  | ConsoleReq DriverId ConsoleRequest
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary Request

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -158,8 +158,8 @@ runMessageQueue opts queue = do
                   sinfo = psSessionInfo s
                   sinfo' = sinfo {sessionIsPaused = isPaused}
                in s {psSessionInfo = sinfo'}
-          ConsoleReq creq ->
-            writeTVar (msgReceiverQueue queue) (Just creq)
+          ConsoleReq drvId' creq ->
+            writeTVar (msgReceiverQueue queue) (Just (drvId', creq))
 
 queueMessage :: MsgQueue -> ChanMessage a -> IO ()
 queueMessage queue !msg =
@@ -183,7 +183,7 @@ consoleAction queue drvId = do
       mreq <- readTVar rQ
       case mreq of
         Nothing -> retry
-        Just (Ping drvId' msg) ->
+        Just (drvId', Ping msg) ->
           if drvId == drvId'
             then do
               writeTVar rQ Nothing

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -170,28 +170,40 @@ breakPoint :: MsgQueue -> DriverId -> BreakpointLoc -> IO ()
 breakPoint queue drvId loc = do
   tid <- forkIO $ sessionInPause queue drvId loc
   atomically $ do
-    isPaused <- sessionIsPaused . psSessionInfo <$> readTVar sessionRef
+    psess <- readTVar sessionRef
+    let sinfo = psSessionInfo psess
+        isSessionPaused = sessionIsPaused sinfo
+        isDriverInStep = maybe False (== drvId) $ psDriverInStep psess
     -- block until the session is resumed.
-    STM.check (not isPaused)
+    STM.check (not isSessionPaused || isDriverInStep)
+    when (isDriverInStep && isSessionPaused) $ do
+      let psess' = psess {psDriverInStep = Nothing}
+      writeTVar sessionRef psess'
   killThread tid
 
 consoleAction :: MsgQueue -> DriverId -> IO ()
 consoleAction queue drvId = do
   let rQ = msgReceiverQueue queue
-  msg <-
+  req <-
     atomically $ do
       mreq <- readTVar rQ
       case mreq of
         Nothing -> retry
-        Just (drvId', Ping msg) ->
+        Just (drvId', req) ->
           if drvId == drvId'
             then do
               writeTVar rQ Nothing
-              pure msg
+              pure req
             else retry
-  TIO.putStrLn $ "ping: " <> msg
-  let pongMsg = "pong: " <> msg
-  queueMessage queue (CMConsole drvId pongMsg)
+  case req of
+    Ping msg -> do
+      TIO.putStrLn $ "ping: " <> msg
+      let pongMsg = "pong: " <> msg
+      queueMessage queue (CMConsole drvId pongMsg)
+    NextBreakpoint -> do
+      putStrLn "NextBreakpoint"
+      atomically $
+        modifyTVar' sessionRef $ \psess -> psess {psDriverInStep = Just drvId}
 
 sessionInPause :: MsgQueue -> DriverId -> BreakpointLoc -> IO ()
 sessionInPause queue drvId loc = do

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -42,11 +42,14 @@ data PluginSession = PluginSession
   { psSessionInfo :: SessionInfo
   , psMessageQueue :: Maybe MsgQueue
   , psNextDriverId :: DriverId
+  , psDriverInStep :: Maybe DriverId
+  -- ^ DriverId in next step operation
+  -- TODO: find a better place
   }
 
 emptyPluginSession :: PluginSession
 emptyPluginSession =
-  PluginSession (SessionInfo 0 Nothing emptyModuleGraphInfo False) Nothing 1
+  PluginSession (SessionInfo 0 Nothing emptyModuleGraphInfo False) Nothing 1 Nothing
 
 -- | Global variable shared across the session
 sessionRef :: TVar PluginSession

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -29,7 +29,7 @@ import System.IO.Unsafe (unsafePerformIO)
 
 data MsgQueue = MsgQueue
   { msgSenderQueue :: TVar (Seq ChanMessageBox)
-  , msgReceiverQueue :: TVar (Maybe ConsoleRequest)
+  , msgReceiverQueue :: TVar (Maybe (DriverId, ConsoleRequest))
   }
 
 initMsgQueue :: IO MsgQueue


### PR DESCRIPTION
By typing `:next`, the paused GHC session can be proceeded to the next break point for a given driver (i.e. module).
