### PR TITLE
Goto-source from console

### DIFF
--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -62,8 +62,8 @@ updateInbox chanMsg = incrementSN . updater
     updater = case chanMsg of
       CMBox (CMCheckImports modu msg) ->
         (serverInbox %~ M.insert (CheckImports, modu) msg)
-      CMBox (CMModuleInfo drvId modu) ->
-        let msg = ConsoleText ("module name: " <> modu)
+      CMBox (CMModuleInfo drvId modu mfile) ->
+        let msg = ConsoleText ("module name: " <> modu <> ", file: " <> T.pack (show mfile))
          in (serverDriverModuleMap %~ insertToBiKeyMap (drvId, modu))
               . (serverConsole %~ alterToKeyMap (appendConsoleMsg msg) drvId)
       CMBox (CMTiming drvId timer') ->

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -25,7 +25,6 @@ import GHCSpecter.Channel.Outbound.Types
     ChanMessageBox (..),
     Channel (..),
     ConsoleReply (..),
-    HsSourceInfo (..),
     SessionInfo (..),
     Timer (..),
   )
@@ -34,12 +33,17 @@ import GHCSpecter.Comm
     runServer,
     sendObject,
   )
+import GHCSpecter.Data.GHC.Hie
+  ( HasModuleHieInfo (..),
+    emptyModuleHieInfo,
+  )
 import GHCSpecter.Driver.Session.Types
   ( HasServerSession (..),
     ServerSession (..),
   )
 import GHCSpecter.Server.Types
   ( ConsoleItem (..),
+    HasHieState (..),
     HasServerState (..),
     ServerState (..),
     incrementSN,
@@ -73,7 +77,7 @@ updateInbox chanMsg = incrementSN . updater
          in (serverTiming %~ alterToKeyMap f drvId)
       CMBox (CMSession s') ->
         (serverSessionInfo .~ s')
-      CMBox (CMHsSource _modu _info) ->
+      CMBox (CMHsHie _ _) ->
         id
       CMBox (CMPaused drvId mloc) ->
         let formatMsg (Just loc) = ConsoleText ("paused at " <> T.pack (show loc))
@@ -120,7 +124,15 @@ listener socketFile ssess workQ = do
           CMSession s' -> do
             let mgi = sessionModuleGraph s'
             void $ forkIO (moduleGraphWorker ssRef mgi)
-          CMHsSource _drvId (HsSourceInfo hiefile) ->
+          CMModuleInfo _ modu mfile -> do
+            src <-
+              case mfile of
+                Nothing -> pure ""
+                Just file -> TIO.readFile file
+            let modHie = (modHieSource .~ src) emptyModuleHieInfo
+            atomically $
+              modifyTVar' ssRef (serverHieState . hieModuleMap %~ M.insert modu modHie)
+          CMHsHie _drvId hiefile ->
             void $ forkIO (hieWorker ssRef workQ hiefile)
           CMPaused drvId loc -> do
             mmodu <-

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -51,14 +51,6 @@ type ChanModule = (Channel, Text)
 
 type Inbox = Map ChanModule Text
 
-data HsSourceInfo = HsSourceInfo
-  { _hsSrcFile :: FilePath
-  , _hsHieFile :: Maybe FilePath
-  }
-  deriving (Show, Generic)
-
-makeClassy ''HsSourceInfo
-
 data ModuleGraphState = ModuleGraphState
   { _mgsModuleForest :: Forest ModuleName
   , _mgsClusterGraph :: Maybe GraphVisInfo

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -51,6 +51,14 @@ type ChanModule = (Channel, Text)
 
 type Inbox = Map ChanModule Text
 
+data HsSourceInfo = HsSourceInfo
+  { _hsSrcFile :: FilePath
+  , _hsHieFile :: Maybe FilePath
+  }
+  deriving (Show, Generic)
+
+makeClassy ''HsSourceInfo
+
 data ModuleGraphState = ModuleGraphState
   { _mgsModuleForest :: Forest ModuleName
   , _mgsClusterGraph :: Maybe GraphVisInfo

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -161,7 +161,7 @@ instance Binary ConsoleReply
 
 data ChanMessage (a :: Channel) where
   CMCheckImports :: ModuleName -> Text -> ChanMessage 'CheckImports
-  CMModuleInfo :: DriverId -> ModuleName -> ChanMessage 'ModuleInfo
+  CMModuleInfo :: DriverId -> ModuleName -> Maybe FilePath -> ChanMessage 'ModuleInfo
   CMTiming :: DriverId -> Timer -> ChanMessage 'Timing
   CMSession :: SessionInfo -> ChanMessage 'Session
   CMHsSource :: DriverId -> HsSourceInfo -> ChanMessage 'HsSource
@@ -183,9 +183,9 @@ instance Binary ChanMessageBox where
   put (CMBox (CMCheckImports m t)) = do
     put (fromEnum CheckImports)
     put (m, t)
-  put (CMBox (CMModuleInfo i m)) = do
+  put (CMBox (CMModuleInfo i m mf)) = do
     put (fromEnum ModuleInfo)
-    put (i, m)
+    put (i, m, mf)
   put (CMBox (CMTiming i t)) = do
     put (fromEnum Timing)
     put (i, t)
@@ -206,7 +206,7 @@ instance Binary ChanMessageBox where
     tag <- get
     case toEnum tag of
       CheckImports -> CMBox . uncurry CMCheckImports <$> get
-      ModuleInfo -> CMBox . uncurry CMModuleInfo <$> get
+      ModuleInfo -> CMBox . (\(i, m, mf) -> CMModuleInfo i m mf) <$> get
       Timing -> CMBox . uncurry CMTiming <$> get
       Session -> CMBox . CMSession <$> get
       HsSource -> CMBox . uncurry CMHsSource <$> get

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -45,7 +45,7 @@ import GHC.Driver.Session
   )
 import GHC.Hs (HsParsedModule)
 import GHC.Tc.Types (TcGblEnv (..), TcM)
-import GHC.Unit.Module.Location (ModLocation (ml_hie_file))
+import GHC.Unit.Module.Location (ModLocation (..))
 import GHC.Unit.Module.ModSummary (ModSummary (..))
 import GHCSpecter.Channel.Common.Types
   ( DriverId (..),
@@ -162,9 +162,10 @@ sendModuleName ::
   MsgQueue ->
   DriverId ->
   ModuleName ->
+  Maybe FilePath ->
   IO ()
-sendModuleName queue drvId modName =
-  queueMessage queue (CMModuleInfo drvId modName)
+sendModuleName queue drvId modName msrcfile =
+  queueMessage queue (CMModuleInfo drvId modName msrcfile)
 
 sendCompStateOnPhase ::
   MsgQueue ->
@@ -212,9 +213,10 @@ parsedResultActionPlugin ::
   Hsc HsParsedModule
 parsedResultActionPlugin queue drvId modNameRef modSummary parsedMod = do
   let modName = getModuleName modSummary
+      msrcFile = ml_hs_file $ ms_location modSummary
   liftIO $ do
     writeIORef modNameRef (Just modName)
-    sendModuleName queue drvId modName
+    sendModuleName queue drvId modName msrcFile
   pure parsedMod
 
 --


### PR DESCRIPTION
`:goto-source` is introduced, which automatically open source-view tab from the focused module console.