### PR TITLE
Handling curried application and recursive binding in Core visualization

### DIFF
--- a/daemon/src/GHCSpecter/Data/GHC/Core.hs
+++ b/daemon/src/GHCSpecter/Data/GHC/Core.hs
@@ -9,10 +9,6 @@ module GHCSpecter.Data.GHC.Core
     Alt (..),
     Expr (..),
 
-    -- * property check
-    isInlineable,
-    doesNeedParens,
-
     -- * conversion
     toListTree,
     toVar,
@@ -60,19 +56,6 @@ data Expr
   | Type Expr
   | Other (Text, Text) [Expr]
   deriving (Show)
-
-isInlineable :: Expr -> Bool
-isInlineable (Var _) = True
-isInlineable (Lit _) = True
-isInlineable (App e1 e2) = isInlineable e1 && isInlineable e2
-isInlineable (Type _) = True
-isInlineable _ = False
-
-doesNeedParens :: Expr -> Bool
-doesNeedParens (Var _) = False
-doesNeedParens (Lit _) = False
-doesNeedParens (Type _) = False
-doesNeedParens _ = True
 
 toListTree :: Tree (Text, Text) -> Either Text [Tree (Text, Text)]
 toListTree (Node (typ, val) xs)

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -58,7 +58,7 @@ renderConsoleItem (ConsoleCore forest) =
     renderErr err = divClass "error" [] [pre [] [text err]]
     render1 tr =
       let -- for debug
-          txt = T.pack $ drawTree $ fmap show tr
+          -- txt = T.pack $ drawTree $ fmap show tr
           ebind = toBind tr
           rendered =
             case ebind of
@@ -67,8 +67,8 @@ renderConsoleItem (ConsoleCore forest) =
        in div
             [style [("display", "inline-block"), ("margin", "0"), ("padding", "0")]]
             [ -- for debug
-              divClass "noinline" [] [pre [] [text txt]]
-            , div [style [("display", "block")]] [rendered]
+              -- divClass "noinline" [] [pre [] [text txt]]
+              div [style [("display", "block")]] [rendered]
             ]
     renderedForest = fmap render1 forest'
 

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -16,6 +16,8 @@ import Concur.Replica.DOM.Events qualified as DE
 import Control.Monad (join)
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Tree (drawTree)
 import GHCSpecter.Data.GHC.Core (toBind)
 import GHCSpecter.Render.Components.GHCCore (renderTopBind)
 import GHCSpecter.Render.Util (divClass)
@@ -56,18 +58,17 @@ renderConsoleItem (ConsoleCore forest) =
     renderErr err = divClass "error" [] [pre [] [text err]]
     render1 tr =
       let -- for debug
-          -- txt = T.pack $ drawTree $ fmap show tr
+          txt = T.pack $ drawTree $ fmap show tr
           ebind = toBind tr
           rendered =
             case ebind of
               Left err -> renderErr err
               Right bind -> renderTopBind bind
-       in divClass
-            "nomargin"
-            []
+       in div
+            [style [("display", "inline-block"), ("margin", "0"), ("padding", "0")]]
             [ -- for debug
-              -- divClass "noinline" [] [pre [] [text txt]],
-              divClass "noinline" [] [rendered]
+              divClass "noinline" [] [pre [] [text txt]]
+            , div [style [("display", "block")]] [rendered]
             ]
     renderedForest = fmap render1 forest'
 

--- a/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
@@ -58,7 +58,7 @@ renderTopBind bind = goB 0 bind
         goB1 lvl' (var', expr') =
           let varEl = span [] [text (unId var')]
               expEl = goE (lvl' + 1) expr'
-           in divClass (cls lvl') [] [varEl, eqEl, expEl]
+           in divClass (cls lvl') [] [varEl, space, eqEl, space, expEl]
 
     goApp lvl e1 e2
       | isInlineable e1 =
@@ -78,6 +78,7 @@ renderTopBind bind = goB 0 bind
                         []
                         (wrapParen (e1, e1El) ++ [divClass (cls (lvl + 1)) [] (wrapParen (e2, e2El))])
       | otherwise =
+          -- NOTE: Indent applied argument one level further than applying function.
           let e1El = goE (lvl + 1) e1
               e2El = goE (lvl + 2) e2
            in divClass

--- a/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
@@ -13,8 +13,6 @@ import GHCSpecter.Data.GHC.Core
     Expr (..),
     Id (..),
     Literal (..),
-    doesNeedParens,
-    isInlineable,
   )
 import GHCSpecter.Render.Util (divClass, spanClass)
 import GHCSpecter.UI.ConcurReplica.DOM
@@ -24,6 +22,19 @@ import GHCSpecter.UI.ConcurReplica.DOM
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import Prelude hiding (div, span)
+
+isInlineable :: Expr -> Bool
+isInlineable (Var _) = True
+isInlineable (Lit _) = True
+isInlineable (App e1 e2) = isInlineable e1 && isInlineable e2
+isInlineable (Type _) = True
+isInlineable _ = False
+
+doesNeedParens :: Expr -> Bool
+doesNeedParens (Var _) = False
+doesNeedParens (Lit _) = False
+doesNeedParens (Type _) = False
+doesNeedParens _ = True
 
 renderTopBind :: Bind -> Widget IHTML a
 renderTopBind bind = goB 0 bind
@@ -45,30 +56,38 @@ renderTopBind bind = goB 0 bind
        in divClass (cls lvl) [] [varEl, eqEl, expEl]
 
     goApp lvl e1 e2
-      | isInlineable e1 && isInlineable e2 =
-          let e1El = span [] [goE lvl e1]
-              e2El = span [] [goE lvl e2]
-           in span [] (wrapParen (e1, e1El) ++ [space] ++ wrapParen (e2, e2El))
       | isInlineable e1 =
-          let e1El = span [] [goE lvl e1]
-              e2El = goE (lvl + 1) e2
-           in divClass
-                (cls lvl)
-                []
-                (wrapParen (e1, e1El) ++ [space, parenLEl, e2El, parenREl])
+          let e1El = span [] $
+                case e1 of
+                  -- simplify as curry
+                  App e1' e2' -> [goApp lvl e1' e2']
+                  _ -> [goE lvl e1]
+           in if isInlineable e2
+                then
+                  let e2El = span [] [goE lvl e2]
+                   in span [] ([e1El, space] ++ wrapParen (e2, e2El))
+                else
+                  let e2El = goE (lvl + 2) e2
+                   in divClass
+                        (cls lvl)
+                        []
+                        (wrapParen (e1, e1El) ++ [divClass (cls (lvl + 1)) [] (wrapParen (e2, e2El))])
       | otherwise =
           let e1El = goE (lvl + 1) e1
-              e2El = goE (lvl + 1) e2
+              e2El = goE (lvl + 2) e2
            in divClass
                 (cls lvl)
                 []
                 [ parenLEl
                 , e1El
                 , parenREl
-                , space
-                , parenLEl
-                , e2El
-                , parenREl
+                , divClass
+                    (cls (lvl + 1))
+                    []
+                    [ parenLEl
+                    , e2El
+                    , parenREl
+                    ]
                 ]
 
     goAlt lvl (Alt con ids expr) =

--- a/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
@@ -50,10 +50,15 @@ renderTopBind bind = goB 0 bind
       | otherwise = [rendered]
 
     goB :: Int -> Bind -> Widget IHTML a
-    goB lvl (Bind var expr) =
-      let varEl = span [] [text (unId var)]
-          expEl = goE (lvl + 1) expr
-       in divClass (cls lvl) [] [varEl, eqEl, expEl]
+    goB lvl b =
+      case b of
+        NonRec var expr -> goB1 lvl (var, expr)
+        Rec bs -> divClass (cls lvl) [] (fmap (goB1 (lvl + 1)) bs)
+      where
+        goB1 lvl' (var', expr') =
+          let varEl = span [] [text (unId var')]
+              expEl = goE (lvl' + 1) expr'
+           in divClass (cls lvl') [] [varEl, eqEl, expEl]
 
     goApp lvl e1 e2
       | isInlineable e1 =

--- a/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
@@ -105,6 +105,8 @@ getContent dflags x = (T.pack dtypName, evalue)
       | dtypName == "Unit" =
           let my :: Maybe Unit = cast x
            in Right $ fmap (T.pack . unitString . toUnitId) my
+      -- NOTE: OccName is not enough for distinguishing Var's.
+      -- Using ppr, "_(uniq symbol)" suffix is added.
       | dtypName == "Var" = Right $ getNameDynamically (Proxy @Var) dflags x
       | otherwise = Left (T.pack (show (toConstr x)))
 

--- a/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/PrintCore.hs
@@ -15,11 +15,12 @@ import Data.Typeable (Typeable)
 import GHC.Core.Class (Class)
 import GHC.Core.ConLike (ConLike)
 import GHC.Core.DataCon (DataCon)
-import GHC.Core.Opt.Monad (CoreM)
+import GHC.Core.Opt.Monad (CoreM, getDynFlags)
 import GHC.Core.PatSyn (PatSyn)
 import GHC.Core.TyCon (TyCon)
 import GHC.Data.FastString (FastString (..))
-import GHC.Types.Name (Name, NamedThing (getOccName), OccName)
+import GHC.Driver.Session (DynFlags)
+import GHC.Types.Name (Name, NamedThing (..), OccName)
 import GHC.Types.Name.Occurrence (occNameString)
 import GHC.Types.SrcLoc (RealSrcSpan, SrcSpan)
 import GHC.Types.Var (Var)
@@ -27,6 +28,7 @@ import GHC.Unit.Module.ModGuts (ModGuts (..))
 import GHC.Unit.Module.Name (ModuleName, moduleNameString)
 import GHC.Unit.Types (Unit, toUnitId, unitString)
 import GHCSpecter.Channel.Outbound.Types (ConsoleReply (..))
+import GHCSpecter.Util.GHC (showPpr)
 
 getOccNameDynamically ::
   forall t a.
@@ -39,6 +41,18 @@ getOccNameDynamically _ x =
       my = cast x
    in fmap (T.pack . occNameString . getOccName) my
 
+getNameDynamically ::
+  forall t a.
+  (Typeable t, NamedThing t, Data a) =>
+  Proxy t ->
+  DynFlags ->
+  a ->
+  Maybe Text
+getNameDynamically _ dflags x =
+  let my :: Maybe t
+      my = cast x
+   in fmap (T.pack . showPpr dflags . getName) my
+
 -- NOTE: a few data types used in Core has partial toConstr (Data.ByteString.ByteString)
 -- or abstractConstr, which causes an exception or not inspectable expression
 -- after conversion.
@@ -46,8 +60,8 @@ getOccNameDynamically _ x =
 -- in such cases and do not proceed the conversion to the children of the node.
 
 -- | Left: ordinary node, Right: extract and do not proceed to the children
-getContent :: forall a. Data a => a -> (Text, Either Text (Maybe Text))
-getContent x = (T.pack dtypName, evalue)
+getContent :: forall a. Data a => DynFlags -> a -> (Text, Either Text (Maybe Text))
+getContent dflags x = (T.pack dtypName, evalue)
   where
     dtyp = dataTypeOf x
     dtypName = dataTypeName dtyp
@@ -91,21 +105,22 @@ getContent x = (T.pack dtypName, evalue)
       | dtypName == "Unit" =
           let my :: Maybe Unit = cast x
            in Right $ fmap (T.pack . unitString . toUnitId) my
-      | dtypName == "Var" = Right $ getOccNameDynamically (Proxy @Var) x
+      | dtypName == "Var" = Right $ getNameDynamically (Proxy @Var) dflags x
       | otherwise = Left (T.pack (show (toConstr x)))
 
-core2tree :: forall a. Data a => a -> Tree (Text, Text)
-core2tree a =
-  case getContent a of
+core2tree :: forall a. Data a => DynFlags -> a -> Tree (Text, Text)
+core2tree dflags a =
+  case getContent dflags a of
     (typ, Left val) -> Node (typ, val) (getConst (gfoldl k z a))
     (typ, Right (Just val)) -> Node (typ, val) []
     (typ, Right Nothing) -> Node (typ, "#######") []
   where
     z _ = Const []
-    k (Const acc) x = Const (acc ++ [core2tree x])
+    k (Const acc) x = Const (acc ++ [core2tree dflags x])
 
 printCore :: ModGuts -> CoreM ConsoleReply
 printCore guts = do
+  dflags <- getDynFlags
   let binds = mg_binds guts
-      forest = fmap core2tree binds
+      forest = fmap (core2tree dflags) binds
   pure (ConsoleReplyCore forest)


### PR DESCRIPTION
Left-leaning binary tree of App application is interpreted as curried application for a better visualization.
The recursive binding is also handled.
Used unique suffix for Var Id as well.