### PR TITLE
Interactive phase-specific command from the console

### DIFF
--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE MultiWayIf #-}
+
 module GHCSpecter.Control
   ( main,
   )
@@ -194,9 +196,13 @@ goCommon ev (view, model0) = do
             Just drvId -> do
               let msg = model0 ^. modelConsole . consoleInputEntry
                   model = (modelConsole . consoleInputEntry .~ "") model0
-              if msg == ":next"
-                then sendRequest $ ConsoleReq drvId NextBreakpoint
-                else sendRequest $ ConsoleReq drvId (Ping msg)
+              if
+                  | msg == ":next" ->
+                      sendRequest $ ConsoleReq drvId NextBreakpoint
+                  | msg == ":unqualified" ->
+                      sendRequest $ ConsoleReq drvId ShowUnqualifiedImports
+                  | otherwise ->
+                      sendRequest $ ConsoleReq drvId (Ping msg)
               pure model
           else pure model0
       ConsoleEv (ConsoleInput content) -> do

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -28,7 +28,7 @@ instance ToJSON SessionRequest
 data ConsoleRequest
   = Ping Text
   | NextBreakpoint
-  --   | ShowUnqualifiedImports
+  | ShowUnqualifiedImports
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary ConsoleRequest

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -28,6 +28,7 @@ instance ToJSON SessionRequest
 data ConsoleRequest
   = Ping Text
   | NextBreakpoint
+  --   | ShowUnqualifiedImports
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary ConsoleRequest

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -55,7 +55,7 @@ data BreakpointLoc
   | Typecheck
   | PreRunPhase Text
   | PostRunPhase Text
-  deriving (Show, Generic)
+  deriving (Show, Eq, Generic)
 
 instance Binary BreakpointLoc
 
@@ -162,6 +162,7 @@ instance Show ChanMessageBox where
   show (CMBox (CMSession {})) = "CMSession"
   show (CMBox (CMHsSource {})) = "CMHsSource"
   show (CMBox (CMPaused {})) = "CMPaused"
+  show (CMBox (CMConsole {})) = "CMConsole"
 
 instance Binary ChanMessageBox where
   put (CMBox (CMCheckImports m t)) = do

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -9,30 +9,22 @@ module Plugin.GHCSpecter
   )
 where
 
-import Control.Concurrent (forkIO, forkOS, killThread)
+import Control.Concurrent (forkOS)
 import Control.Concurrent.STM
   ( atomically,
     modifyTVar',
     readTVar,
-    retry,
-    writeTVar,
   )
-import Control.Concurrent.STM qualified as STM
-import Control.Exception qualified as E
-import Control.Monad (forever, void, when)
+import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (for_)
-import Data.Foldable qualified as F
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Data.List qualified as L
 import Data.Map (Map)
 import Data.Map qualified as M
-import Data.Sequence ((|>))
-import Data.Sequence qualified as Seq
 import Data.Set (Set)
 import Data.Set qualified as S
 import Data.Text qualified as T
-import Data.Text.IO qualified as TIO
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import GHC.Driver.Env (Hsc, HscEnv (..))
 import GHC.Driver.Flags (GeneralFlag (Opt_WriteHie))
@@ -69,32 +61,17 @@ import GHCSpecter.Channel.Common.Types
   ( DriverId (..),
     type ModuleName,
   )
-import GHCSpecter.Channel.Inbound.Types
-  ( ConsoleRequest (..),
-    Request (..),
-    SessionRequest (..),
-  )
 import GHCSpecter.Channel.Outbound.Types
   ( BreakpointLoc (..),
     ChanMessage (..),
-    ChanMessageBox (..),
     HsSourceInfo (..),
     SessionInfo (..),
     Timer (..),
     TimerTag (..),
   )
-import GHCSpecter.Comm
-  ( receiveObject,
-    runClient,
-    sendObject,
-  )
-import GHCSpecter.Config
-  ( Config (..),
-    defaultGhcSpecterConfigFile,
-    loadConfig,
-  )
 import GHCSpecter.Util.GHC (showPpr)
-import Network.Socket (Socket)
+import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
+import Plugin.GHCSpecter.Console (breakPoint)
 import Plugin.GHCSpecter.Types
   ( MsgQueue (..),
     PluginSession (..),
@@ -108,112 +85,8 @@ import Plugin.GHCSpecter.Util
     getModuleName,
     mkModuleNameMap,
   )
-import System.Directory (canonicalizePath, doesFileExist)
+import System.Directory (canonicalizePath)
 import System.Process (getCurrentPid)
-
-runMessageQueue :: [CommandLineOption] -> MsgQueue -> IO ()
-runMessageQueue opts queue = do
-  mipcfile <-
-    case opts of
-      ipcfile : _ -> pure (Just ipcfile)
-      [] -> do
-        ecfg <- loadConfig defaultGhcSpecterConfigFile
-        case ecfg of
-          Left _ -> pure Nothing
-          Right cfg -> pure (Just (configSocket cfg))
-  for_ mipcfile $ \ipcfile -> do
-    socketExists <- doesFileExist ipcfile
-    when socketExists $
-      runClient ipcfile $ \sock -> do
-        _ <- forkIO $ receiver sock
-        sender sock
-  where
-    sender :: Socket -> IO ()
-    sender sock = forever $ do
-      msgs <- atomically $ do
-        queued <- readTVar (msgSenderQueue queue)
-        if Seq.null queued
-          then retry
-          else do
-            writeTVar (msgSenderQueue queue) Seq.empty
-            pure queued
-      let msgList = F.toList msgs
-      msgList `seq` sendObject sock msgList
-    receiver :: Socket -> IO ()
-    receiver sock = forever $ do
-      putStrLn "################"
-      putStrLn "receiver started"
-      putStrLn "################"
-      msg :: Request <- receiveObject sock
-      putStrLn "################"
-      putStrLn $ "message received: " ++ show msg
-      putStrLn "################"
-      atomically $
-        case msg of
-          SessionReq sreq ->
-            modifyTVar' sessionRef $ \s ->
-              let isPaused
-                    | sreq == Pause = True
-                    | otherwise = False
-                  sinfo = psSessionInfo s
-                  sinfo' = sinfo {sessionIsPaused = isPaused}
-               in s {psSessionInfo = sinfo'}
-          ConsoleReq drvId' creq ->
-            writeTVar (msgReceiverQueue queue) (Just (drvId', creq))
-
-queueMessage :: MsgQueue -> ChanMessage a -> IO ()
-queueMessage queue !msg =
-  atomically $
-    modifyTVar' (msgSenderQueue queue) (|> CMBox msg)
-
-breakPoint :: MsgQueue -> DriverId -> BreakpointLoc -> IO ()
-breakPoint queue drvId loc = do
-  tid <- forkIO $ sessionInPause queue drvId loc
-  atomically $ do
-    psess <- readTVar sessionRef
-    let sinfo = psSessionInfo psess
-        isSessionPaused = sessionIsPaused sinfo
-        isDriverInStep = maybe False (== drvId) $ psDriverInStep psess
-    -- block until the session is resumed.
-    STM.check (not isSessionPaused || isDriverInStep)
-    when (isDriverInStep && isSessionPaused) $ do
-      let psess' = psess {psDriverInStep = Nothing}
-      writeTVar sessionRef psess'
-  killThread tid
-
-consoleAction :: MsgQueue -> DriverId -> IO ()
-consoleAction queue drvId = do
-  let rQ = msgReceiverQueue queue
-  req <-
-    atomically $ do
-      mreq <- readTVar rQ
-      case mreq of
-        Nothing -> retry
-        Just (drvId', req) ->
-          if drvId == drvId'
-            then do
-              writeTVar rQ Nothing
-              pure req
-            else retry
-  case req of
-    Ping msg -> do
-      TIO.putStrLn $ "ping: " <> msg
-      let pongMsg = "pong: " <> msg
-      queueMessage queue (CMConsole drvId pongMsg)
-    NextBreakpoint -> do
-      putStrLn "NextBreakpoint"
-      atomically $
-        modifyTVar' sessionRef $ \psess -> psess {psDriverInStep = Just drvId}
-
-sessionInPause :: MsgQueue -> DriverId -> BreakpointLoc -> IO ()
-sessionInPause queue drvId loc = do
-  atomically $ do
-    isPaused <- sessionIsPaused . psSessionInfo <$> readTVar sessionRef
-    -- prodceed when the session is paused.
-    STM.check isPaused
-  queueMessage queue (CMPaused drvId (Just loc))
-  (forever $ consoleAction queue drvId)
-    `E.catch` (\(_e :: E.AsyncException) -> queueMessage queue (CMPaused drvId Nothing))
 
 -- | Called only once for sending session information
 startSession ::

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -206,9 +206,9 @@ typecheckPlugin ::
 typecheckPlugin queue drvId modsummary tc = do
   let cmdSet = CommandSet [(":unqualified", fetchUnqualifiedImports tc)]
   breakPoint queue drvId Typecheck cmdSet
-  -- rendered <- fetchUnqualifiedImports tc
-  -- let modName = T.pack $ moduleNameString $ moduleName $ ms_mod modsummary
-  -- liftIO $ queueMessage queue (CMCheckImports modName rendered)
+  rendered <- fetchUnqualifiedImports tc
+  let modName = T.pack $ moduleNameString $ moduleName $ ms_mod modsummary
+  liftIO $ queueMessage queue (CMCheckImports modName rendered)
   pure tc
 
 --

--- a/plugin/src/Plugin/GHCSpecter/Comm.hs
+++ b/plugin/src/Plugin/GHCSpecter/Comm.hs
@@ -1,0 +1,101 @@
+module Plugin.GHCSpecter.Comm
+  ( runMessageQueue,
+    queueMessage,
+  )
+where
+
+import Control.Concurrent (forkIO)
+import Control.Concurrent.STM
+  ( atomically,
+    modifyTVar',
+    readTVar,
+    retry,
+    writeTVar,
+  )
+import Control.Monad (forever, when)
+import Data.Foldable (for_)
+import Data.Foldable qualified as F
+import Data.Sequence ((|>))
+import Data.Sequence qualified as Seq
+import GHC.Driver.Plugins (type CommandLineOption)
+import GHCSpecter.Channel.Inbound.Types
+  ( Request (..),
+    SessionRequest (..),
+  )
+import GHCSpecter.Channel.Outbound.Types
+  ( ChanMessage (..),
+    ChanMessageBox (..),
+    SessionInfo (..),
+  )
+import GHCSpecter.Comm
+  ( receiveObject,
+    runClient,
+    sendObject,
+  )
+import GHCSpecter.Config
+  ( Config (..),
+    defaultGhcSpecterConfigFile,
+    loadConfig,
+  )
+import Network.Socket (Socket)
+import Plugin.GHCSpecter.Types
+  ( MsgQueue (..),
+    PluginSession (..),
+    sessionRef,
+  )
+import System.Directory (doesFileExist)
+
+runMessageQueue :: [CommandLineOption] -> MsgQueue -> IO ()
+runMessageQueue opts queue = do
+  mipcfile <-
+    case opts of
+      ipcfile : _ -> pure (Just ipcfile)
+      [] -> do
+        ecfg <- loadConfig defaultGhcSpecterConfigFile
+        case ecfg of
+          Left _ -> pure Nothing
+          Right cfg -> pure (Just (configSocket cfg))
+  for_ mipcfile $ \ipcfile -> do
+    socketExists <- doesFileExist ipcfile
+    when socketExists $
+      runClient ipcfile $ \sock -> do
+        _ <- forkIO $ receiver sock
+        sender sock
+  where
+    sender :: Socket -> IO ()
+    sender sock = forever $ do
+      msgs <- atomically $ do
+        queued <- readTVar (msgSenderQueue queue)
+        if Seq.null queued
+          then retry
+          else do
+            writeTVar (msgSenderQueue queue) Seq.empty
+            pure queued
+      let msgList = F.toList msgs
+      msgList `seq` sendObject sock msgList
+    receiver :: Socket -> IO ()
+    receiver sock = forever $ do
+      putStrLn "################"
+      putStrLn "receiver started"
+      putStrLn "################"
+      msg :: Request <- receiveObject sock
+      putStrLn "################"
+      putStrLn $ "message received: " ++ show msg
+      putStrLn "################"
+      atomically $
+        case msg of
+          SessionReq sreq ->
+            modifyTVar' sessionRef $ \s ->
+              let isPaused
+                    | sreq == Pause = True
+                    | otherwise = False
+                  sinfo = psSessionInfo s
+                  sinfo' = sinfo {sessionIsPaused = isPaused}
+               in s {psSessionInfo = sinfo'}
+          ConsoleReq drvId' creq ->
+            writeTVar (msgReceiverQueue queue) (Just (drvId', creq))
+
+queueMessage :: MsgQueue -> ChanMessage a -> IO ()
+queueMessage queue !msg =
+  atomically $
+    modifyTVar' (msgSenderQueue queue) (|> CMBox msg)

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -1,0 +1,81 @@
+module Plugin.GHCSpecter.Console
+  ( breakPoint,
+  )
+where
+
+import Control.Concurrent (forkIO, killThread)
+import Control.Concurrent.STM
+  ( atomically,
+    modifyTVar',
+    readTVar,
+    retry,
+    writeTVar,
+  )
+import Control.Concurrent.STM qualified as STM
+import Control.Exception qualified as E
+import Control.Monad (forever, when)
+import Data.Text.IO qualified as TIO
+import GHCSpecter.Channel.Common.Types (DriverId (..))
+import GHCSpecter.Channel.Inbound.Types
+  ( ConsoleRequest (..),
+  )
+import GHCSpecter.Channel.Outbound.Types
+  ( BreakpointLoc (..),
+    ChanMessage (..),
+    SessionInfo (..),
+  )
+import Plugin.GHCSpecter.Comm (queueMessage)
+import Plugin.GHCSpecter.Types
+  ( MsgQueue (..),
+    PluginSession (..),
+    sessionRef,
+  )
+
+breakPoint :: MsgQueue -> DriverId -> BreakpointLoc -> IO ()
+breakPoint queue drvId loc = do
+  tid <- forkIO $ sessionInPause queue drvId loc
+  atomically $ do
+    psess <- readTVar sessionRef
+    let sinfo = psSessionInfo psess
+        isSessionPaused = sessionIsPaused sinfo
+        isDriverInStep = maybe False (== drvId) $ psDriverInStep psess
+    -- block until the session is resumed.
+    STM.check (not isSessionPaused || isDriverInStep)
+    when (isDriverInStep && isSessionPaused) $ do
+      let psess' = psess {psDriverInStep = Nothing}
+      writeTVar sessionRef psess'
+  killThread tid
+
+consoleAction :: MsgQueue -> DriverId -> IO ()
+consoleAction queue drvId = do
+  let rQ = msgReceiverQueue queue
+  req <-
+    atomically $ do
+      mreq <- readTVar rQ
+      case mreq of
+        Nothing -> retry
+        Just (drvId', req) ->
+          if drvId == drvId'
+            then do
+              writeTVar rQ Nothing
+              pure req
+            else retry
+  case req of
+    Ping msg -> do
+      TIO.putStrLn $ "ping: " <> msg
+      let pongMsg = "pong: " <> msg
+      queueMessage queue (CMConsole drvId pongMsg)
+    NextBreakpoint -> do
+      putStrLn "NextBreakpoint"
+      atomically $
+        modifyTVar' sessionRef $ \psess -> psess {psDriverInStep = Just drvId}
+
+sessionInPause :: MsgQueue -> DriverId -> BreakpointLoc -> IO ()
+sessionInPause queue drvId loc = do
+  atomically $ do
+    isPaused <- sessionIsPaused . psSessionInfo <$> readTVar sessionRef
+    -- prodceed when the session is paused.
+    STM.check isPaused
+  queueMessage queue (CMPaused drvId (Just loc))
+  (forever $ consoleAction queue drvId)
+    `E.catch` (\(_e :: E.AsyncException) -> queueMessage queue (CMPaused drvId Nothing))

--- a/plugin/src/Plugin/GHCSpecter/Task/UnqualifiedImports.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/UnqualifiedImports.hs
@@ -1,0 +1,41 @@
+module Plugin.GHCSpecter.Task.UnqualifiedImports
+  ( fetchUnqualifiedImports,
+  )
+where
+
+import Control.Monad.IO.Class (liftIO)
+import Data.IORef (readIORef)
+import Data.List qualified as L
+import Data.Map (Map)
+import Data.Map qualified as M
+import Data.Set (Set)
+import Data.Set qualified as S
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Driver.Session (getDynFlags)
+import GHC.Plugins (Name)
+import GHC.Tc.Types (TcGblEnv (..), TcM)
+import GHC.Types.Name.Reader (GlobalRdrElt (..))
+import GHCSpecter.Channel.Common.Types
+  ( type ModuleName,
+  )
+import Plugin.GHCSpecter.Util
+  ( formatImportedNames,
+    formatName,
+    mkModuleNameMap,
+  )
+
+fetchUnqualifiedImports :: TcGblEnv -> TcM Text
+fetchUnqualifiedImports tc = do
+  dflags <- getDynFlags
+  usedGREs :: [GlobalRdrElt] <- liftIO $ readIORef (tcg_used_gres tc)
+  let moduleImportMap :: Map ModuleName (Set Name)
+      moduleImportMap =
+        L.foldl' (\(!m) (modu, name) -> M.insertWith S.union modu (S.singleton name) m) M.empty $
+          concatMap mkModuleNameMap usedGREs
+      rendered =
+        unlines $ do
+          (modu, names) <- M.toList moduleImportMap
+          let imported = fmap (formatName dflags) $ S.toList names
+          [T.unpack modu, formatImportedNames imported]
+  pure (T.pack rendered)

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -3,6 +3,10 @@ module Plugin.GHCSpecter.Types
     MsgQueue (..),
     initMsgQueue,
 
+    -- * Console state
+    ConsoleState (..),
+    emptyConsoleState,
+
     -- * PluginSession
     PluginSession (..),
     emptyPluginSession,
@@ -38,18 +42,29 @@ initMsgQueue = do
   rQ <- newTVarIO Nothing
   pure $ MsgQueue sQ rQ
 
+newtype ConsoleState = ConsoleState
+  { consoleDriverInStep :: Maybe DriverId
+  -- ^ DriverId in next step operation
+  }
+
+emptyConsoleState :: ConsoleState
+emptyConsoleState = ConsoleState Nothing
+
 data PluginSession = PluginSession
   { psSessionInfo :: SessionInfo
   , psMessageQueue :: Maybe MsgQueue
   , psNextDriverId :: DriverId
-  , psDriverInStep :: Maybe DriverId
-  -- ^ DriverId in next step operation
-  -- TODO: find a better place
+  , psConsoleState :: ConsoleState
   }
 
 emptyPluginSession :: PluginSession
 emptyPluginSession =
-  PluginSession (SessionInfo 0 Nothing emptyModuleGraphInfo False) Nothing 1 Nothing
+  PluginSession
+    { psSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo False
+    , psMessageQueue = Nothing
+    , psNextDriverId = 1
+    , psConsoleState = emptyConsoleState
+    }
 
 -- | Global variable shared across the session
 sessionRef :: TVar PluginSession


### PR DESCRIPTION
On the console from a paused session, depending on the phase the session stop at, users can now run inspection commands allowed on the breakpoint.
As an example, the task fetching unqualified imported symbols is now allowed at Typecheck breakpoint (with the `:unqualified` command).