### PR TITLE
Generate button from the result of list-core

### DIFF
--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -230,6 +230,9 @@ goCommon ev (view, model0) = do
       ConsoleEv (ConsoleInput content) -> do
         let model = (modelConsole . consoleInputEntry .~ content) model0
         pure model
+      ConsoleEv (ConsoleButtonPressed msg) -> do
+        printMsg msg
+        pure model0
       _ -> pure model0
   ui <- getUI
   ss <- getSS

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -230,9 +230,10 @@ goCommon ev (view, model0) = do
       ConsoleEv (ConsoleInput content) -> do
         let model = (modelConsole . consoleInputEntry .~ content) model0
         pure model
-      ConsoleEv (ConsoleButtonPressed msg) -> do
-        printMsg msg
-        pure model0
+      ConsoleEv (ConsoleButtonPressed content) -> do
+        printMsg content
+        let model = (modelConsole . consoleInputEntry .~ content) model0
+        pure model
       _ -> pure model0
   ui <- getUI
   ss <- getSS

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -81,9 +81,13 @@ updateInbox chanMsg = incrementSN . updater
          in (serverPaused %~ alterToKeyMap (const mloc) drvId)
               . (serverConsole %~ alterToKeyMap (appendConsoleMsg (formatMsg mloc)) drvId)
       CMBox (CMConsole drvId creply) ->
+        -- TODO: unify ConsoleReply and ConsoleItem if no obstacles.
         case creply of
           ConsoleReplyText txt ->
             let msg = ConsoleText txt
+             in (serverConsole %~ alterToKeyMap (appendConsoleMsg msg) drvId)
+          ConsoleReplyButton buttonss ->
+            let msg = ConsoleButton buttonss
              in (serverConsole %~ alterToKeyMap (appendConsoleMsg msg) drvId)
           ConsoleReplyCore forest ->
             let msg = ConsoleCore forest

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -81,13 +81,13 @@ updateInbox chanMsg = incrementSN . updater
          in (serverPaused %~ alterToKeyMap (const mloc) drvId)
               . (serverConsole %~ alterToKeyMap (appendConsoleMsg (formatMsg mloc)) drvId)
       CMBox (CMConsole drvId creply) ->
-        -- TODO: unify ConsoleReply and ConsoleItem if no obstacles.
         case creply of
           ConsoleReplyText txt ->
             let msg = ConsoleText txt
              in (serverConsole %~ alterToKeyMap (appendConsoleMsg msg) drvId)
-          ConsoleReplyButton buttonss ->
-            let msg = ConsoleButton buttonss
+          ConsoleReplyCoreBindList bindList ->
+            let mkButton n = (n, ":print-core " <> n)
+                msg = ConsoleButton (fmap (fmap mkButton) bindList)
              in (serverConsole %~ alterToKeyMap (appendConsoleMsg msg) drvId)
           ConsoleReplyCore forest ->
             let msg = ConsoleCore forest

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -18,8 +18,7 @@ import Data.Maybe (maybeToList)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Tree (drawTree)
-import GHCSpecter.Data.GHC.Core (toBind)
-import GHCSpecter.Render.Components.GHCCore (renderTopBind)
+import GHCSpecter.Render.Components.ConsoleItem qualified as CI (render)
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types (ConsoleItem (..))
 import GHCSpecter.UI.ConcurReplica.DOM
@@ -39,37 +38,6 @@ import GHCSpecter.Util.Map
     lookupKey,
   )
 import Prelude hiding (div)
-
-renderConsoleItem :: ConsoleItem -> Widget IHTML a
-renderConsoleItem (ConsoleText txt) =
-  divClass
-    "console-item"
-    []
-    [ div [style [("width", "10px")]] [text "<"]
-    , pre [] [text txt]
-    ]
-renderConsoleItem (ConsoleCore forest) =
-  divClass
-    "console-item"
-    []
-    (divClass "langle" [] [text "<"] : renderedForest)
-  where
-    renderErr err = divClass "error" [] [pre [] [text err]]
-    render1 tr =
-      let -- for debug
-          -- txt = T.pack $ drawTree $ fmap show tr
-          ebind = toBind tr
-          rendered =
-            case ebind of
-              Left err -> renderErr err
-              Right bind -> renderTopBind bind
-       in div
-            [style [("display", "block"), ("margin", "0"), ("padding", "0")]]
-            [ -- for debug
-              -- divClass "noinline" [] [pre [] [text txt]]
-              div [style [("display", "block")]] [rendered]
-            ]
-    renderedForest = fmap render1 forest
 
 render ::
   (IsKey k, Eq k) =>
@@ -122,7 +90,7 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
                 , ("overflow", "scroll")
                 ]
             ]
-            (scriptContent : fmap renderConsoleItem (join (maybeToList mtxts)))
+            (scriptContent : fmap CI.render (join (maybeToList mtxts)))
     consoleInput =
       divClass
         "console-input"

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -31,7 +31,10 @@ import GHCSpecter.UI.ConcurReplica.DOM
     text,
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
-import GHCSpecter.UI.Types.Event (ConsoleEvent (..))
+import GHCSpecter.UI.Types.Event
+  ( Event (..),
+    ConsoleEvent (..),
+  )
 import GHCSpecter.Util.Map
   ( IsKey (..),
     KeyMap,

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -31,10 +31,7 @@ import GHCSpecter.UI.ConcurReplica.DOM
     text,
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
-import GHCSpecter.UI.Types.Event
-  ( ConsoleEvent (..),
-    Event (..),
-  )
+import GHCSpecter.UI.Types.Event (ConsoleEvent (..))
 import GHCSpecter.Util.Map
   ( IsKey (..),
     KeyMap,

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -32,8 +32,8 @@ import GHCSpecter.UI.ConcurReplica.DOM
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types.Event
-  ( Event (..),
-    ConsoleEvent (..),
+  ( ConsoleEvent (..),
+    Event (..),
   )
 import GHCSpecter.Util.Map
   ( IsKey (..),

--- a/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
@@ -11,7 +11,8 @@ import GHCSpecter.Render.Components.GHCCore (renderTopBind)
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types (ConsoleItem (..))
 import GHCSpecter.UI.ConcurReplica.DOM
-  ( div,
+  ( button,
+    div,
     pre,
     text,
   )
@@ -27,13 +28,15 @@ render (ConsoleText txt) =
     , pre [] [text txt]
     ]
 render (ConsoleButton buttonss) =
-  let txt = T.intercalate "\n" $ fmap (T.intercalate " " . fmap fst) buttonss
+  let mkButton (label, cmd) =
+        button [style [("display", "inline-block")]] [text label]
+      mkRow buttons =
+        div [style [("display", "block")]] (fmap mkButton buttons)
+      rows = fmap mkRow buttonss
    in divClass
         "console-item"
         []
-        [ div [style [("width", "10px")]] [text "<"]
-        , pre [] [text txt]
-        ]
+        (div [style [("width", "10px")]] [text "<"] : rows)
 render (ConsoleCore forest) =
   divClass
     "console-item"

--- a/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
@@ -1,0 +1,58 @@
+module GHCSpecter.Render.Components.ConsoleItem
+  ( render,
+  )
+where
+
+import Concur.Core (Widget)
+import Concur.Replica (style)
+import Data.Text qualified as T
+import GHCSpecter.Data.GHC.Core (toBind)
+import GHCSpecter.Render.Components.GHCCore (renderTopBind)
+import GHCSpecter.Render.Util (divClass)
+import GHCSpecter.Server.Types (ConsoleItem (..))
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( div,
+    pre,
+    text,
+  )
+import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import Prelude hiding (div)
+
+render :: ConsoleItem -> Widget IHTML a
+render (ConsoleText txt) =
+  divClass
+    "console-item"
+    []
+    [ div [style [("width", "10px")]] [text "<"]
+    , pre [] [text txt]
+    ]
+render (ConsoleButton buttonss) =
+  let txt = T.intercalate "\n" $ fmap (T.intercalate " " . fmap fst) buttonss
+   in divClass
+        "console-item"
+        []
+        [ div [style [("width", "10px")]] [text "<"]
+        , pre [] [text txt]
+        ]
+render (ConsoleCore forest) =
+  divClass
+    "console-item"
+    []
+    (divClass "langle" [] [text "<"] : renderedForest)
+  where
+    renderErr err = divClass "error" [] [pre [] [text err]]
+    render1 tr =
+      let -- for debug
+          -- txt = T.pack $ drawTree $ fmap show tr
+          ebind = toBind tr
+          rendered =
+            case ebind of
+              Left err -> renderErr err
+              Right bind -> renderTopBind bind
+       in div
+            [style [("display", "block"), ("margin", "0"), ("padding", "0")]]
+            [ -- for debug
+              -- divClass "noinline" [] [pre [] [text txt]]
+              div [style [("display", "block")]] [rendered]
+            ]
+    renderedForest = fmap render1 forest

--- a/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
@@ -4,7 +4,7 @@ module GHCSpecter.Render.Components.ConsoleItem
 where
 
 import Concur.Core (Widget)
-import Concur.Replica (style)
+import Concur.Replica (onClick, style)
 import Data.Text qualified as T
 import GHCSpecter.Data.GHC.Core (toBind)
 import GHCSpecter.Render.Components.GHCCore (renderTopBind)
@@ -17,9 +17,10 @@ import GHCSpecter.UI.ConcurReplica.DOM
     text,
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import GHCSpecter.UI.Types.Event (ConsoleEvent (..))
 import Prelude hiding (div)
 
-render :: ConsoleItem -> Widget IHTML a
+render :: ConsoleItem -> Widget IHTML (ConsoleEvent k)
 render (ConsoleText txt) =
   divClass
     "console-item"
@@ -29,7 +30,11 @@ render (ConsoleText txt) =
     ]
 render (ConsoleButton buttonss) =
   let mkButton (label, cmd) =
-        button [style [("display", "inline-block")]] [text label]
+        button
+          [ ConsoleButtonPressed cmd <$ onClick
+          , style [("display", "inline-block")]
+          ]
+          [text label]
       mkRow buttons =
         div [style [("display", "block")]] (fmap mkButton buttons)
       rows = fmap mkRow buttonss

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -86,9 +86,10 @@ emptyHieState = HieState mempty mempty
 data ConsoleItem
   = -- | Simple text message
     ConsoleText Text
-  | -- | Collection of buttons.
+  | -- | Collection of buttons. Note that the information from ConsoleReply is
+    -- enriched with the corresponding console command for convenience.
     -- Each item in the outer list is a row of buttons and ones in the inner list
-    -- are (button label, the corresponding  console command)
+    -- are (button label, console command)
     ConsoleButton [[(Text, Text)]]
   | -- | GHC Core expression trees (as untyped)
     ConsoleCore [Tree (Text, Text)]

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -84,8 +84,14 @@ emptyHieState :: HieState
 emptyHieState = HieState mempty mempty
 
 data ConsoleItem
-  = ConsoleText Text
-  | ConsoleCore [Tree (Text, Text)]
+  = -- | Simple text message
+    ConsoleText Text
+  | -- | Collection of buttons.
+    -- Each item in the outer list is a row of buttons and ones in the inner list
+    -- are (button label, the corresponding  console command)
+    ConsoleButton [[(Text, Text)]]
+  | -- | GHC Core expression trees (as untyped)
+    ConsoleCore [Tree (Text, Text)]
   deriving (Show, Generic)
 
 instance FromJSON ConsoleItem

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -68,6 +68,7 @@ data ConsoleEvent k
   = ConsoleTab k
   | ConsoleKey Text
   | ConsoleInput Text
+  | ConsoleButtonPressed Text
   deriving (Show, Eq)
 
 data BackgroundEvent

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -149,18 +149,11 @@ instance ToJSON HsSourceInfo
 
 data ConsoleReply
   = ConsoleReplyText Text
+  | ConsoleReplyButton [[(Text, Text)]]
   | ConsoleReplyCore (Forest (Text, Text))
   deriving (Show, Generic)
 
-instance Binary ConsoleReply where
-  put (ConsoleReplyText t) = put (1 :: Int) >> put t
-  put (ConsoleReplyCore f) = put (2 :: Int) >> put f
-  get = do
-    tag :: Int <- get
-    case tag of
-      1 -> ConsoleReplyText <$> get
-      2 -> ConsoleReplyCore <$> get
-      _ -> error "Binary: ConsoleReply"
+instance Binary ConsoleReply
 
 data ChanMessage (a :: Channel) where
   CMCheckImports :: ModuleName -> Text -> ChanMessage 'CheckImports

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -148,9 +148,13 @@ instance FromJSON HsSourceInfo
 instance ToJSON HsSourceInfo
 
 data ConsoleReply
-  = ConsoleReplyText Text
-  | ConsoleReplyButton [[(Text, Text)]]
-  | ConsoleReplyCore (Forest (Text, Text))
+  = -- | simple textual reply
+    ConsoleReplyText Text
+  | -- | list of Core bind items. The items in the same inner list are mutually
+    -- recursive binding, i.e. should be presented together.
+    ConsoleReplyCoreBindList [[Text]]
+  | -- | core tree
+    ConsoleReplyCore (Forest (Text, Text))
   deriving (Show, Generic)
 
 instance Binary ConsoleReply

--- a/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
@@ -132,7 +132,7 @@ listCore guts = do
       extractName =
         note "Error in getNameDynamically"
           . getNameDynamically (Proxy @Var) dflags
-      mkButton n = (n, "dummy")
+      mkButton n = (n, ":print-core " <> n)
       formatBind (NonRec t _) = (\n -> [mkButton n]) <$> extractName t
       formatBind (Rec bs) = traverse (fmap mkButton . extractName . fst) bs
       reply =

--- a/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
@@ -132,15 +132,14 @@ listCore guts = do
       extractName =
         note "Error in getNameDynamically"
           . getNameDynamically (Proxy @Var) dflags
-      mkButton n = (n, ":print-core " <> n)
-      formatBind (NonRec t _) = (\n -> [mkButton n]) <$> extractName t
-      formatBind (Rec bs) = traverse (fmap mkButton . extractName . fst) bs
+      formatBind (NonRec t _) = (\n -> [n]) <$> extractName t
+      formatBind (Rec bs) = traverse (extractName . fst) bs
       reply =
         case traverse formatBind binds of
           Left err ->
             ConsoleReplyText ("Error: " <> err)
-          Right bindButtons ->
-            ConsoleReplyButton bindButtons
+          Right bindList ->
+            ConsoleReplyCoreBindList bindList
   pure reply
 
 printCore :: ModGuts -> [Text] -> CoreM ConsoleReply

--- a/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
@@ -132,16 +132,15 @@ listCore guts = do
       extractName =
         note "Error in getNameDynamically"
           . getNameDynamically (Proxy @Var) dflags
-      formatBind (NonRec t _) = extractName t
-      formatBind (Rec bs) =
-        let enames = traverse (extractName . fst) bs
-         in T.intercalate " " <$> enames
+      mkButton n = (n, "dummy")
+      formatBind (NonRec t _) = (\n -> [mkButton n]) <$> extractName t
+      formatBind (Rec bs) = traverse (fmap mkButton . extractName . fst) bs
       reply =
         case traverse formatBind binds of
           Left err ->
             ConsoleReplyText ("Error: " <> err)
-          Right bindTxts ->
-            ConsoleReplyText $ T.intercalate "\n" bindTxts
+          Right bindButtons ->
+            ConsoleReplyButton bindButtons
   pure reply
 
 printCore :: ModGuts -> [Text] -> CoreM ConsoleReply


### PR DESCRIPTION
Now clicking the resultant buttons from `:list-core` will populate console input with the corresponding `:print-core` commands.