### PR TITLE
Show blocker modules in both up/downstream direction interactively in TimingView

### DIFF
--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -91,6 +91,20 @@ nav {
     padding: 0;
 }
 
+.blocker p {
+    font-family: "Courier", monospace;
+    font-size: 6px;
+    margin: 0 0 0 10px;
+    padding: 0;
+}
+
+.blocker.title {
+    font-family: "Arial", San-Serif;
+    font-size: 6px;
+    margin: 0;
+    padding: 0;
+}
+
 .console {
     margin: 0;
     padding: 2px 0 0 0;

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -31,6 +31,7 @@ import GHCSpecter.Control.Types
     saveSession,
     sendRequest,
     shouldUpdate,
+    updateTimingCache,
     type Control,
   )
 import GHCSpecter.Data.Timing.Types (HasTimingTable (..))
@@ -170,15 +171,14 @@ defaultUpdateModel topEv (oldModel, oldSS) =
           newSS = (serverShouldUpdate .~ False) oldSS
       pure (newModel, newSS)
     TimingEv (HoverOnModule modu) -> do
-      printMsg ("hover on " <> modu)
       let newModel = (modelTiming . timingUIHoveredModule .~ Just modu) oldModel
       pure (newModel, oldSS)
-    TimingEv (HoverOffModule modu) -> do
-      printMsg ("hover off " <> modu)
+    TimingEv (HoverOffModule _modu) -> do
       let newModel = (modelTiming . timingUIHoveredModule .~ Nothing) oldModel
       pure (newModel, oldSS)
     BkgEv MessageChanUpdated -> do
       let newSS = (serverShouldUpdate .~ True) oldSS
+      updateTimingCache
       pure (oldModel, newSS)
     BkgEv RefreshUI -> do
       pure (oldModel, oldSS)

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -9,6 +9,7 @@ where
 import Control.Lens (to, (%~), (&), (.~), (^.), _1, _2)
 import Data.List qualified as L
 import Data.List.NonEmpty qualified as NE
+import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Data.Time.Clock qualified as Clock
 import GHCSpecter.Channel.Inbound.Types
@@ -32,7 +33,7 @@ import GHCSpecter.Control.Types
     shouldUpdate,
     type Control,
   )
-import GHCSpecter.Data.Timing.Util (makeTimingTable)
+import GHCSpecter.Data.Timing.Types (HasTimingTable (..))
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState,
@@ -139,8 +140,9 @@ defaultUpdateModel topEv (oldModel, oldSS) =
       sendRequest (SessionReq Pause)
       pure (oldModel, newSS)
     TimingEv ToCurrentTime -> do
-      let -- TODO: This is inefficient. Make a cache for timing table.
-          timingInfos = makeTimingTable oldSS
+      let ttable =
+            fromMaybe (oldSS ^. serverTimingTable) (oldModel ^. modelTiming . timingFrozenTable)
+          timingInfos = ttable ^. ttableTimingInfos
           nMods = length timingInfos
           totalHeight = 5 * nMods
           newModel =

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -169,6 +169,14 @@ defaultUpdateModel topEv (oldModel, oldSS) =
       let newModel = (modelTiming . timingUIHowParallel .~ b) oldModel
           newSS = (serverShouldUpdate .~ False) oldSS
       pure (newModel, newSS)
+    TimingEv (HoverOnModule modu) -> do
+      printMsg ("hover on " <> modu)
+      let newModel = (modelTiming . timingUIHoveredModule .~ Just modu) oldModel
+      pure (newModel, oldSS)
+    TimingEv (HoverOffModule modu) -> do
+      printMsg ("hover off " <> modu)
+      let newModel = (modelTiming . timingUIHoveredModule .~ Nothing) oldModel
+      pure (newModel, oldSS)
     BkgEv MessageChanUpdated -> do
       let newSS = (serverShouldUpdate .~ True) oldSS
       pure (oldModel, newSS)

--- a/daemon/src/GHCSpecter/Control/Types.hs
+++ b/daemon/src/GHCSpecter/Control/Types.hs
@@ -16,6 +16,7 @@ module GHCSpecter.Control.Types
     refreshUIAfter,
     shouldUpdate,
     saveSession,
+    updateTimingCache,
   )
 where
 
@@ -41,6 +42,7 @@ data ControlF r
   | ShouldUpdate Bool r
   | SaveSession r
   | RefreshUIAfter Double r
+  | UpdateTimingCache r
   deriving (Functor)
 
 type Control = Free ControlF
@@ -80,3 +82,6 @@ saveSession = liftF (SaveSession ())
 
 refreshUIAfter :: Double -> Control ()
 refreshUIAfter nSec = liftF (RefreshUIAfter nSec ())
+
+updateTimingCache :: Control ()
+updateTimingCache = liftF (UpdateTimingCache ())

--- a/daemon/src/GHCSpecter/Data/Timing/Types.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Types.hs
@@ -2,10 +2,14 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Data.Timing.Types
-  ( -- * extracted timing information
+  ( -- * extracted timing information per module
     TimingInfo (..),
     HasTimingInfo (..),
-    type TimingTable,
+
+    -- * collective timing information for the session
+    TimingTable (..),
+    HasTimingTable (..),
+    emptyTimingTable,
   )
 where
 
@@ -29,4 +33,16 @@ instance FromJSON a => FromJSON (TimingInfo a)
 
 instance ToJSON a => ToJSON (TimingInfo a)
 
-type TimingTable = [(Maybe ModuleName, TimingInfo NominalDiffTime)]
+data TimingTable = TimingTable
+  { _ttableTimingInfos :: [(Maybe ModuleName, TimingInfo NominalDiffTime)]
+  }
+  deriving (Show, Generic)
+
+makeClassy ''TimingTable
+
+emptyTimingTable :: TimingTable
+emptyTimingTable = TimingTable []
+
+instance FromJSON TimingTable
+
+instance ToJSON TimingTable

--- a/daemon/src/GHCSpecter/Data/Timing/Types.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Types.hs
@@ -15,6 +15,8 @@ where
 
 import Control.Lens (makeClassy)
 import Data.Aeson (FromJSON, ToJSON)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
 import Data.Time.Clock (NominalDiffTime)
 import GHC.Generics (Generic)
 import GHCSpecter.Channel.Common.Types (ModuleName)
@@ -35,13 +37,14 @@ instance ToJSON a => ToJSON (TimingInfo a)
 
 data TimingTable = TimingTable
   { _ttableTimingInfos :: [(Maybe ModuleName, TimingInfo NominalDiffTime)]
+  , _ttableLastDepends :: Map ModuleName (ModuleName, TimingInfo NominalDiffTime)
   }
   deriving (Show, Generic)
 
 makeClassy ''TimingTable
 
 emptyTimingTable :: TimingTable
-emptyTimingTable = TimingTable []
+emptyTimingTable = TimingTable [] M.empty
 
 instance FromJSON TimingTable
 

--- a/daemon/src/GHCSpecter/Data/Timing/Types.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Types.hs
@@ -37,14 +37,15 @@ instance ToJSON a => ToJSON (TimingInfo a)
 
 data TimingTable = TimingTable
   { _ttableTimingInfos :: [(Maybe ModuleName, TimingInfo NominalDiffTime)]
-  , _ttableLastDepends :: Map ModuleName (ModuleName, TimingInfo NominalDiffTime)
+  , _ttableBlockingUpstreamDependency :: Map ModuleName ModuleName
+  , _ttableBlockedDownstreamDependency :: Map ModuleName [ModuleName]
   }
   deriving (Show, Generic)
 
 makeClassy ''TimingTable
 
 emptyTimingTable :: TimingTable
-emptyTimingTable = TimingTable [] M.empty
+emptyTimingTable = TimingTable [] M.empty M.empty
 
 instance FromJSON TimingTable
 

--- a/daemon/src/GHCSpecter/Data/Timing/Util.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Util.hs
@@ -13,19 +13,25 @@ where
 
 import Control.Lens (makeClassy, to, (&), (.~), (^.), (^?), _2, _Just)
 import Data.Bifunctor (first)
+import Data.Foldable (for_, traverse_)
+import Data.Function (on)
+import Data.IntMap qualified as IM
 import Data.List qualified as L
+import Data.Map.Strict qualified as M
 import Data.Maybe (isJust, mapMaybe)
 import Data.Time.Clock
   ( NominalDiffTime,
     UTCTime,
     diffUTCTime,
   )
+import Data.Tuple (swap)
 import GHCSpecter.Channel.Common.Types
   ( DriverId (..),
     type ModuleName,
   )
 import GHCSpecter.Channel.Outbound.Types
-  ( SessionInfo (..),
+  ( ModuleGraphInfo (..),
+    SessionInfo (..),
     Timer (..),
     getAsTime,
     getEndTime,
@@ -39,6 +45,7 @@ import GHCSpecter.Data.Timing.Types
     TimingTable,
     emptyTimingTable,
   )
+import GHCSpecter.GraphLayout.Algorithm.Builder (makeBiDep)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     ServerState,
@@ -63,34 +70,60 @@ isModuleCompilationDone drvModMap timing modu =
     timing ^? to (lookupKey i) . _Just . to getEndTime . _Just
 
 makeTimingTable ::
-  -- ServerState -> TimingTable
   KeyMap DriverId Timer ->
   BiKeyMap DriverId ModuleName ->
+  ModuleGraphInfo ->
   UTCTime ->
-  TimingTable
-makeTimingTable timing drvModMap sessStart =
-  let findModName drvId = forwardLookup drvId drvModMap
+  IO TimingTable
+makeTimingTable timing drvModMap mgi sessStart = do
+  for_ (findLastDep testCase) $ \(lst, mlastDep) -> do
+    putStrLn "=================="
+    traverse_ print lst
+    putStrLn "##################"
+    print mlastDep
 
-      subtractTime (modName, timer) = do
-        modStartTime <- getStartTime timer
-        modHscOutTime <- getHscOutTime timer
-        modAsTime <- getAsTime timer
-        modEndTime <- getEndTime timer
-        let modStartTimeDiff = modStartTime `diffUTCTime` sessStart
-            modHscOutTimeDiff = modHscOutTime `diffUTCTime` sessStart
-            modAsTimeDiff = modAsTime `diffUTCTime` sessStart
-            modEndTimeDiff = modEndTime `diffUTCTime` sessStart
-            tinfo =
-              TimingInfo
-                { _timingStart = modStartTimeDiff
-                , _timingHscOut = modHscOutTimeDiff
-                , _timingAs = modAsTimeDiff
-                , _timingEnd = modEndTimeDiff
-                }
-        pure (modName, tinfo)
-      timingInfos =
-        fmap (first findModName)
-          . L.sortOn (^. _2 . timingStart)
-          . mapMaybe subtractTime
-          $ keyMapToList timing
-   in emptyTimingTable & (ttableTimingInfos .~ timingInfos)
+  pure $
+    emptyTimingTable & (ttableTimingInfos .~ timingInfos)
+  where
+    testCase = "Model.Import"
+    findLastDep mod = do
+      modId <- M.lookup mod nameModMap
+      upIds <- IM.lookup modId modDep
+      upNames <- traverse (`IM.lookup` modNameMap) upIds
+      let timingInfos' = mapMaybe (\(mn, t) -> (,t) <$> mn) timingInfos
+          isMyUpstream = (`elem` upNames) . fst
+          upTiming = filter isMyUpstream timingInfos'
+          lastDep
+            | null upTiming = Nothing
+            | otherwise =
+                Just $
+                  L.maximumBy (compare `on` (^. _2 . timingEnd)) upTiming
+      pure (upTiming, lastDep)
+
+    modNameMap = mginfoModuleNameMap mgi
+    nameModMap = M.fromList $ fmap swap $ IM.toList modNameMap
+    modDep = mginfoModuleDep mgi
+
+    findModName drvId = forwardLookup drvId drvModMap
+    subtractTime (modName, timer) = do
+      modStartTime <- getStartTime timer
+      modHscOutTime <- getHscOutTime timer
+      modAsTime <- getAsTime timer
+      modEndTime <- getEndTime timer
+      let modStartTimeDiff = modStartTime `diffUTCTime` sessStart
+          modHscOutTimeDiff = modHscOutTime `diffUTCTime` sessStart
+          modAsTimeDiff = modAsTime `diffUTCTime` sessStart
+          modEndTimeDiff = modEndTime `diffUTCTime` sessStart
+          tinfo =
+            TimingInfo
+              { _timingStart = modStartTimeDiff
+              , _timingHscOut = modHscOutTimeDiff
+              , _timingAs = modAsTimeDiff
+              , _timingEnd = modEndTimeDiff
+              }
+      pure (modName, tinfo)
+    timingInfos =
+      fmap (first findModName)
+        . L.sortOn (^. _2 . timingStart)
+        . mapMaybe subtractTime
+        $ keyMapToList timing

--- a/daemon/src/GHCSpecter/Data/Timing/Util.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Util.hs
@@ -74,13 +74,12 @@ makeTimingTable ::
   BiKeyMap DriverId ModuleName ->
   ModuleGraphInfo ->
   UTCTime ->
-  IO TimingTable
-makeTimingTable timing drvModMap mgi sessStart = do
-  putStrLn "##################"
-  print lastDepMap
-  print lastDepRevMap
-  pure $
-    emptyTimingTable & (ttableTimingInfos .~ timingInfos)
+  TimingTable
+makeTimingTable timing drvModMap mgi sessStart =
+  emptyTimingTable &
+    (ttableTimingInfos .~ timingInfos)
+      . (ttableBlockingUpstreamDependency .~ lastDepMap)
+      . (ttableBlockedDownstreamDependency .~ lastDepRevMap)
   where
     findModName drvId = forwardLookup drvId drvModMap
     subtractTime (modName, timer) = do

--- a/daemon/src/GHCSpecter/Data/Timing/Util.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Util.hs
@@ -76,8 +76,8 @@ makeTimingTable ::
   UTCTime ->
   TimingTable
 makeTimingTable timing drvModMap mgi sessStart =
-  emptyTimingTable &
-    (ttableTimingInfos .~ timingInfos)
+  emptyTimingTable
+    & (ttableTimingInfos .~ timingInfos)
       . (ttableBlockingUpstreamDependency .~ lastDepMap)
       . (ttableBlockedDownstreamDependency .~ lastDepRevMap)
   where

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -56,7 +56,6 @@ import GHCSpecter.Util.Map
   )
 import GHCSpecter.Worker.Hie (hieWorker)
 import GHCSpecter.Worker.ModuleGraph (moduleGraphWorker)
-import GHCSpecter.Worker.Timing (timingWorker)
 
 updateInbox :: ChanMessageBox -> ServerState -> ServerState
 updateInbox chanMsg = incrementSN . updater
@@ -102,6 +101,7 @@ updateInbox chanMsg = incrementSN . updater
             let msg = ConsoleCore forest
              in (serverConsole %~ alterToKeyMap (appendConsoleMsg msg) drvId)
 
+-- TODO: These all should be part of Control, not here.
 invokeWorker :: TVar ServerState -> TQueue (IO ()) -> ChanMessageBox -> IO ()
 invokeWorker ssRef workQ (CMBox o) =
   case o of
@@ -114,7 +114,7 @@ invokeWorker ssRef workQ (CMBox o) =
       let modHie = (modHieSource .~ src) emptyModuleHieInfo
       atomically $
         modifyTVar' ssRef (serverHieState . hieModuleMap %~ M.insert modu modHie)
-    CMTiming {} -> void $ forkIO $ timingWorker ssRef
+    CMTiming {} -> pure ()
     CMSession s' -> do
       let mgi = sessionModuleGraph s'
       void $ forkIO (moduleGraphWorker ssRef mgi)

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -43,7 +43,7 @@ import GHCSpecter.Channel.Outbound.Types
     emptyModuleGraphInfo,
   )
 import GHCSpecter.Data.GHC.Hie (ModuleHieInfo)
-import GHCSpecter.Data.Timing.Types (TimingTable)
+import GHCSpecter.Data.Timing.Types (TimingTable, emptyTimingTable)
 import GHCSpecter.GraphLayout.Types (GraphVisInfo)
 import GHCSpecter.UI.Types.Event (DetailLevel)
 import GHCSpecter.Util.Map (BiKeyMap, KeyMap, emptyBiKeyMap, emptyKeyMap)
@@ -133,7 +133,7 @@ emptyServerState =
     , _serverSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo False
     , _serverDriverModuleMap = emptyBiKeyMap
     , _serverTiming = emptyKeyMap
-    , _serverTimingTable = []
+    , _serverTimingTable = emptyTimingTable
     , _serverPaused = emptyKeyMap
     , _serverConsole = emptyKeyMap
     , _serverModuleGraphState = emptyModuleGraphState

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -69,12 +69,13 @@ data TimingUI = TimingUI
   , _timingUIViewPortTopLeft :: (Double, Double)
   -- ^ Top-Left corner of timing UI viewport
   , _timingUIHandleMouseMove :: Bool
+  , _timingUIHoveredModule :: Maybe Text
   }
 
 makeClassy ''TimingUI
 
 emptyTimingUI :: TimingUI
-emptyTimingUI = TimingUI Nothing False False (0, 0) False
+emptyTimingUI = TimingUI Nothing False False (0, 0) False Nothing
 
 data ConsoleUI = ConsoleUI
   { _consoleFocus :: Maybe DriverId

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -65,6 +65,8 @@ data TimingEvent
     TimingFlow Bool
   | UpdatePartition Bool
   | UpdateParallel Bool
+  | HoverOnModule ModuleName
+  | HoverOffModule ModuleName
   deriving (Show, Eq)
 
 data MouseEvent

--- a/daemon/src/GHCSpecter/Worker/Timing.hs
+++ b/daemon/src/GHCSpecter/Worker/Timing.hs
@@ -27,5 +27,5 @@ timingWorker ssRef = do
       let timing = ss ^. serverTiming
           drvModMap = ss ^. serverDriverModuleMap
           mgi = sessionModuleGraph sessInfo
-      ttable <- makeTimingTable timing drvModMap mgi sessStart
+          ttable = makeTimingTable timing drvModMap mgi sessStart
       atomically $ modifyTVar' ssRef (serverTimingTable .~ ttable)

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -77,9 +77,7 @@ instance FromJSON ModuleGraphInfo
 
 instance ToJSON ModuleGraphInfo
 
-instance Binary ModuleGraphInfo where
-  put (ModuleGraphInfo m d s) = put (m, d, s)
-  get = (\(m, d, s) -> ModuleGraphInfo m d s) <$> get
+instance Binary ModuleGraphInfo
 
 emptyModuleGraphInfo :: ModuleGraphInfo
 emptyModuleGraphInfo = ModuleGraphInfo mempty mempty []
@@ -92,9 +90,7 @@ data SessionInfo = SessionInfo
   }
   deriving (Show, Generic)
 
-instance Binary SessionInfo where
-  put (SessionInfo pid mtime modGraph isPaused) = put (pid, mtime, modGraph, isPaused)
-  get = (\(pid, mtime, modGraph, isPaused) -> SessionInfo pid mtime modGraph isPaused) <$> get
+instance Binary SessionInfo
 
 instance FromJSON SessionInfo
 


### PR DESCRIPTION
The last compiled upper dependency blocking a given module and downstream modules that was blocked by a given module are now interactively shown.