### PR TITLE
Refine Core presentation

### DIFF
--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -226,7 +226,9 @@ ul.tree span::before {
 }
 
 .arrow {
-    width: 6px;
+    padding-left: 4px;
+    padding-right: 4px;
+    width: 20px;
 }
 
 .paren {

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -16,8 +16,6 @@ import Concur.Replica.DOM.Events qualified as DE
 import Control.Monad (join)
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
-import Data.Text qualified as T
-import Data.Tree (drawTree)
 import GHCSpecter.Render.Components.ConsoleItem qualified as CI (render)
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types (ConsoleItem (..))
@@ -26,7 +24,6 @@ import GHCSpecter.UI.ConcurReplica.DOM
     el,
     input,
     nav,
-    pre,
     script,
     text,
   )

--- a/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
@@ -6,6 +6,7 @@ where
 import Concur.Core (Widget)
 import Concur.Replica (onClick, style)
 import Data.Text qualified as T
+import Data.Tree (drawTree)
 import GHCSpecter.Data.GHC.Core (toBind)
 import GHCSpecter.Render.Components.GHCCore (renderTopBind)
 import GHCSpecter.Render.Util (divClass)

--- a/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
@@ -52,7 +52,7 @@ render (ConsoleCore forest) =
     renderErr err = divClass "error" [] [pre [] [text err]]
     render1 tr =
       let -- for debug
-          -- txt = T.pack $ drawTree $ fmap show tr
+          txt = T.pack $ drawTree $ fmap show tr
           ebind = toBind tr
           rendered =
             case ebind of
@@ -61,7 +61,7 @@ render (ConsoleCore forest) =
        in div
             [style [("display", "block"), ("margin", "0"), ("padding", "0")]]
             [ -- for debug
-              -- divClass "noinline" [] [pre [] [text txt]]
-              div [style [("display", "block")]] [rendered]
+              divClass "noinline" [] [pre [] [text txt]]
+            , div [style [("display", "block")]] [rendered]
             ]
     renderedForest = fmap render1 forest

--- a/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
@@ -52,7 +52,7 @@ render (ConsoleCore forest) =
     renderErr err = divClass "error" [] [pre [] [text err]]
     render1 tr =
       let -- for debug
-          txt = T.pack $ drawTree $ fmap show tr
+          -- txt = T.pack $ drawTree $ fmap show tr
           ebind = toBind tr
           rendered =
             case ebind of
@@ -61,7 +61,7 @@ render (ConsoleCore forest) =
        in div
             [style [("display", "block"), ("margin", "0"), ("padding", "0")]]
             [ -- for debug
-              divClass "noinline" [] [pre [] [text txt]]
-            , div [style [("display", "block")]] [rendered]
+              -- divClass "noinline" [] [pre [] [text txt]],
+              div [style [("display", "block")]] [rendered]
             ]
     renderedForest = fmap render1 forest

--- a/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
@@ -131,8 +131,11 @@ renderTopBind bind = goB 0 bind
         Var var -> span [] [text (unId var)]
         -- special treatment for readability
         Lit (LitString txt) ->
-          let txt' = "\"" <> txt <> "\""
+          let txt' = "\"" <> txt <> "\"#"
            in span [] [text txt']
+        Lit (LitNumber _ num) ->
+          let txt = T.pack (show num) <> "#"
+           in span [] [text txt]
         Lit (LitOther e) ->
           goE lvl e
         App e1 e2 -> goApp lvl e1 e2

--- a/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GHCCore.hs
@@ -23,6 +23,10 @@ import GHCSpecter.UI.ConcurReplica.DOM
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import Prelude hiding (div, span)
 
+isType :: Expr -> Bool
+isType (Type _) = True
+isType _ = False
+
 isInlineable :: Expr -> Bool
 isInlineable (Var _) = True
 isInlineable (Lit _) = True
@@ -61,6 +65,9 @@ renderTopBind bind = goB 0 bind
            in divClass (cls lvl') [] [varEl, space, eqEl, space, expEl]
 
     goApp lvl e1 e2
+      -- suppress type, i.e. drop
+      -- TODO: handle this correctly and customizable.
+      | isType e2 = goE lvl e1
       | isInlineable e1 =
           let e1El = span [] $
                 case e1 of

--- a/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
@@ -5,6 +5,7 @@ module Plugin.GHCSpecter.Task.Core2Core
 where
 
 import Control.Error.Util (note)
+import Control.Monad.IO.Class (liftIO)
 import Data.ByteString.Short qualified as SB
 import Data.Data (Data (..), cast, dataTypeName)
 import Data.Functor.Const (Const (..))
@@ -33,7 +34,7 @@ import GHC.Unit.Module.ModGuts (ModGuts (..))
 import GHC.Unit.Module.Name (ModuleName, moduleNameString)
 import GHC.Unit.Types (Unit, toUnitId, unitString)
 import GHCSpecter.Channel.Outbound.Types (ConsoleReply (..))
-import GHCSpecter.Util.GHC (showPpr)
+import GHCSpecter.Util.GHC (printPpr, showPpr)
 
 getOccNameDynamically ::
   forall t a.
@@ -155,4 +156,6 @@ printCore guts args = do
       binds = mg_binds guts
       binds' = filter isReq binds
       forest = fmap (core2tree dflags) binds'
+  -- for debug
+  mapM_ (liftIO . printPpr dflags) binds'
   pure (ConsoleReplyCore forest)


### PR DESCRIPTION
by suppressing Type and handling LitNumber correctly. 
NOTE: Later, type suppression should be handled optionally and more consistently and matched with GHC default textual presentation as well. 