### PR TITLE
GHC session can be started as paused by config

### DIFF
--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -54,7 +54,6 @@ renderConsoleItem (ConsoleCore forest) =
     []
     (divClass "langle" [] [text "<"] : renderedForest)
   where
-    forest' = take 3 forest
     renderErr err = divClass "error" [] [pre [] [text err]]
     render1 tr =
       let -- for debug
@@ -65,12 +64,12 @@ renderConsoleItem (ConsoleCore forest) =
               Left err -> renderErr err
               Right bind -> renderTopBind bind
        in div
-            [style [("display", "inline-block"), ("margin", "0"), ("padding", "0")]]
+            [style [("display", "block"), ("margin", "0"), ("padding", "0")]]
             [ -- for debug
               -- divClass "noinline" [] [pre [] [text txt]]
               div [style [("display", "block")]] [rendered]
             ]
-    renderedForest = fmap render1 forest'
+    renderedForest = fmap render1 forest
 
 render ::
   (IsKey k, Eq k) =>

--- a/ghc-specter.yaml.sample
+++ b/ghc-specter.yaml.sample
@@ -1,3 +1,4 @@
 socket: /tmp/socket.ipc
 session_file: session.json
 web_port: 7070
+start_with_breakpoint: True

--- a/plugin/src/GHCSpecter/Config.hs
+++ b/plugin/src/GHCSpecter/Config.hs
@@ -1,5 +1,6 @@
 module GHCSpecter.Config
   ( Config (..),
+    emptyConfig,
     defaultGhcSpecterConfigFile,
     loadConfig,
   )
@@ -26,6 +27,9 @@ data Config = Config
   , configStartWithBreakpoint :: Bool
   }
   deriving (Show, Generic)
+
+emptyConfig :: Config
+emptyConfig = Config "" "" 0 False
 
 modifier :: String -> String
 modifier = camelTo2 '_' . drop 6

--- a/plugin/src/GHCSpecter/Config.hs
+++ b/plugin/src/GHCSpecter/Config.hs
@@ -23,6 +23,7 @@ data Config = Config
   { configSocket :: FilePath
   , configSessionFile :: FilePath
   , configWebPort :: Int
+  , configStartWithBreakpoint :: Bool
   }
   deriving (Show, Generic)
 

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -94,7 +94,7 @@ startSession opts env = do
   let modGraph = hsc_mod_graph env
       modGraphInfo = extractModuleGraphInfo modGraph
       startedSession =
-        modGraphInfo `seq` SessionInfo pid (Just startTime) modGraphInfo False
+        modGraphInfo `seq` SessionInfo pid (Just startTime) modGraphInfo True
   -- NOTE: return Nothing if session info is already initiated
   queue' <- initMsgQueue
   (mNewStartedSession, drvId, queue, willStartMsgQueue) <-

--- a/plugin/src/Plugin/GHCSpecter/Comm.hs
+++ b/plugin/src/Plugin/GHCSpecter/Comm.hs
@@ -45,16 +45,11 @@ import Plugin.GHCSpecter.Types
   )
 import System.Directory (doesFileExist)
 
-runMessageQueue :: [CommandLineOption] -> MsgQueue -> IO ()
-runMessageQueue opts queue = do
-  mipcfile <-
-    case opts of
-      ipcfile : _ -> pure (Just ipcfile)
-      [] -> do
-        ecfg <- loadConfig defaultGhcSpecterConfigFile
-        case ecfg of
-          Left _ -> pure Nothing
-          Right cfg -> pure (Just (configSocket cfg))
+runMessageQueue :: Config -> MsgQueue -> IO ()
+runMessageQueue cfg queue = do
+  let mipcfile
+        | null (configSocket cfg) = Nothing
+        | otherwise = Just (configSocket cfg)
   for_ mipcfile $ \ipcfile -> do
     socketExists <- doesFileExist ipcfile
     when socketExists $

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -29,6 +29,7 @@ import GHCSpecter.Channel.Outbound.Types
     SessionInfo (..),
     emptyModuleGraphInfo,
   )
+import GHCSpecter.Config (Config, emptyConfig)
 import System.IO.Unsafe (unsafePerformIO)
 
 data MsgQueue = MsgQueue
@@ -51,7 +52,8 @@ emptyConsoleState :: ConsoleState
 emptyConsoleState = ConsoleState Nothing
 
 data PluginSession = PluginSession
-  { psSessionInfo :: SessionInfo
+  { psSessionConfig :: Config
+  , psSessionInfo :: SessionInfo
   , psMessageQueue :: Maybe MsgQueue
   , psNextDriverId :: DriverId
   , psConsoleState :: ConsoleState
@@ -60,7 +62,8 @@ data PluginSession = PluginSession
 emptyPluginSession :: PluginSession
 emptyPluginSession =
   PluginSession
-    { psSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo True
+    { psSessionConfig = emptyConfig
+    , psSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo True
     , psMessageQueue = Nothing
     , psNextDriverId = 1
     , psConsoleState = emptyConsoleState

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -60,7 +60,7 @@ data PluginSession = PluginSession
 emptyPluginSession :: PluginSession
 emptyPluginSession =
   PluginSession
-    { psSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo False
+    { psSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo True
     , psMessageQueue = Nothing
     , psNextDriverId = 1
     , psConsoleState = emptyConsoleState


### PR DESCRIPTION
By setting `start_with_breakpoint: True` in ghc-specter.yaml, the session is paused from the beginning. Useful for debugging.
Driver initialization step is split into GHC session init and Driver session init, so that the code gets simplified.