### PR TITLE
Bug fix in core2tree

### DIFF
--- a/plugin/src/Plugin/GHCSpecter/Task/UnqualifiedImports.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/UnqualifiedImports.hs
@@ -10,7 +10,6 @@ import Data.Map (Map)
 import Data.Map qualified as M
 import Data.Set (Set)
 import Data.Set qualified as S
-import Data.Text (Text)
 import Data.Text qualified as T
 import GHC.Driver.Session (getDynFlags)
 import GHC.Plugins (Name)


### PR DESCRIPTION
`gfoldl` iterates over arguments, not including the constructor itself. Constructor should be handled at the top level before applying `gfoldl`.