### PR TITLE
Further style adjustment

### DIFF
--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -20,12 +20,12 @@ nav {
     margin-right: 2px;
     padding: 2px 2px 2px 2px;
     background: white;
-    border: solid 0.5px grey;
 }
 
 .is-tab.is-active {
     padding: 2px 2px 3.1px 2px;
     background: lightskyblue;
+    border: solid 0.5px grey;
     border-bottom: none;
 }
 

--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -5,6 +5,11 @@ body {
     background: white;
 }
 
+.banner {
+    overflow: hidden;
+    text-align: center;
+}
+
 nav {
     margin: 2px 2px 1px 0px;
     padding: 2px 2px 2px 0px;

--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -20,12 +20,12 @@ nav {
     margin-right: 2px;
     padding: 2px 2px 2px 2px;
     background: white;
+    border-left: solid 0.5px grey;
 }
 
 .is-tab.is-active {
     padding: 2px 2px 3.1px 2px;
     background: lightskyblue;
-    border: solid 0.5px grey;
     border-bottom: none;
 }
 

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -2,18 +2,18 @@
 
 module GHCSpecter.Render
   ( render,
-    cssLink,
   )
 where
 
 import Concur.Core (Widget (..))
 import Concur.Replica
-  ( Props,
-    classList,
+  ( classList,
+    height,
     onClick,
     src,
     style,
     textProp,
+    width,
   )
 import Control.Lens (to, (^.))
 import Data.Text (Text)
@@ -25,6 +25,7 @@ import GHCSpecter.Render.ModuleGraph qualified as ModuleGraph
 import GHCSpecter.Render.Session qualified as Session
 import GHCSpecter.Render.SourceView qualified as SourceView
 import GHCSpecter.Render.Timing qualified as Timing
+import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState (..),
@@ -32,10 +33,9 @@ import GHCSpecter.Server.Types
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,
     el,
-    figure,
     img,
-    link,
     nav,
+    p,
     progress,
     section,
     text,
@@ -58,27 +58,21 @@ import GHCSpecter.UI.Types.Event
 import GHCSpecter.Util.Map (keyMapToList)
 import Prelude hiding (div, span)
 
-divClass :: Text -> [Props a] -> [Widget IHTML a] -> Widget IHTML a
-divClass cls props = div (classList [(cls, True)] : props)
-
-renderMainPanel ::
-  MainView ->
-  UIModel ->
-  ServerState ->
-  Widget IHTML Event
-renderMainPanel view model ss =
-  case view ^. mainTab of
-    TabSession -> Session.render ss
-    TabModuleGraph -> ModuleGraph.render model ss
-    TabSourceView -> SourceView.render (model ^. modelSourceView) ss
-    TabTiming -> Timing.render model ss
-
-cssLink :: Text -> Widget IHTML a
-cssLink url =
-  link
-    [ textProp "rel" "stylesheet"
-    , textProp "href" url
-    ]
+renderBanner :: Text -> Double -> Widget IHTML a
+renderBanner png fraction = divClass "banner" [] [contents]
+  where
+    progressBar =
+      progress
+        [ textProp "value" (T.pack $ show $ floor @_ @Int (fraction * 100.0))
+        , textProp "max" "100"
+        ]
+        []
+    contents =
+      div
+        []
+        [ img [src png, width "150px", height "150px"]
+        , div [] [p [] [text "ghc-specter"], p [] [progressBar]]
+        ]
 
 renderNavbar :: Tab -> Widget IHTML Event
 renderNavbar tab =
@@ -102,6 +96,18 @@ renderNavbar tab =
             | otherwise = ["navbar-item", "is-tab"]
           cls = classList $ map (\tag -> (tag, True)) clss
        in el "a" [cls, onClick]
+
+renderMainPanel ::
+  MainView ->
+  UIModel ->
+  ServerState ->
+  Widget IHTML Event
+renderMainPanel view model ss =
+  case view ^. mainTab of
+    TabSession -> Session.render ss
+    TabModuleGraph -> ModuleGraph.render model ss
+    TabSourceView -> SourceView.render (model ^. modelSourceView) ss
+    TabTiming -> Timing.render model ss
 
 renderBottomPanel :: UIModel -> ServerState -> Widget IHTML Event
 renderBottomPanel model ss = div [] (consolePanel ++ [msgCounter])
@@ -157,28 +163,5 @@ render ::
   Widget IHTML Event
 render (ui, ss) =
   case ui ^. uiView of
-    BannerMode v ->
-      div
-        [ classList [("is-fullheight", True)]
-        , style [("overflow", "hidden")]
-        ]
-        [ section
-            []
-            [ div
-                []
-                [ figure
-                    []
-                    [img [src (ui ^. uiAssets . assetsGhcSpecterPng)]]
-                , div
-                    []
-                    [ text "ghc-specter"
-                    , progress
-                        [ textProp "value" (T.pack $ show $ floor @_ @Int (v * 100.0))
-                        , textProp "max" "100"
-                        ]
-                        []
-                    ]
-                ]
-            ]
-        ]
+    BannerMode fraction -> renderBanner (ui ^. uiAssets . assetsGhcSpecterPng) fraction
     MainMode view -> renderMainView (view, ui ^. uiModel, ss)

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -36,7 +36,7 @@ import Prelude hiding (div)
 
 render ::
   (IsKey k, Eq k) =>
-  [k] ->
+  [(k, Text)] ->
   KeyMap k Text ->
   Maybe k ->
   Text ->
@@ -45,7 +45,7 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
   where
     navbarMenu = divClass "navbar-menu" []
     navbarStart = divClass "navbar-start" []
-    navItem k =
+    navItem (k, tab) =
       let isActive = Just k == mfocus
           clss
             | isActive = ["navbar-item", "is-tab", "console-tab", "is-active"]
@@ -54,7 +54,7 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
        in el
             "a"
             [cls, ConsoleTab k <$ onClick]
-            [text (T.pack (show (fromKey k)))]
+            [text tab]
     consoleTabs =
       nav
         [classList [("navbar", True)]]

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -5,8 +5,7 @@ where
 
 import Concur.Core (Widget)
 import Concur.Replica
-  ( Props,
-    classList,
+  ( classList,
     onClick,
     onInput,
     onKeyPress,
@@ -17,6 +16,7 @@ import Concur.Replica.DOM.Events qualified as DE
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,
     el,
@@ -43,8 +43,6 @@ render ::
   Widget IHTML (ConsoleEvent k)
 render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
   where
-    divClass :: Text -> [Props a] -> [Widget IHTML a] -> Widget IHTML a
-    divClass cls props = div (classList [(cls, True)] : props)
     navbarMenu = divClass "navbar-menu" []
     navbarStart = divClass "navbar-start" []
     navItem k =

--- a/daemon/src/GHCSpecter/Render/Components/GraphView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GraphView.hs
@@ -231,7 +231,7 @@ renderGraph cond grVisInfo =
               [ SP.x (T.pack $ show (x + offX))
               , SP.y (T.pack $ show (y + h * offYFactor + h - 6))
               , width (T.pack $ show (w * aFactor))
-              , height "13"
+              , height "10"
               , SP.stroke "dimgray"
               , SP.fill color
               ]

--- a/daemon/src/GHCSpecter/Render/Components/TextView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TextView.hs
@@ -57,32 +57,40 @@ render showCharBox txt highlighted =
         , SP.fill "none"
         ]
         []
-    highlightBox ((startI, startJ), (endI, endJ)) =
+
+    boxSize ((startI, startJ), (endI, endJ)) =
+      let w1 = charSize * fromIntegral (endJ - startJ + 1)
+          h1 = rowSize * fromIntegral (endI - startI + 1)
+       in (w1, h1 + 2)
+
+    highlightBox range@((startI, startJ), _) =
       S.rect
         [ SP.x (packShow $ leftOfBox startJ)
         , SP.y (packShow $ topOfBox startI)
-        , SP.width (packShow (charSize * fromIntegral (endJ - startJ + 1)))
-        , SP.height (packShow (rowSize * fromIntegral (endI - startI + 1)))
+        , SP.width (packShow $ fst (boxSize range))
+        , SP.height (packShow $ snd (boxSize range))
         , SP.fill "yellow"
         ]
         []
-    highlightBox2 ((startI, startJ), (endI, endJ)) =
+    highlightBox2 range@((startI, startJ), _) =
       S.rect
         [ SP.x (packShow $ leftOfBox startJ)
         , SP.y (packShow $ topOfBox startI)
-        , SP.width (packShow (charSize * fromIntegral (endJ - startJ + 1)))
-        , SP.height (packShow (rowSize * fromIntegral (endI - startI + 1)))
+        , SP.width (packShow $ fst (boxSize range))
+        , SP.height (packShow $ snd (boxSize range))
         , SP.stroke "red"
         , SP.strokeWidth "1px"
         , SP.fill "none"
         ]
         []
+
     mkText (i, t) =
       S.text
         [ SP.x (packShow $ leftOfBox 1)
         , SP.y (packShow $ bottomOfBox i)
         ]
         [text t]
+
     contents =
       let contents_ =
             fmap highlightBox highlighted

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -223,7 +223,9 @@ renderDetailLevel :: UIModel -> Widget IHTML Event
 renderDetailLevel model =
   SubModuleEv . SubModuleLevelEv
     <$> div
-      [classList [("control", True)]]
+      [ classList [("control", True)]
+      , style [("position", "absolute"), ("top", "0"), ("right", "0")]
+      ]
       [detail30, detail100, detail300]
   where
     currLevel = model ^. modelSubModuleGraph . _1
@@ -261,13 +263,20 @@ render model ss =
                   clustering
                   grVisInfo
                   (model ^. modelMainModuleGraph)
-              , renderDetailLevel model
-              , renderSubModuleGraph
-                  nameMap
-                  drvModMap
-                  timing
-                  (mgs ^. mgsSubgraph)
-                  (model ^. modelMainModuleGraph, model ^. modelSubModuleGraph)
+              , div
+                  [ style
+                      [ ("width", "100%")
+                      , ("position", "relative")
+                      ]
+                  ]
+                  [ renderDetailLevel model
+                  , renderSubModuleGraph
+                      nameMap
+                      drvModMap
+                      timing
+                      (mgs ^. mgsSubgraph)
+                      (model ^. modelMainModuleGraph, model ^. modelSubModuleGraph)
+                  ]
               ]
         )
   where

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -25,6 +25,7 @@ import GHCSpecter.Channel.Outbound.Types
     Timer,
     getEndTime,
   )
+import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState (..),
@@ -122,7 +123,8 @@ render ss =
                   <> T.pack (show nInProg)
                   <> " / "
                   <> T.pack (show nTot)
-           in div
+           in divClass
+                "box"
                 [ style
                     [ ("height", ss ^. serverSessionInfo . to sessionIsPaused . to widgetHeight)
                     , ("position", "relative")

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -62,7 +62,7 @@ renderSessionButtons session =
     buttonSaveSession =
       button
         [ SessionEv SaveSessionEv <$ onClick
-        , classList [("button is-primary is-size-7 m-1 p-1", True)]
+        , classList [("button", True)]
         ]
         [text "Save Session"]
     buttonPauseResumeSession =
@@ -71,7 +71,7 @@ renderSessionButtons session =
             | otherwise = ("Pause Session", PauseSessionEv)
        in button
             [ SessionEv ev <$ onClick
-            , classList [("button is-primary is-size-7 m-1 p-1", True)]
+            , classList [("button", True)]
             ]
             [text txt]
 

--- a/daemon/src/GHCSpecter/Render/Util.hs
+++ b/daemon/src/GHCSpecter/Render/Util.hs
@@ -1,12 +1,33 @@
 module GHCSpecter.Render.Util
   ( xmlns,
+    divClass,
+    cssLink,
   )
 where
 
+import Concur.Core (Widget)
 import Concur.Replica
   ( Props,
+    classList,
     textProp,
   )
+import Data.Text (Text)
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( div,
+    link,
+  )
+import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import Prelude hiding (div)
 
 xmlns :: Props a
 xmlns = textProp "xmlns" "http://www.w3.org/2000/svg"
+
+divClass :: Text -> [Props a] -> [Widget IHTML a] -> Widget IHTML a
+divClass cls props = div (classList [(cls, True)] : props)
+
+cssLink :: Text -> Widget IHTML a
+cssLink url =
+  link
+    [ textProp "rel" "stylesheet"
+    , textProp "href" url
+    ]

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -57,9 +57,7 @@ emptySourceViewUI :: SourceViewUI
 emptySourceViewUI = SourceViewUI Nothing
 
 data TimingUI = TimingUI
-  { _timingUISticky :: Bool
-  -- ^ Whether the timing view is sticky to the current time or not
-  , _timingUIPartition :: Bool
+  { _timingUIPartition :: Bool
   -- ^ Whether each module timing is partitioned into division
   , _timingUIHowParallel :: Bool
   -- ^ Whether showing color-coded parallel processes
@@ -71,7 +69,7 @@ data TimingUI = TimingUI
 makeClassy ''TimingUI
 
 emptyTimingUI :: TimingUI
-emptyTimingUI = TimingUI False False False (0, 0) False
+emptyTimingUI = TimingUI False False (0, 0) False
 
 data ConsoleUI = ConsoleUI
   { _consoleFocus :: Maybe DriverId

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -53,7 +53,7 @@ data SessionEvent
   deriving (Show, Eq)
 
 data TimingEvent
-  = UpdateSticky Bool
+  = ToCurrentTime
   | UpdatePartition Bool
   | UpdateParallel Bool
   deriving (Show, Eq)


### PR DESCRIPTION
"Sticky" checkbox is replaced by "To Current Time" button (i.e. not staying stick to the current time, but move to the current time viewport window as the button is pressed)
Console tabs now show module names. 
I made a few more minor style adjustments. 
