### PR TITLE
Automatic scroll-down console when new entry comes

### DIFF
--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -6,7 +6,6 @@ where
 import Concur.Core (Widget)
 import Concur.Replica
   ( classList,
-    id,
     onClick,
     onInput,
     onKeyPress,
@@ -33,7 +32,7 @@ import GHCSpecter.Util.Map
     KeyMap,
     lookupKey,
   )
-import Prelude hiding (div, id)
+import Prelude hiding (div)
 
 render ::
   (IsKey k, Eq k) =>
@@ -82,8 +81,7 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
                   \observer.observe(myParent, config);\n"
               ]
        in pre
-            [ id "console"
-            , style
+            [ style
                 [ ("height", "200px")
                 , ("overflow", "scroll")
                 ]

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -6,6 +6,7 @@ where
 import Concur.Core (Widget)
 import Concur.Replica
   ( classList,
+    id,
     onClick,
     onInput,
     onKeyPress,
@@ -22,6 +23,7 @@ import GHCSpecter.UI.ConcurReplica.DOM
     input,
     nav,
     pre,
+    script,
     text,
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
@@ -31,7 +33,7 @@ import GHCSpecter.Util.Map
     KeyMap,
     lookupKey,
   )
-import Prelude hiding (div)
+import Prelude hiding (div, id)
 
 render ::
   (IsKey k, Eq k) =>
@@ -62,13 +64,33 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
       let mtxt = do
             focus <- mfocus
             lookupKey focus contents
+
+          -- This is a hack. Property update should be supported by concur-replica.
+          -- TODO: implement prop update in internalized concur-replica.
+          scriptContent =
+            script
+              []
+              [ text
+                  "var me = document.currentScript;\n\
+                  \var myParent = me.parentElement;\n\
+                  \console.log(myParent);\n\
+                  \var config = {attirbutes: true, childList: true, subtree: true, characterData: true };\n\
+                  \var callback = (mutationList, observer) => {\n\
+                  \      myParent.scrollTop = myParent.scrollHeight;\n\
+                  \    };\n\
+                  \var observer = new MutationObserver(callback);\n\
+                  \observer.observe(myParent, config);\n"
+              ]
        in pre
-            [ style
+            [ id "console"
+            , style
                 [ ("height", "200px")
                 , ("overflow", "scroll")
                 ]
             ]
-            [text (fromMaybe "" mtxt)]
+            [ scriptContent
+            , text (fromMaybe "" mtxt)
+            ]
     consoleInput =
       divClass
         "console-input"
@@ -82,8 +104,4 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
             , textProp "value" inputEntry
             ]
         ]
-    console =
-      divClass
-        "console"
-        []
-        [consoleContent, consoleInput]
+    console = divClass "console" [] [consoleContent, consoleInput]

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -19,7 +19,6 @@ import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (for_)
 import Data.IORef (IORef, newIORef, writeIORef)
-import Data.List qualified as L
 import Data.Text qualified as T
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import GHC.Core.Opt.Monad (CoreM, CoreToDo (..), getDynFlags)
@@ -64,7 +63,7 @@ import GHCSpecter.Channel.Outbound.Types
     Timer (..),
     TimerTag (..),
   )
-import GHCSpecter.Util.GHC (printPpr, showPpr)
+import GHCSpecter.Util.GHC (showPpr)
 import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
 import Plugin.GHCSpecter.Console
   ( CommandSet (..),


### PR DESCRIPTION
Console is scrolled down to the end of a new content. 
Unfortunately, this cannot be easily done via concur-replica as it does not support property update via VDOM.
So the solution is rather hacky using direct <script> insertion into the console element. We will revisit this when a proper solution by modifying concur-replica is implemented.