### PR TITLE
Breakpoint at Core2Core transformation

### DIFF
--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -14,6 +14,8 @@ nav {
     margin: 2px 2px 1px 0px;
     padding: 2px 2px 2px 0px;
     border-bottom: solid 0.5px grey;
+    white-space: nowrap;
+    overflow-x: scroll;
 }
 
 .is-tab {

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -217,6 +217,8 @@ goCommon ev (view, model0) = do
                       sendRequest $ ConsoleReq drvId NextBreakpoint
                   | msg == ":unqualified" ->
                       sendRequest $ ConsoleReq drvId ShowUnqualifiedImports
+                  | msg == ":print-core" ->
+                      sendRequest $ ConsoleReq drvId PrintCore
                   | otherwise ->
                       sendRequest $ ConsoleReq drvId (Ping msg)
               pure model

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -78,7 +78,7 @@ renderBanner png fraction = divClass "banner" [] [contents]
 renderNavbar :: Tab -> Widget IHTML Event
 renderNavbar tab =
   nav
-    [classList [("navbar m-0 p-0", True)]]
+    [classList [("navbar", True)]]
     [ navbarMenu
         [ navbarStart
             [ TabEv TabSession <$ navItem (tab == TabSession) [text "Session"]

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -15,7 +15,6 @@ import Concur.Replica
 import Concur.Replica.DOM.Events qualified as DE
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
-import Data.Text qualified as T
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -29,6 +29,7 @@ data ConsoleRequest
   = Ping Text
   | NextBreakpoint
   | ShowUnqualifiedImports
+  | PrintCore
   deriving (Eq, Ord, Show, Generic)
 
 instance Binary ConsoleRequest

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -53,6 +53,7 @@ data BreakpointLoc
   = StartDriver
   | AfterParser
   | Typecheck
+  | Core2Core Text
   | PreRunPhase Text
   | PostRunPhase Text
   deriving (Show, Eq, Generic)

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -19,8 +19,10 @@ import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (for_)
 import Data.IORef (IORef, newIORef, writeIORef)
+import Data.List qualified as L
 import Data.Text qualified as T
 import Data.Time.Clock (UTCTime, getCurrentTime)
+import GHC.Core.Opt.Monad (CoreM, CoreToDo (..), getDynFlags)
 import GHC.Driver.Env (Hsc, HscEnv (..))
 import GHC.Driver.Flags (GeneralFlag (Opt_WriteHie))
 import GHC.Driver.Hooks (runPhaseHook)
@@ -62,7 +64,7 @@ import GHCSpecter.Channel.Outbound.Types
     Timer (..),
     TimerTag (..),
   )
-import GHCSpecter.Util.GHC (showPpr)
+import GHCSpecter.Util.GHC (printPpr, showPpr)
 import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
 import Plugin.GHCSpecter.Console
   ( CommandSet (..),
@@ -212,6 +214,26 @@ typecheckPlugin queue drvId modsummary tc = do
   pure tc
 
 --
+-- core plugin
+--
+
+corePlugin :: [CoreToDo] -> CoreM [CoreToDo]
+corePlugin todos = do
+  dflags <- getDynFlags
+  let n = length todos
+  liftIO $ putStrLn $ "corePlugin n = " <> show n
+  liftIO $ printPpr dflags todos
+  let printMe pass guts = do
+        liftIO $ putStrLn pass
+        pure guts
+      firstPlugin = CoreDoPluginPass "CoreStart" (printMe "CoreStart")
+      mkPlugin pass =
+        let label = "After:" <> show pass
+         in CoreDoPluginPass label (printMe label)
+      todos' = firstPlugin : concatMap (\todo -> [todo, mkPlugin (showPpr dflags todo)]) todos
+  pure todos'
+
+--
 -- top-level driver plugin
 --
 
@@ -228,7 +250,8 @@ driver opts env0 = do
       -- TODO: if other plugins exist, throw exception.
       newPlugin =
         plugin
-          { parsedResultAction = \_opts -> parsedResultActionPlugin queue drvId modNameRef
+          { installCoreToDos = \_opts -> corePlugin
+          , parsedResultAction = \_opts -> parsedResultActionPlugin queue drvId modNameRef
           , typeCheckResultAction = \_opts -> typecheckPlugin queue drvId
           }
       env = env0 {hsc_static_plugins = [StaticPlugin (PluginWithArgs newPlugin opts)]}

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -71,6 +71,7 @@ import Plugin.GHCSpecter.Console
     breakPoint,
     emptyCommandSet,
   )
+import Plugin.GHCSpecter.Task.PrintCore (printCore)
 import Plugin.GHCSpecter.Task.UnqualifiedImports (fetchUnqualifiedImports)
 import Plugin.GHCSpecter.Types
   ( MsgQueue (..),
@@ -230,8 +231,10 @@ corePlugin queue drvId todos = do
       todos' = startPlugin : concatMap (\todo -> [todo, mkPlugin (showPpr dflags todo)]) todos
   pure todos'
   where
+    cmdSet guts = CommandSet [(":print-core", printCore guts)]
+
     eachPlugin pass guts = do
-      breakPoint queue drvId (Core2Core pass) emptyCommandSet
+      breakPoint queue drvId (Core2Core pass) (cmdSet guts)
       pure guts
 
 --

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -94,10 +94,28 @@ consoleAction queue drvId loc cmds actionRef = liftIO $ do
                     liftIO $ consoleMessage txt
               atomically $
                 writeTVar actionRef (Just action)
-            Nothing -> consoleMessage "show unqualified imports not implemented"
+            Nothing ->
+              consoleMessage $
+                "cannot show unqualified imports at the breakpoint: " <> T.pack (show loc)
         else do
           consoleMessage $
             "cannot show unqualified imports at the breakpoint: " <> T.pack (show loc)
+    PrintCore ->
+      case loc of
+        Core2Core _ -> do
+          case L.lookup ":print-core" (unCommandSet cmds) of
+            Just cmd -> do
+              let action = do
+                    txt <- cmd
+                    liftIO $ consoleMessage txt
+              atomically $
+                writeTVar actionRef (Just action)
+            Nothing ->
+              consoleMessage $
+                "cannot print core at the breakpoint: " <> T.pack (show loc)
+        _ ->
+          consoleMessage $
+            "cannot print core at the breakpoint: " <> T.pack (show loc)
   where
     consoleMessage = queueMessage queue . CMConsole drvId
 

--- a/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
@@ -1,0 +1,16 @@
+module Plugin.GHCSpecter.Task.PrintCore
+  ( printCore,
+  )
+where
+
+import Data.Text (Text)
+import Data.Text qualified as T
+import GHC.Core.Opt.Monad (CoreM, getDynFlags)
+import GHC.Unit.Module.ModGuts (ModGuts (..))
+import GHCSpecter.Util.GHC (showPpr)
+
+printCore :: ModGuts -> CoreM Text
+printCore guts = do
+  dflags <- getDynFlags
+  let txt = T.pack $ showPpr dflags (mg_binds guts)
+  pure txt


### PR DESCRIPTION
Introduced new CorePlugin that inserts breakpoints before and after every core-to-core transformation.
At the breakpoint, users can inspect the current Core expression of the module under the inspection from the console.