### PR TITLE
Place breakpoints at additional points using source plugins

### DIFF
--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -52,7 +52,7 @@ instance ToJSON Channel
 
 data BreakpointLoc
   = StartDriver
-  | AfterParser
+  | ParsedResultAction
   | Typecheck
   | Core2Core Text
   | PreRunPhase Text

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -53,6 +53,7 @@ instance ToJSON Channel
 data BreakpointLoc
   = StartDriver
   | ParsedResultAction
+  | RenamedResultAction
   | Typecheck
   | Core2Core Text
   | PreRunPhase Text

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -56,6 +56,7 @@ data BreakpointLoc
   | RenamedResultAction
   | SpliceRunAction
   | Typecheck
+  | TypecheckResultAction
   | Core2Core Text
   | PreRunPhase Text
   | -- | (before_phase, after_phase)

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -54,6 +54,7 @@ data BreakpointLoc
   = StartDriver
   | ParsedResultAction
   | RenamedResultAction
+  | SpliceRunAction
   | Typecheck
   | Core2Core Text
   | PreRunPhase Text

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -205,6 +205,8 @@ parsedResultActionPlugin queue drvId modNameRef modSummary parsedMod = do
     msrcFile' <- traverse canonicalizePath msrcFile
     writeIORef modNameRef (Just modName)
     sendModuleName queue drvId modName msrcFile'
+  let cmdSet = CommandSet []
+  breakPoint queue drvId modNameRef ParsedResultAction cmdSet
   pure parsedMod
 
 --
@@ -218,7 +220,7 @@ typecheckPlugin ::
   ModSummary ->
   TcGblEnv ->
   TcM TcGblEnv
-typecheckPlugin queue drvId mmodNameRef modSummary tc = do
+typecheckPlugin queue drvId modNameRef modSummary tc = do
   -- send HIE file information to the daemon after compilation
   dflags <- getDynFlags
   let modLoc = ms_location modSummary
@@ -229,7 +231,7 @@ typecheckPlugin queue drvId mmodNameRef modSummary tc = do
       queueMessage queue (CMHsHie drvId hiefile')
 
   let cmdSet = CommandSet [(":unqualified", \_ -> fetchUnqualifiedImports tc)]
-  breakPoint queue drvId mmodNameRef Typecheck cmdSet
+  breakPoint queue drvId modNameRef Typecheck cmdSet
   pure tc
 
 --

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -317,6 +317,8 @@ driver opts env0 = do
   drvId <- initDriverSession
   let -- NOTE: this will wipe out all other plugins and fix opts
       -- TODO: if other plugins exist, throw exception.
+      -- TODO: intefaceLoadAction plugin (interfere with driverPlugin due to withPlugin)
+      -- TODO: tcPlugin. need different mechanism
       newPlugin =
         plugin
           { installCoreToDos = \_opts -> corePlugin queue drvId modNameRef

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -244,17 +244,17 @@ spliceRunActionPlugin queue drvId modNameRef expr = do
   pure expr
 
 --
--- typecheck plugin
+-- typeCheckResultAction plugin
 --
 
-typecheckPlugin ::
+typeCheckResultActionPlugin ::
   MsgQueue ->
   DriverId ->
   IORef (Maybe ModuleName) ->
   ModSummary ->
   TcGblEnv ->
   TcM TcGblEnv
-typecheckPlugin queue drvId modNameRef modSummary tc = do
+typeCheckResultActionPlugin queue drvId modNameRef modSummary tc = do
   -- send HIE file information to the daemon after compilation
   dflags <- getDynFlags
   let modLoc = ms_location modSummary
@@ -265,7 +265,7 @@ typecheckPlugin queue drvId modNameRef modSummary tc = do
       queueMessage queue (CMHsHie drvId hiefile')
 
   let cmdSet = CommandSet [(":unqualified", \_ -> fetchUnqualifiedImports tc)]
-  breakPoint queue drvId modNameRef Typecheck cmdSet
+  breakPoint queue drvId modNameRef TypecheckResultAction cmdSet
   pure tc
 
 --
@@ -323,7 +323,7 @@ driver opts env0 = do
           , parsedResultAction = \_opts -> parsedResultActionPlugin queue drvId modNameRef
           , renamedResultAction = \_opts -> renamedResultActionPlugin queue drvId modNameRef
           , spliceRunAction = \_opts -> spliceRunActionPlugin queue drvId modNameRef
-          , typeCheckResultAction = \_opts -> typecheckPlugin queue drvId modNameRef
+          , typeCheckResultAction = \_opts -> typeCheckResultActionPlugin queue drvId modNameRef
           }
       env = env0 {hsc_static_plugins = [StaticPlugin (PluginWithArgs newPlugin opts)]}
   startTime <- getCurrentTime

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -108,7 +108,7 @@ consoleAction queue drvId loc cmds actionRef = liftIO $ do
               console' = console {consoleDriverInStep = Just drvId}
            in psess {psConsoleState = console'}
     ShowUnqualifiedImports ->
-      doCommand ":unqualified" (== Typecheck) "show unqualified imports" []
+      doCommand ":unqualified" (== TypecheckResultAction) "show unqualified imports" []
     ListCore ->
       doCommand ":list-core" (\case Core2Core _ -> True; _ -> False) "list core" []
     PrintCore args ->


### PR DESCRIPTION
parsedResultAction, renamedResultAction, spliceRunAction can be paused.
Typecheck breakpoint is renamed to TypecheckResultAction to be more correct.