### PR TITLE
Scroll to the source location when printing core

### DIFF
--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -59,6 +59,14 @@ nav {
     width: 80%;
 }
 
+.column.is-one-quarter {
+    width: 25%;
+}
+
+.column.is-three-quarters {
+    width: 75%;
+}
+
 nav {
     width: 100%;
 }

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -251,7 +251,7 @@ goCommon ev (view, model0) = do
                         case NE.nonEmpty args of
                           Nothing -> pure model
                           Just (NE.head -> sym) ->
-                            let model1 = (modelConsole . consoleLastBinding .~ Just sym) model
+                            let model1 = (modelSourceView . srcViewFocusedBinding .~ Just sym) model
                              in pure model1
                     | msg == ":goto-source" -> do
                         ss <- getSS

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module GHCSpecter.Control
   ( main,
@@ -230,27 +231,40 @@ goCommon ev (view, model0) = do
             Just drvId -> do
               let msg = model0 ^. modelConsole . consoleInputEntry
                   model = (modelConsole . consoleInputEntry .~ "") model0
-              if
-                  | msg == ":next" ->
-                      sendRequest $ ConsoleReq drvId NextBreakpoint
-                  | msg == ":unqualified" ->
-                      sendRequest $ ConsoleReq drvId ShowUnqualifiedImports
-                  | msg == ":test" ->
-                      sendRequest $ ConsoleReq drvId Test
-                  | msg == ":list-core" ->
-                      sendRequest $ ConsoleReq drvId ListCore
-                  | ":print-core" `T.isPrefixOf` msg -> do
-                      let args = maybe [] NE.tail $ NE.nonEmpty (T.words msg)
-                      sendRequest $ ConsoleReq drvId (PrintCore args)
-                  | msg == ":goto-source" -> do
-                      ss <- getSS
-                      let mmod = ss ^. serverDriverModuleMap . to (forwardLookup drvId)
-                          model' =
-                            (modelSourceView . srcViewExpandedModule .~ mmod) model
-                      branchTab TabSourceView (view, model')
-                  | otherwise ->
-                      sendRequest $ ConsoleReq drvId (Ping msg)
-              pure model
+              model' <-
+                if
+                    | msg == ":next" -> do
+                        sendRequest $ ConsoleReq drvId NextBreakpoint
+                        pure model
+                    | msg == ":unqualified" -> do
+                        sendRequest $ ConsoleReq drvId ShowUnqualifiedImports
+                        pure model
+                    | msg == ":test" -> do
+                        sendRequest $ ConsoleReq drvId Test
+                        pure model
+                    | msg == ":list-core" -> do
+                        sendRequest $ ConsoleReq drvId ListCore
+                        pure model
+                    | ":print-core" `T.isPrefixOf` msg -> do
+                        let args = maybe [] NE.tail $ NE.nonEmpty (T.words msg)
+                        sendRequest $ ConsoleReq drvId (PrintCore args)
+                        case NE.nonEmpty args of
+                          Nothing -> pure model
+                          Just (NE.head -> sym) ->
+                            let model1 = (modelConsole . consoleLastBinding .~ Just sym) model
+                             in pure model1
+                    | msg == ":goto-source" -> do
+                        ss <- getSS
+                        let mmod = ss ^. serverDriverModuleMap . to (forwardLookup drvId)
+                            model' =
+                              (modelSourceView . srcViewExpandedModule .~ mmod) model
+                        branchTab TabSourceView (view, model')
+                        -- should not be reached.
+                        pure model'
+                    | otherwise -> do
+                        sendRequest $ ConsoleReq drvId (Ping msg)
+                        pure model
+              pure model'
           else pure model0
       ConsoleEv (ConsoleInput content) -> do
         let model = (modelConsole . consoleInputEntry .~ content) model0

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -235,6 +235,8 @@ goCommon ev (view, model0) = do
                       sendRequest $ ConsoleReq drvId NextBreakpoint
                   | msg == ":unqualified" ->
                       sendRequest $ ConsoleReq drvId ShowUnqualifiedImports
+                  | msg == ":test" ->
+                      sendRequest $ ConsoleReq drvId Test
                   | msg == ":list-core" ->
                       sendRequest $ ConsoleReq drvId ListCore
                   | ":print-core" `T.isPrefixOf` msg -> do

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -239,9 +239,6 @@ goCommon ev (view, model0) = do
                     | msg == ":unqualified" -> do
                         sendRequest $ ConsoleReq drvId ShowUnqualifiedImports
                         pure model
-                    | msg == ":test" -> do
-                        sendRequest $ ConsoleReq drvId Test
-                        pure model
                     | msg == ":list-core" -> do
                         sendRequest $ ConsoleReq drvId ListCore
                         pure model

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -72,8 +72,7 @@ render tabs contents mfocus inputEntry = div [] [consoleTabs, console]
               [ text
                   "var me = document.currentScript;\n\
                   \var myParent = me.parentElement;\n\
-                  \console.log(myParent);\n\
-                  \var config = {attirbutes: true, childList: true, subtree: true, characterData: true };\n\
+                  \var config = {attributes: true, childList: true, subtree: true, characterData: true };\n\
                   \var callback = (mutationList, observer) => {\n\
                   \      myParent.scrollTop = myParent.scrollHeight;\n\
                   \    };\n\

--- a/daemon/src/GHCSpecter/Render/Components/TextView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TextView.hs
@@ -1,5 +1,15 @@
 module GHCSpecter.Render.Components.TextView
-  ( render,
+  ( -- * predefined layout
+    rowSize,
+    ratio,
+    charSize,
+    topOfBox,
+    bottomOfBox,
+    leftOfBox,
+    rightOfBox,
+
+    -- * top-level render function
+    render,
   )
 where
 
@@ -15,6 +25,27 @@ import GHCSpecter.Render.Util (xmlns)
 import GHCSpecter.UI.ConcurReplica.DOM (text)
 import GHCSpecter.UI.ConcurReplica.SVG qualified as S
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+
+rowSize :: Double
+rowSize = 8
+
+ratio :: Double
+ratio = 0.6
+
+charSize :: Double
+charSize = rowSize * ratio
+
+topOfBox :: Int -> Double
+topOfBox i = rowSize * fromIntegral (i - 1)
+
+bottomOfBox :: Int -> Double
+bottomOfBox i = rowSize * fromIntegral i
+
+leftOfBox :: Int -> Double
+leftOfBox j = charSize * fromIntegral (j - 1)
+
+rightOfBox :: Int -> Double
+rightOfBox j = charSize * fromIntegral j
 
 render :: Bool -> Text -> [((Int, Int), (Int, Int))] -> Widget IHTML a
 render showCharBox txt highlighted =
@@ -35,17 +66,6 @@ render showCharBox txt highlighted =
         [] -> 200
         _ -> charSize * fromIntegral (maximum $ fmap (T.length . snd) ls)
     packShow = T.pack . show
-    rowSize = 8
-    ratio = 0.6
-    charSize = rowSize * ratio
-    topOfBox :: Int -> Double
-    topOfBox i = rowSize * fromIntegral (i - 1)
-    bottomOfBox :: Int -> Double
-    bottomOfBox i = rowSize * fromIntegral i
-    leftOfBox :: Int -> Double
-    leftOfBox j = charSize * fromIntegral (j - 1)
-    rightOfBox :: Int -> Double
-    rightOfBox j = charSize * fromIntegral j
     charBox ((i, j), _) =
       S.rect
         [ SP.x (packShow $ leftOfBox j)

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -193,6 +193,8 @@ renderSourceView srcUI ss =
             "var me1 = document.currentScript;\n\
             \var myParent1 = me1.parentElement;\n\
             \console.log(myParent1);\n\
+            \var top0 = myParent1.getAttribute(\"myval\");\n\
+            \myParent1.scrollTop = top0;\n\
             \var config1 = {attributes: true, childList: false, subtree: false, characterData: false};\n\
             \var callback1 = (mutationList, observer) => {\n\
             \      var top = myParent1.getAttribute(\"myval\");\n\

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -28,6 +28,7 @@ import GHCSpecter.Channel.Outbound.Types
 import GHCSpecter.Data.GHC.Hie (HasModuleHieInfo (..), ModuleHieInfo)
 import GHCSpecter.Render.Components.GraphView qualified as GraphView
 import GHCSpecter.Render.Components.TextView qualified as TextView
+import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types
   ( HasHieState (..),
     HasModuleGraphState (..),
@@ -37,7 +38,6 @@ import GHCSpecter.Server.Types
   )
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,
-    hr,
     input,
     li,
     pre,
@@ -166,15 +166,15 @@ renderCallGraph modu ss =
 
 renderSourceView :: SourceViewUI -> ServerState -> Widget IHTML Event
 renderSourceView srcUI ss =
-  div
+  divClass
+    "columns"
     [ style
         [ ("height", ss ^. serverSessionInfo . to sessionIsPaused . to widgetHeight)
-        , ("overflow", "scroll")
+        , ("overflow", "hidden")
         ]
     ]
     contents
   where
-    inbox = ss ^. serverInbox
     hie = ss ^. serverHieState
     mexpandedModu = srcUI ^. srcViewExpandedModule
     contents =
@@ -185,29 +185,24 @@ renderSourceView srcUI ss =
                 case mmodHieInfo of
                   Nothing -> div [] [pre [] [text "No Hie info"]]
                   Just modHieInfo -> renderSourceCode modHieInfo
-           in [ sourcePanel
-              , hr []
-              , renderCallGraph modu ss
-              , hr []
-              , renderUnqualifiedImports modu inbox
+           in [ divClass "column box is-three-quarters" [style [("overflow", "scroll")]] [sourcePanel]
+              , divClass "column box is-one-quarter" [style [("overflow", "scroll")]] [renderCallGraph modu ss]
               ]
         _ -> []
 
 render :: SourceViewUI -> ServerState -> Widget IHTML Event
 render srcUI ss =
-  div
-    [ classList [("columns", True)]
-    , style [("overflow", "hidden")]
+  divClass
+    "columns"
+    [ style [("overflow", "hidden")]
     , height "100%"
     ]
-    [ div
-        [ classList [("column box is-one-fifths", True)]
-        , style [("overflow", "scroll")]
-        ]
+    [ divClass
+        "column box is-one-fifths"
+        [style [("overflow", "scroll")]]
         [SourceViewEv <$> renderModuleTree srcUI ss]
-    , div
-        [ classList [("column box is-four-fifths", True)]
-        , style [("overflow", "scroll")]
-        ]
+    , divClass
+        "column box is-four-fifths"
+        [style [("overflow", "scroll")]]
         [renderSourceView srcUI ss]
     ]

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -46,15 +46,17 @@ makeClassy ''ModuleGraphUI
 emptyModuleGraphUI :: ModuleGraphUI
 emptyModuleGraphUI = ModuleGraphUI Nothing Nothing
 
-newtype SourceViewUI = SourceViewUI
+data SourceViewUI = SourceViewUI
   { _srcViewExpandedModule :: Maybe Text
   -- ^ expanded module in SourceView
+  , _srcViewFocusedBinding :: Maybe Text
+  -- ^ focused binding if exist
   }
 
 makeClassy ''SourceViewUI
 
 emptySourceViewUI :: SourceViewUI
-emptySourceViewUI = SourceViewUI Nothing
+emptySourceViewUI = SourceViewUI Nothing Nothing
 
 data TimingUI = TimingUI
   { _timingUIPartition :: Bool
@@ -76,13 +78,12 @@ data ConsoleUI = ConsoleUI
   -- ^ focused console tab
   , _consoleInputEntry :: Text
   -- ^ console input entry
-  , _consoleLastBinding :: Maybe Text
   }
 
 makeClassy ''ConsoleUI
 
 emptyConsoleUI :: ConsoleUI
-emptyConsoleUI = ConsoleUI Nothing "" Nothing
+emptyConsoleUI = ConsoleUI Nothing ""
 
 data MainView = MainView
   { _mainTab :: Tab

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -76,12 +76,13 @@ data ConsoleUI = ConsoleUI
   -- ^ focused console tab
   , _consoleInputEntry :: Text
   -- ^ console input entry
+  , _consoleLastBinding :: Maybe Text
   }
 
 makeClassy ''ConsoleUI
 
 emptyConsoleUI :: ConsoleUI
-emptyConsoleUI = ConsoleUI Nothing ""
+emptyConsoleUI = ConsoleUI Nothing "" Nothing
 
 data MainView = MainView
   { _mainTab :: Tab

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -30,6 +30,7 @@ data ConsoleRequest
   = Ping Text
   | NextBreakpoint
   | ShowUnqualifiedImports
+  | Test
   | ListCore
   | PrintCore [Text]
   deriving (Eq, Ord, Show, Generic)

--- a/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Inbound/Types.hs
@@ -30,7 +30,6 @@ data ConsoleRequest
   = Ping Text
   | NextBreakpoint
   | ShowUnqualifiedImports
-  | Test
   | ListCore
   | PrintCore [Text]
   deriving (Eq, Ord, Show, Generic)

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -72,7 +72,6 @@ import Plugin.GHCSpecter.Task.Core2Core
   )
 import Plugin.GHCSpecter.Task.Typecheck
   ( fetchUnqualifiedImports,
-    testSourceLocation,
   )
 import Plugin.GHCSpecter.Types
   ( MsgQueue (..),
@@ -229,11 +228,7 @@ typecheckPlugin queue drvId mmodNameRef modSummary tc = do
       hiefile' <- canonicalizePath hiefile
       queueMessage queue (CMHsHie drvId hiefile')
 
-  let cmdSet =
-        CommandSet
-          [ (":unqualified", \_ -> fetchUnqualifiedImports tc)
-          , (":test", \_ -> testSourceLocation tc)
-          ]
+  let cmdSet = CommandSet [(":unqualified", \_ -> fetchUnqualifiedImports tc)]
   breakPoint queue drvId mmodNameRef Typecheck cmdSet
   pure tc
 

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -70,7 +70,10 @@ import Plugin.GHCSpecter.Task.Core2Core
   ( listCore,
     printCore,
   )
-import Plugin.GHCSpecter.Task.UnqualifiedImports (fetchUnqualifiedImports)
+import Plugin.GHCSpecter.Task.Typecheck
+  ( fetchUnqualifiedImports,
+    testSourceLocation,
+  )
 import Plugin.GHCSpecter.Types
   ( MsgQueue (..),
     PluginSession (..),
@@ -226,7 +229,11 @@ typecheckPlugin queue drvId mmodNameRef modSummary tc = do
       hiefile' <- canonicalizePath hiefile
       queueMessage queue (CMHsHie drvId hiefile')
 
-  let cmdSet = CommandSet [(":unqualified", \_ -> fetchUnqualifiedImports tc)]
+  let cmdSet =
+        CommandSet
+          [ (":unqualified", \_ -> fetchUnqualifiedImports tc)
+          , (":test", \_ -> testSourceLocation tc)
+          ]
   breakPoint queue drvId mmodNameRef Typecheck cmdSet
   pure tc
 

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -112,22 +112,6 @@ consoleAction queue drvId loc cmds actionRef = liftIO $ do
           reply $
             ConsoleReplyText $
               "cannot show unqualified imports at the breakpoint: " <> T.pack (show loc)
-    Test ->
-      if loc == Typecheck
-        then do
-          case L.lookup ":test" (unCommandSet cmds) of
-            Just cmd -> do
-              let action = liftIO . reply =<< cmd []
-              atomically $
-                writeTVar actionRef (Just action)
-            Nothing ->
-              reply $
-                ConsoleReplyText $
-                  "no such command :test at the breakpoint: " <> T.pack (show loc)
-        else do
-          reply $
-            ConsoleReplyText $
-              "cannot show test at the breakpoint: " <> T.pack (show loc)
     ListCore ->
       case loc of
         Core2Core _ -> do

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -112,6 +112,22 @@ consoleAction queue drvId loc cmds actionRef = liftIO $ do
           reply $
             ConsoleReplyText $
               "cannot show unqualified imports at the breakpoint: " <> T.pack (show loc)
+    Test ->
+      if loc == Typecheck
+        then do
+          case L.lookup ":test" (unCommandSet cmds) of
+            Just cmd -> do
+              let action = liftIO . reply =<< cmd []
+              atomically $
+                writeTVar actionRef (Just action)
+            Nothing ->
+              reply $
+                ConsoleReplyText $
+                  "no such command :test at the breakpoint: " <> T.pack (show loc)
+        else do
+          reply $
+            ConsoleReplyText $
+              "cannot show test at the breakpoint: " <> T.pack (show loc)
     ListCore ->
       case loc of
         Core2Core _ -> do

--- a/plugin/src/Plugin/GHCSpecter/Task/Typecheck.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Typecheck.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE RecordWildCards #-}
-
 module Plugin.GHCSpecter.Task.Typecheck
   ( fetchUnqualifiedImports,
   )

--- a/plugin/src/Plugin/GHCSpecter/Task/Typecheck.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Typecheck.hs
@@ -3,7 +3,6 @@
 
 module Plugin.GHCSpecter.Task.Typecheck
   ( fetchUnqualifiedImports,
-    testSourceLocation,
   )
 where
 
@@ -15,18 +14,14 @@ import Data.Map qualified as M
 import Data.Set (Set)
 import Data.Set qualified as S
 import Data.Text qualified as T
-import GHC.Data.Bag (bagToList)
 import GHC.Driver.Session (getDynFlags)
 import GHC.Plugins (Name)
 import GHC.Tc.Types (TcGblEnv (..), TcM)
 import GHC.Types.Name.Reader (GlobalRdrElt (..))
-import GHC.Types.SrcLoc (getLoc, unLoc)
 import GHCSpecter.Channel.Common.Types
   ( type ModuleName,
   )
 import GHCSpecter.Channel.Outbound.Types (ConsoleReply (..))
-import GHCSpecter.Util.GHC (printPpr, showPpr)
-import Language.Haskell.Syntax.Binds (HsBindLR (..))
 import Plugin.GHCSpecter.Util
   ( formatImportedNames,
     formatName,
@@ -47,39 +42,3 @@ fetchUnqualifiedImports tc = do
           let imported = fmap (formatName dflags) $ S.toList names
           [T.unpack modu, formatImportedNames imported]
   pure (ConsoleReplyText (T.pack rendered))
-
-testSourceLocation :: TcGblEnv -> TcM ConsoleReply
-testSourceLocation tc = do
-  dflags <- getDynFlags
-  let extract FunBind {..} = [fun_id] --  Nothing -- "funbind" -- Just (unLoc fun_id)
-      extract VarBind {..} = [] -- "varbind" -- Just var_id
-      extract PatBind {..} = [] -- "patbind"
-      extract AbsBinds {..} =
-        concatMap (extract . unLoc) (bagToList abs_binds)
-      -- Just () -- "absbinds"
-      extract PatSynBind {} = [] -- "patsynbind"
-      extract XHsBindsLR {} = [] -- "xhsbindsLR"
-      extract _ = []
-      format i =
-        T.pack $
-          showPpr dflags (getLoc i) ++ ":" ++ showPpr dflags (unLoc i)
-  let bs = bagToList $ tcg_binds tc
-      is = concatMap (extract . unLoc) bs
-      txt = T.intercalate "\n" $ fmap format is
-
-  -- txt = T.intercalate " " $ fmap (format . unLoc) bs
-  liftIO $ printPpr dflags bs
-  pure (ConsoleReplyText txt)
-
-{-  usedGREs :: [GlobalRdrElt] <- liftIO $ readIORef (tcg_used_gres tc)
-  let moduleImportMap :: Map ModuleName (Set Name)
-      moduleImportMap =
-        L.foldl' (\(!m) (modu, name) -> M.insertWith S.union modu (S.singleton name) m) M.empty $
-          concatMap mkModuleNameMap usedGREs
-      rendered =
-        unlines $ do
-          (modu, names) <- M.toList moduleImportMap
-          let imported = fmap (formatName dflags) $ S.toList names
-          [T.unpack modu, formatImportedNames imported]
-  pure (ConsoleReplyText (T.pack rendered))
--}

--- a/plugin/src/Plugin/GHCSpecter/Task/Typecheck.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Typecheck.hs
@@ -1,5 +1,6 @@
-module Plugin.GHCSpecter.Task.UnqualifiedImports
+module Plugin.GHCSpecter.Task.Typecheck
   ( fetchUnqualifiedImports,
+    testSourceLocation,
   )
 where
 
@@ -39,3 +40,21 @@ fetchUnqualifiedImports tc = do
           let imported = fmap (formatName dflags) $ S.toList names
           [T.unpack modu, formatImportedNames imported]
   pure (ConsoleReplyText (T.pack rendered))
+
+testSourceLocation :: TcGblEnv -> TcM ConsoleReply
+testSourceLocation tc = do
+  dflags <- getDynFlags
+  pure (ConsoleReplyText "test")
+
+{-  usedGREs :: [GlobalRdrElt] <- liftIO $ readIORef (tcg_used_gres tc)
+  let moduleImportMap :: Map ModuleName (Set Name)
+      moduleImportMap =
+        L.foldl' (\(!m) (modu, name) -> M.insertWith S.union modu (S.singleton name) m) M.empty $
+          concatMap mkModuleNameMap usedGREs
+      rendered =
+        unlines $ do
+          (modu, names) <- M.toList moduleImportMap
+          let imported = fmap (formatName dflags) $ S.toList names
+          [T.unpack modu, formatImportedNames imported]
+  pure (ConsoleReplyText (T.pack rendered))
+-}


### PR DESCRIPTION
`:print-core (symbol)` will  automatically locate the source position if in source view mode.