### PR TITLE
Send structural Core data, not pretty-printed text

### DIFF
--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -5,6 +5,17 @@ body {
     background: white;
 }
 
+button {
+    font-size: 10px;
+    padding: 2px;
+    border: solid 0.5px grey;
+    background: white;
+}
+
+button:hover {
+    background: lightgrey;
+}
+
 .banner {
     overflow: hidden;
     text-align: center;
@@ -75,11 +86,31 @@ nav {
 .console {
     margin: 0;
     padding: 2px 0 0 0;
+    background-color: white;
+    color: black;
 }
 
-.console pre {
+.console-item {
+    margin: 0;
+    padding: 2px 0 2px 0;
+    border-bottom: solid 0.3px lightgrey;
+    display: block;
+}
+
+.console-item > div {
+    margin: 0 5px;
+    padding: 0;
+    font-size: 8px;
+    font-family: monospace;
+    display: inline-block;
+    vertical-align: top;
+}
+
+.console-item > pre {
     margin: 0;
     padding: 0;
+    font-size: 8px;
+    display: inline-block;
 }
 
 .console-input {
@@ -93,12 +124,6 @@ nav {
     font-family: monospace;
     font-size: 10px;
     width: 100%;
-}
-
-.console pre {
-    background-color: white;
-    color: black;
-    font-size: 10px;
 }
 
 .expandable {

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -17,6 +17,7 @@ import Control.Lens ((%~), (.~), (^.))
 import Control.Monad (forever, void)
 import Data.Foldable qualified as F
 import Data.Map.Strict qualified as M
+import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import GHCSpecter.Channel.Common.Types (DriverId (..))
@@ -53,8 +54,9 @@ import GHCSpecter.Worker.ModuleGraph (moduleGraphWorker)
 updateInbox :: ChanMessageBox -> ServerState -> ServerState
 updateInbox chanMsg = incrementSN . updater
   where
-    appendConsoleMsg newMsg Nothing = Just newMsg
-    appendConsoleMsg newMsg (Just prevMsgs) = Just (prevMsgs <> "\n" <> newMsg)
+    appendConsoleMsg :: Text -> Maybe [Text] -> Maybe [Text]
+    appendConsoleMsg newMsg Nothing = Just [newMsg]
+    appendConsoleMsg newMsg (Just prevMsgs) = Just (prevMsgs ++ [newMsg])
 
     updater = case chanMsg of
       CMBox (CMCheckImports modu msg) ->

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -13,9 +13,9 @@ import Concur.Replica
     textProp,
   )
 import Concur.Replica.DOM.Events qualified as DE
-import Data.Maybe (fromMaybe)
+import Control.Monad (join)
+import Data.Maybe (maybeToList)
 import Data.Text (Text)
-import Data.Text qualified as T
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,
@@ -62,6 +62,13 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
         [navbarMenu [navbarStart (fmap navItem tabs)]]
     consoleContent =
       let mtxts = mfocus >>= (`lookupKey` contents)
+          makeConsoleItem txt =
+            divClass
+              "console-item"
+              []
+              [ div [style [("width", "10px")]] [text "<"]
+              , pre [] [text txt]
+              ]
 
           -- This is a hack. Property update should be supported by concur-replica.
           -- TODO: implement prop update in internalized concur-replica.
@@ -79,16 +86,14 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
                   \var observer = new MutationObserver(callback);\n\
                   \observer.observe(myParent, config);\n"
               ]
-       in pre
+       in div
             [ classList [("box", True)]
             , style
                 [ ("height", "200px")
                 , ("overflow", "scroll")
                 ]
             ]
-            [ scriptContent
-            , text (maybe "" (T.intercalate "\n") mtxts)
-            ]
+            (scriptContent : fmap makeConsoleItem (join (maybeToList mtxts)))
     consoleInput =
       divClass
         "console-input"

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -15,6 +15,7 @@ import Concur.Replica
 import Concur.Replica.DOM.Events qualified as DE
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
+import Data.Text qualified as T
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,
@@ -37,7 +38,7 @@ import Prelude hiding (div)
 render ::
   (IsKey k, Eq k) =>
   [(k, Text)] ->
-  KeyMap k Text ->
+  KeyMap k [Text] ->
   Maybe k ->
   Text ->
   Widget IHTML (ConsoleEvent k)
@@ -60,9 +61,7 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
         [classList [("navbar", True)]]
         [navbarMenu [navbarStart (fmap navItem tabs)]]
     consoleContent =
-      let mtxt = do
-            focus <- mfocus
-            lookupKey focus contents
+      let mtxts = mfocus >>= (`lookupKey` contents)
 
           -- This is a hack. Property update should be supported by concur-replica.
           -- TODO: implement prop update in internalized concur-replica.
@@ -81,13 +80,14 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
                   \observer.observe(myParent, config);\n"
               ]
        in pre
-            [ style
+            [ classList [("box", True)]
+            , style
                 [ ("height", "200px")
                 , ("overflow", "scroll")
                 ]
             ]
             [ scriptContent
-            , text (fromMaybe "" mtxt)
+            , text (maybe "" (T.intercalate "\n") mtxts)
             ]
     consoleInput =
       divClass

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -169,7 +169,7 @@ data ServerState = ServerState
   , _serverDriverModuleMap :: BiKeyMap DriverId ModuleName
   , _serverTiming :: KeyMap DriverId Timer
   , _serverPaused :: KeyMap DriverId BreakpointLoc
-  , _serverConsole :: KeyMap DriverId Text
+  , _serverConsole :: KeyMap DriverId [Text]
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   }

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -26,11 +26,11 @@ where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Binary (Binary (..))
 import Data.Binary.Instances.Time ()
-import Data.Tree (Forest)
 import Data.IntMap (IntMap)
 import Data.List qualified as L
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
+import Data.Tree (Forest)
 import GHC.Generics (Generic)
 import GHCSpecter.Channel.Common.Types
   ( DriverId (..),

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -25,6 +25,7 @@ where
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Binary (Binary (..))
 import Data.Binary.Instances.Time ()
+import Data.Tree (Forest)
 import Data.IntMap (IntMap)
 import Data.List qualified as L
 import Data.Text (Text)
@@ -145,6 +146,10 @@ instance FromJSON HsSourceInfo
 
 instance ToJSON HsSourceInfo
 
+data ConsoleReply
+  = ConsoleReplyText Text
+  | ConsoleReplyCore (Forest (Text, Text))
+
 data ChanMessage (a :: Channel) where
   CMCheckImports :: ModuleName -> Text -> ChanMessage 'CheckImports
   CMModuleInfo :: DriverId -> ModuleName -> ChanMessage 'ModuleInfo
@@ -152,7 +157,7 @@ data ChanMessage (a :: Channel) where
   CMSession :: SessionInfo -> ChanMessage 'Session
   CMHsSource :: DriverId -> HsSourceInfo -> ChanMessage 'HsSource
   CMPaused :: DriverId -> Maybe BreakpointLoc -> ChanMessage 'Paused
-  CMConsole :: DriverId -> Text -> ChanMessage 'Console
+  CMConsole :: DriverId -> Text {- ConsoleReply -} -> ChanMessage 'Console
 
 data ChanMessageBox = forall (a :: Channel). CMBox !(ChanMessage a)
 

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -233,6 +233,7 @@ corePlugin queue drvId todos = do
     cmdSet guts = CommandSet [(":print-core", printCore guts)]
 
     eachPlugin pass guts = do
+      _ <- printCore guts
       breakPoint queue drvId (Core2Core pass) (cmdSet guts)
       pure guts
 

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -45,12 +45,9 @@ import GHC.Driver.Session
     gopt,
   )
 import GHC.Hs (HsParsedModule)
-import GHC.Plugins (ModSummary)
 import GHC.Tc.Types (TcGblEnv (..), TcM)
 import GHC.Unit.Module.Location (ModLocation (ml_hie_file))
 import GHC.Unit.Module.ModSummary (ModSummary (..))
-import GHC.Unit.Module.Name (moduleNameString)
-import GHC.Unit.Types (GenModule (moduleName))
 import GHCSpecter.Channel.Common.Types
   ( DriverId (..),
     type ModuleName,
@@ -205,12 +202,9 @@ typecheckPlugin ::
   ModSummary ->
   TcGblEnv ->
   TcM TcGblEnv
-typecheckPlugin queue drvId modsummary tc = do
+typecheckPlugin queue drvId _modsummary tc = do
   let cmdSet = CommandSet [(":unqualified", fetchUnqualifiedImports tc)]
   breakPoint queue drvId Typecheck cmdSet
-  -- rendered <- fetchUnqualifiedImports tc
-  -- let modName = T.pack $ moduleNameString $ moduleName $ ms_mod modsummary
-  -- liftIO $ queueMessage queue (CMCheckImports modName rendered)
   pure tc
 
 --

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -208,9 +208,9 @@ typecheckPlugin ::
 typecheckPlugin queue drvId modsummary tc = do
   let cmdSet = CommandSet [(":unqualified", fetchUnqualifiedImports tc)]
   breakPoint queue drvId Typecheck cmdSet
-  rendered <- fetchUnqualifiedImports tc
-  let modName = T.pack $ moduleNameString $ moduleName $ ms_mod modsummary
-  liftIO $ queueMessage queue (CMCheckImports modName rendered)
+  -- rendered <- fetchUnqualifiedImports tc
+  -- let modName = T.pack $ moduleNameString $ moduleName $ ms_mod modsummary
+  -- liftIO $ queueMessage queue (CMCheckImports modName rendered)
   pure tc
 
 --

--- a/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
@@ -39,7 +39,13 @@ getOccNameDynamically _ x =
       my = cast x
    in fmap (T.pack . occNameString . getOccName) my
 
--- | Left: ordinary node, Right: short-circuit to terminal
+-- NOTE: a few data types used in Core has partial toConstr (Data.ByteString.ByteString)
+-- or abstractConstr, which causes an exception or not inspectable expression
+-- after conversion.
+-- Many of them contain stringy information (usually name), so we extract the names
+-- in such cases and do not proceed the conversion to the children of the node.
+
+-- | Left: ordinary node, Right: extract and do not proceed to the children
 getContent :: forall a. Data a => a -> (Text, Either Text (Maybe Text))
 getContent x = (T.pack dtypName, evalue)
   where

--- a/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
@@ -3,14 +3,43 @@ module Plugin.GHCSpecter.Task.PrintCore
   )
 where
 
+import Control.Concurrent (threadDelay)
+import Control.Monad.IO.Class (liftIO)
+import Data.ByteString (ByteString)
+import Data.ByteString.Internal (packBytes)
+import Data.Data (Data (..), dataTypeName, isNorepType, mkNoRepType)
+import Data.Foldable (for_)
+import Data.Functor.Const (Const (..))
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Tree (Tree (..), drawForest)
 import GHC.Core.Opt.Monad (CoreM, getDynFlags)
 import GHC.Unit.Module.ModGuts (ModGuts (..))
-import GHCSpecter.Util.GHC (showPpr)
+import GHCSpecter.Util.GHC (printPpr, showPpr)
+
+gshow :: forall a. Data a => a -> Const [Tree String] a
+gshow = gfoldl k mkEmpty
+  where
+    mkEmpty _ = Const []
+    k (Const acc) x =
+      let dtyp = dataTypeOf x
+          trs = [Node (dataTypeName dtyp) (getConst (gshow x))]
+          --  | isNorepType dtyp = [Node (dataTypeName dtyp) []]
+          --   | otherwise = [Node (dataTypeName dtyp) (getConst (gshow x))]
+          acc' = acc ++ trs
+       in Const acc'
 
 printCore :: ModGuts -> CoreM Text
 printCore guts = do
   dflags <- getDynFlags
-  let txt = T.pack $ showPpr dflags (mg_binds guts)
+  let binds = mg_binds guts
+      txt = T.pack $ showPpr dflags binds
+  case binds of
+    [] -> pure ()
+    (b : _) -> liftIO $ do
+      -- for_ binds $ \b -> do
+      printPpr dflags b
+      putStrLn "========="
+      putStrLn $ drawForest (getConst (gshow b))
+      threadDelay 10_000_000
   pure txt

--- a/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
@@ -6,40 +6,61 @@ where
 import Control.Concurrent (threadDelay)
 import Control.Monad.IO.Class (liftIO)
 import Data.ByteString (ByteString)
+import Data.ByteString.Char8 qualified as B
 import Data.ByteString.Internal (packBytes)
-import Data.Data (Data (..), dataTypeName, isNorepType, mkNoRepType)
+import Data.Data (Data (..), cast, dataTypeName, isNorepType, mkNoRepType)
 import Data.Foldable (for_)
 import Data.Functor.Const (Const (..))
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.Encoding (decodeUtf8)
 import Data.Tree (Tree (..), drawForest)
 import GHC.Core.Opt.Monad (CoreM, getDynFlags)
+import GHC.Core.TyCon (TyCon)
+import GHC.Types.Name (NamedThing (getOccName))
+import GHC.Types.Name.Occurrence (occNameString)
+import GHC.Types.Var (Var)
 import GHC.Unit.Module.ModGuts (ModGuts (..))
 import GHCSpecter.Util.GHC (printPpr, showPpr)
 
-gshow :: forall a. Data a => a -> Const [Tree String] a
-gshow = gfoldl k mkEmpty
+core2tree :: forall a. Data a => a -> Const [Tree (Text, Text)] a
+core2tree = gfoldl k mkEmpty
   where
     mkEmpty _ = Const []
     k (Const acc) x =
       let dtyp = dataTypeOf x
-          trs = [Node (dataTypeName dtyp) (getConst (gshow x))]
-          --  | isNorepType dtyp = [Node (dataTypeName dtyp) []]
-          --   | otherwise = [Node (dataTypeName dtyp) (getConst (gshow x))]
-          acc' = acc ++ trs
-       in Const acc'
+          dtypName = dataTypeName dtyp
+          trs
+            | dtypName == "Data.ByteString.ByteString" =
+                let mbs = cast x
+                    content = maybe "#######" decodeUtf8 mbs
+                    info = (T.pack dtypName, content)
+                 in [Node info []]
+            | dtypName == "Var" =
+                let mvar :: Maybe Var
+                    mvar = cast x
+                    content = maybe "#######" (T.pack . occNameString . getOccName) mvar
+                    info = (T.pack dtypName, content)
+                 in [Node info []]
+            | dtypName == "TyCon" =
+                let mtyc :: Maybe TyCon
+                    mtyc = cast x
+                    content = maybe "#######" (T.pack . occNameString . getOccName) mtyc
+                    info = (T.pack dtypName, content)
+                 in [Node info []]
+            | otherwise =
+                let info = (T.pack dtypName, T.pack (show (toConstr x)))
+                 in [Node info (getConst (core2tree x))]
+       in Const (acc ++ trs)
 
 printCore :: ModGuts -> CoreM Text
 printCore guts = do
   dflags <- getDynFlags
   let binds = mg_binds guts
       txt = T.pack $ showPpr dflags binds
-  case binds of
-    [] -> pure ()
-    (b : _) -> liftIO $ do
-      -- for_ binds $ \b -> do
+  liftIO $ do
+    for_ binds $ \b -> do
       printPpr dflags b
       putStrLn "========="
-      putStrLn $ drawForest (getConst (gshow b))
-      threadDelay 10_000_000
+      putStrLn $ drawForest (fmap (fmap show) $ getConst (core2tree b))
   pure txt

--- a/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
@@ -3,64 +3,58 @@ module Plugin.GHCSpecter.Task.PrintCore
   )
 where
 
-import Control.Concurrent (threadDelay)
-import Control.Monad.IO.Class (liftIO)
-import Data.ByteString (ByteString)
-import Data.ByteString.Char8 qualified as B
-import Data.ByteString.Internal (packBytes)
-import Data.Data (Data (..), cast, dataTypeName, isNorepType, mkNoRepType)
-import Data.Foldable (for_)
+import Data.Data (Data (..), cast, dataTypeName)
 import Data.Functor.Const (Const (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
-import Data.Tree (Tree (..), drawForest)
+import Data.Tree (Tree (..))
 import GHC.Core.Opt.Monad (CoreM, getDynFlags)
 import GHC.Core.TyCon (TyCon)
 import GHC.Types.Name (NamedThing (getOccName))
 import GHC.Types.Name.Occurrence (occNameString)
 import GHC.Types.Var (Var)
 import GHC.Unit.Module.ModGuts (ModGuts (..))
-import GHCSpecter.Util.GHC (printPpr, showPpr)
+import GHCSpecter.Channel.Outbound.Types (ConsoleReply (..))
+
+import Control.Monad.IO.Class
+import Data.Tree
+
+-- | Left: ordinary node, Right: short-circuit to terminal
+getContent :: forall a. Data a => a -> (Text, Either Text (Maybe Text))
+getContent x = (T.pack dtypName, evalue)
+  where
+    dtyp = dataTypeOf x
+    dtypName = dataTypeName dtyp
+    evalue
+      | dtypName == "Data.ByteString.ByteString" =
+          let mbs = cast x
+           in Right (fmap decodeUtf8 mbs)
+      | dtypName == "Var" =
+          let mvar :: Maybe Var
+              mvar = cast x
+           in Right (fmap (T.pack . occNameString . getOccName) mvar)
+      | dtypName == "TyCon" =
+          let mtyc :: Maybe TyCon
+              mtyc = cast x
+           in Right (fmap (T.pack . occNameString . getOccName) mtyc)
+      | otherwise = Left (T.pack (show (toConstr x)))
 
 core2tree :: forall a. Data a => a -> Const [Tree (Text, Text)] a
 core2tree = gfoldl k mkEmpty
   where
     mkEmpty _ = Const []
     k (Const acc) x =
-      let dtyp = dataTypeOf x
-          dtypName = dataTypeName dtyp
-          trs
-            | dtypName == "Data.ByteString.ByteString" =
-                let mbs = cast x
-                    content = maybe "#######" decodeUtf8 mbs
-                    info = (T.pack dtypName, content)
-                 in [Node info []]
-            | dtypName == "Var" =
-                let mvar :: Maybe Var
-                    mvar = cast x
-                    content = maybe "#######" (T.pack . occNameString . getOccName) mvar
-                    info = (T.pack dtypName, content)
-                 in [Node info []]
-            | dtypName == "TyCon" =
-                let mtyc :: Maybe TyCon
-                    mtyc = cast x
-                    content = maybe "#######" (T.pack . occNameString . getOccName) mtyc
-                    info = (T.pack dtypName, content)
-                 in [Node info []]
-            | otherwise =
-                let info = (T.pack dtypName, T.pack (show (toConstr x)))
-                 in [Node info (getConst (core2tree x))]
-       in Const (acc ++ trs)
+      let delta =
+            case getContent x of
+              (typ, Left val) -> [Node (typ, val) (getConst (core2tree x))]
+              (typ, Right (Just val)) -> [Node (typ, val) []]
+              (typ, Right Nothing) -> [Node (typ, "#######") []]
+       in Const (acc ++ delta)
 
-printCore :: ModGuts -> CoreM Text
+printCore :: ModGuts -> CoreM ConsoleReply
 printCore guts = do
-  dflags <- getDynFlags
   let binds = mg_binds guts
-      txt = T.pack $ showPpr dflags binds
-  liftIO $ do
-    for_ binds $ \b -> do
-      printPpr dflags b
-      putStrLn "========="
-      putStrLn $ drawForest (fmap (fmap show) $ getConst (core2tree b))
-  pure txt
+      forest = getConst (core2tree binds)
+  -- liftIO $ putStrLn $ drawForest . fmap (fmap show) $ forest
+  pure (ConsoleReplyCore forest)

--- a/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
@@ -3,12 +3,16 @@ module Plugin.GHCSpecter.Task.PrintCore
   )
 where
 
+import Control.Monad.IO.Class
 import Data.Data (Data (..), cast, dataTypeName)
 import Data.Functor.Const (Const (..))
+import Data.Proxy (Proxy (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Encoding (decodeUtf8)
+import Data.Tree
 import Data.Tree (Tree (..))
+import Data.Typeable (Typeable)
 import GHC.Core.Opt.Monad (CoreM, getDynFlags)
 import GHC.Core.TyCon (TyCon)
 import GHC.Types.Name (NamedThing (getOccName))
@@ -17,8 +21,16 @@ import GHC.Types.Var (Var)
 import GHC.Unit.Module.ModGuts (ModGuts (..))
 import GHCSpecter.Channel.Outbound.Types (ConsoleReply (..))
 
-import Control.Monad.IO.Class
-import Data.Tree
+getOccNameDynamically ::
+  forall t a.
+  (Typeable t, NamedThing t, Data a) =>
+  Proxy t ->
+  a ->
+  Maybe Text
+getOccNameDynamically _ x =
+  let my :: Maybe t
+      my = cast x
+   in fmap (T.pack . occNameString . getOccName) my
 
 -- | Left: ordinary node, Right: short-circuit to terminal
 getContent :: forall a. Data a => a -> (Text, Either Text (Maybe Text))
@@ -30,14 +42,8 @@ getContent x = (T.pack dtypName, evalue)
       | dtypName == "Data.ByteString.ByteString" =
           let mbs = cast x
            in Right (fmap decodeUtf8 mbs)
-      | dtypName == "Var" =
-          let mvar :: Maybe Var
-              mvar = cast x
-           in Right (fmap (T.pack . occNameString . getOccName) mvar)
-      | dtypName == "TyCon" =
-          let mtyc :: Maybe TyCon
-              mtyc = cast x
-           in Right (fmap (T.pack . occNameString . getOccName) mtyc)
+      | dtypName == "Var" = Right $ getOccNameDynamically (Proxy @Var) x
+      | dtypName == "TyCon" = Right $ getOccNameDynamically (Proxy @TyCon) x
       | otherwise = Left (T.pack (show (toConstr x)))
 
 core2tree :: forall a. Data a => a -> Const [Tree (Text, Text)] a

--- a/plugin/src/Plugin/GHCSpecter/Task/UnqualifiedImports.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/UnqualifiedImports.hs
@@ -19,13 +19,14 @@ import GHC.Types.Name.Reader (GlobalRdrElt (..))
 import GHCSpecter.Channel.Common.Types
   ( type ModuleName,
   )
+import GHCSpecter.Channel.Outbound.Types (ConsoleReply (..))
 import Plugin.GHCSpecter.Util
   ( formatImportedNames,
     formatName,
     mkModuleNameMap,
   )
 
-fetchUnqualifiedImports :: TcGblEnv -> TcM Text
+fetchUnqualifiedImports :: TcGblEnv -> TcM ConsoleReply
 fetchUnqualifiedImports tc = do
   dflags <- getDynFlags
   usedGREs :: [GlobalRdrElt] <- liftIO $ readIORef (tcg_used_gres tc)
@@ -38,4 +39,4 @@ fetchUnqualifiedImports tc = do
           (modu, names) <- M.toList moduleImportMap
           let imported = fmap (formatName dflags) $ S.toList names
           [T.unpack modu, formatImportedNames imported]
-  pure (T.pack rendered)
+  pure (ConsoleReplyText (T.pack rendered))


### PR DESCRIPTION
For semantic formatting on the web frontend side, Core data is converted to Tree using Data.Data, serialized and sent. Console shows the tree in drawForest format.