### PR TITLE
Tabbed Supplementary View interface

### DIFF
--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -46,6 +46,10 @@ nav {
     background: lightgrey;
 }
 
+.is-tab.is-active.supp-tab {
+    background: lightgrey;
+}
+
 .columns {
     width: 100%;
     display: flex;

--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -260,6 +260,13 @@ ul.tree span::before {
     display: block;
 }
 
+.suppview pre {
+    margin: 5px;
+    padding: 5px;
+    font-family: "Courier", monospace;
+    font-size: 8px;
+}
+
 /* symbols */
 
 .langle {

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -111,6 +111,11 @@ defaultUpdateModel topEv (oldModel, oldSS) =
           bps = newSS ^. serverModuleBreakpoints
       sendRequest $ SessionReq (SetModuleBreakpoints bps)
       pure (oldModel, newSS)
+    SourceViewEv (SourceViewTab tab) -> do
+      let newModel =
+            (modelSourceView . srcViewSuppViewTab .~ Just tab) oldModel
+          newSS = (serverShouldUpdate .~ False) oldSS
+      pure (newModel, newSS)
     MainModuleEv ev -> do
       let mgui = oldModel ^. modelMainModuleGraph
           mgui' = handleModuleGraphEv ev mgui

--- a/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
@@ -22,6 +22,13 @@ import GHCSpecter.UI.Types.Event (ConsoleEvent (..))
 import Prelude hiding (div)
 
 render :: ConsoleItem -> Widget IHTML (ConsoleEvent k)
+render (ConsoleCommand txt) =
+  divClass
+    "console-item"
+    []
+    [ div [style [("width", "10px")]] [text ">"]
+    , pre [] [text txt]
+    ]
 render (ConsoleText txt) =
   divClass
     "console-item"

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -174,7 +174,14 @@ renderSuppView (SuppViewCallgraph grVis) =
         ]
     ]
     [GraphView.renderGraph (isJust . T.find (== '.')) grVis]
-renderSuppView _ = div [] []
+renderSuppView (SuppViewText txt) =
+  div
+    [ style
+        [ ("overflow", "scroll")
+        , ("height", "100%")
+        ]
+    ]
+    [pre [] [text txt]]
 
 renderSuppViewPanel :: ModuleName -> SourceViewUI -> ServerState -> Widget IHTML Event
 renderSuppViewPanel modu srcUI ss =
@@ -200,9 +207,10 @@ renderSuppViewPanel modu srcUI ss =
             [text tab]
 
     suppViewTabs =
-      nav
-        [classList [("navbar", True)]]
-        [navbarMenu [navbarStart (fmap (\(t, _) -> navItem (t, t)) suppViews)]]
+      let formatTab (t, i) = t <> ":" <> T.pack (show i)
+       in nav
+            [classList [("navbar", True)]]
+            [navbarMenu [navbarStart (fmap (\(k, _) -> navItem (k, formatTab k)) suppViews)]]
     suppViewContents =
       case msuppView of
         Nothing -> div [] []

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -42,6 +42,7 @@ import GHCSpecter.Server.Types
     HasTimingState (..),
     Inbox,
     ServerState (..),
+    SupplementaryView (..),
   )
 import GHCSpecter.UI.ConcurReplica.DOM
   ( div,
@@ -162,14 +163,17 @@ renderModuleTree srcUI ss =
                   ]
        in modItem
 
-renderCallGraph :: ModuleName -> ServerState -> Widget IHTML a
-renderCallGraph modu ss =
+renderSupplementaryView :: ModuleName -> ServerState -> Widget IHTML a
+renderSupplementaryView modu ss =
   case mgrVis of
     Nothing -> div [] []
     Just grVis -> GraphView.renderGraph (isJust . T.find (== '.')) grVis
   where
-    callGraphMap = ss ^. serverHieState . hieCallGraphMap
-    mgrVis = M.lookup modu callGraphMap
+    -- callGraphMap = ss ^. serverHieState . hieCallGraphMap
+    mgrVis = do
+      suppViews <- M.lookup modu (ss ^. serverSuppView)
+      SuppViewCallgraph grVis <- L.lookup "Call Graph" suppViews
+      pure grVis
 
 renderSourceView :: SourceViewUI -> ServerState -> Widget IHTML Event
 renderSourceView srcUI ss =
@@ -233,7 +237,7 @@ renderSourceView srcUI ss =
               , divClass
                   "column box is-half"
                   [style [("overflow", "scroll")]]
-                  [renderCallGraph modu ss]
+                  [renderSupplementaryView modu ss]
               ]
         _ -> []
 

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -175,7 +175,8 @@ renderSuppView (SuppViewCallgraph grVis) =
     ]
     [GraphView.renderGraph (isJust . T.find (== '.')) grVis]
 renderSuppView (SuppViewText txt) =
-  div
+  divClass
+    "suppview"
     [ style
         [ ("overflow", "scroll")
         , ("height", "100%")

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -20,6 +20,11 @@ module GHCSpecter.Server.Types
     HieState (..),
     HasHieState (..),
     emptyHieState,
+
+    -- * Supplementary view
+    SupplementaryView (..),
+
+    -- * console
     ConsoleItem (..),
 
     -- * Server state
@@ -104,7 +109,7 @@ emptyModuleGraphState = ModuleGraphState [] Nothing [] []
 
 data HieState = HieState
   { _hieModuleMap :: Map ModuleName ModuleHieInfo
-  , _hieCallGraphMap :: Map ModuleName GraphVisInfo
+  -- , _hieCallGraphMap :: Map ModuleName GraphVisInfo
   }
   deriving (Show, Generic)
 
@@ -115,7 +120,7 @@ instance FromJSON HieState
 instance ToJSON HieState
 
 emptyHieState :: HieState
-emptyHieState = HieState mempty mempty
+emptyHieState = HieState mempty -- mempty
 
 data ConsoleItem
   = -- | Command input
@@ -135,6 +140,15 @@ instance FromJSON ConsoleItem
 
 instance ToJSON ConsoleItem
 
+data SupplementaryView
+  = SuppViewCallgraph GraphVisInfo
+  | SuppViewText Text
+  deriving (Show, Generic)
+
+instance FromJSON SupplementaryView
+
+instance ToJSON SupplementaryView
+
 data ServerState = ServerState
   { _serverMessageSN :: Int
   , _serverShouldUpdate :: Bool
@@ -144,6 +158,7 @@ data ServerState = ServerState
   , _serverTiming :: TimingState
   , _serverPaused :: KeyMap DriverId BreakpointLoc
   , _serverConsole :: KeyMap DriverId [ConsoleItem]
+  , _serverSuppView :: Map ModuleName [(Text, SupplementaryView)]
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   , _serverModuleBreakpoints :: [ModuleName]
@@ -167,6 +182,7 @@ emptyServerState =
     , _serverTiming = emptyTimingState
     , _serverPaused = emptyKeyMap
     , _serverConsole = emptyKeyMap
+    , _serverSuppView = mempty
     , _serverModuleGraphState = emptyModuleGraphState
     , _serverHieState = emptyHieState
     , _serverModuleBreakpoints = []

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -107,9 +107,8 @@ instance ToJSON ModuleGraphState
 emptyModuleGraphState :: ModuleGraphState
 emptyModuleGraphState = ModuleGraphState [] Nothing [] []
 
-data HieState = HieState
+newtype HieState = HieState
   { _hieModuleMap :: Map ModuleName ModuleHieInfo
-  -- , _hieCallGraphMap :: Map ModuleName GraphVisInfo
   }
   deriving (Show, Generic)
 
@@ -120,7 +119,7 @@ instance FromJSON HieState
 instance ToJSON HieState
 
 emptyHieState :: HieState
-emptyHieState = HieState mempty -- mempty
+emptyHieState = HieState mempty
 
 data ConsoleItem
   = -- | Command input

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -118,7 +118,9 @@ emptyHieState :: HieState
 emptyHieState = HieState mempty mempty
 
 data ConsoleItem
-  = -- | Simple text message
+  = -- | Command input
+    ConsoleCommand Text
+  | -- | Simple text message
     ConsoleText Text
   | -- | Collection of buttons. Note that the information from ConsoleReply is
     -- enriched with the corresponding console command for convenience.

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -157,7 +157,7 @@ data ServerState = ServerState
   , _serverTiming :: TimingState
   , _serverPaused :: KeyMap DriverId BreakpointLoc
   , _serverConsole :: KeyMap DriverId [ConsoleItem]
-  , _serverSuppView :: Map ModuleName [(Text, SupplementaryView)]
+  , _serverSuppView :: Map ModuleName [((Text, Int), SupplementaryView)]
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   , _serverModuleBreakpoints :: [ModuleName]

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -56,12 +56,13 @@ data SourceViewUI = SourceViewUI
   -- ^ expanded module in SourceView
   , _srcViewFocusedBinding :: Maybe Text
   -- ^ focused binding if exist
+  , _srcViewSuppViewTab :: Maybe Text
   }
 
 makeClassy ''SourceViewUI
 
 emptySourceViewUI :: SourceViewUI
-emptySourceViewUI = SourceViewUI Nothing Nothing
+emptySourceViewUI = SourceViewUI Nothing Nothing Nothing
 
 data TimingUI = TimingUI
   { _timingFrozenTable :: Maybe TimingTable

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -56,7 +56,7 @@ data SourceViewUI = SourceViewUI
   -- ^ expanded module in SourceView
   , _srcViewFocusedBinding :: Maybe Text
   -- ^ focused binding if exist
-  , _srcViewSuppViewTab :: Maybe Text
+  , _srcViewSuppViewTab :: Maybe (Text, Int)
   }
 
 makeClassy ''SourceViewUI

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -41,7 +41,7 @@ data SourceViewEvent
   = SelectModule ModuleName
   | UnselectModule
   | SetBreakpoint ModuleName Bool
-  | SourceViewTab Text
+  | SourceViewTab (Text, Int)
   deriving (Show, Eq)
 
 data ModuleGraphEvent

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -41,6 +41,7 @@ data SourceViewEvent
   = SelectModule ModuleName
   | UnselectModule
   | SetBreakpoint ModuleName Bool
+  | SourceViewTab Text
   deriving (Show, Eq)
 
 data ModuleGraphEvent

--- a/daemon/src/GHCSpecter/Worker/CallGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/CallGraph.hs
@@ -57,8 +57,7 @@ import GHCSpecter.GraphLayout.Algorithm.Builder (makeRevDep)
 import GHCSpecter.GraphLayout.Sugiyama qualified as Sugiyama
 import GHCSpecter.GraphLayout.Types (GraphVisInfo)
 import GHCSpecter.Server.Types
-  ( HasHieState (..),
-    HasServerState (..),
+  ( HasServerState (..),
     ServerState (..),
     SupplementaryView (..),
   )
@@ -227,4 +226,4 @@ worker var modName modHieInfo = do
       atomically $
         modifyTVar' var $
           serverSuppView
-            %~ M.alter (append ("Call Graph", SuppViewCallgraph callGraphViz)) modName
+            %~ M.alter (append (("CallGraph", 0), SuppViewCallgraph callGraphViz)) modName

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -134,8 +134,8 @@ getEndTime :: Timer -> Maybe UTCTime
 getEndTime (Timer ts) = L.lookup TimerEnd ts
 
 data ConsoleReply
-  = -- | simple textual reply
-    ConsoleReplyText Text
+  = -- | simple textual reply (with name optionally)
+    ConsoleReplyText (Maybe Text) Text
   | -- | list of Core bind items. The items in the same inner list are mutually
     -- recursive binding, i.e. should be presented together.
     ConsoleReplyCoreBindList [[Text]]

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -77,13 +77,13 @@ consoleAction queue drvId loc cmds actionRef = liftIO $ do
               writeTVar actionRef (Just action)
         | otherwise =
             reply $
-              ConsoleReplyText $
+              ConsoleReplyText Nothing $
                 "cannot " <> cmdDesc <> " at the breakpoint: " <> T.pack (show loc)
   case req of
     Ping msg -> do
       TIO.putStrLn $ "ping: " <> msg
       let pongMsg = "pong: " <> msg
-      reply (ConsoleReplyText pongMsg)
+      reply (ConsoleReplyText Nothing pongMsg)
     NextBreakpoint -> do
       putStrLn "NextBreakpoint"
       atomically $

--- a/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Core2Core.hs
@@ -138,7 +138,7 @@ listCore guts = do
       reply =
         case traverse formatBind binds of
           Left err ->
-            ConsoleReplyText ("Error: " <> err)
+            ConsoleReplyText Nothing ("Error: " <> err)
           Right bindList ->
             ConsoleReplyCoreBindList bindList
   pure reply

--- a/plugin/src/Plugin/GHCSpecter/Task/Typecheck.hs
+++ b/plugin/src/Plugin/GHCSpecter/Task/Typecheck.hs
@@ -44,16 +44,16 @@ fetchUnqualifiedImports tc = do
           (modu, names) <- M.toList moduleImportMap
           let imported = fmap (formatName dflags) $ S.toList names
           [T.unpack modu, formatImportedNames imported]
-  pure (ConsoleReplyText (T.pack rendered))
+  pure (ConsoleReplyText Nothing (T.pack rendered))
 
 showRenamed :: HsGroup GhcRn -> TcM ConsoleReply
 showRenamed grp = do
   dflags <- getDynFlags
   let txt = T.pack (showPpr dflags grp)
-  pure (ConsoleReplyText txt)
+  pure (ConsoleReplyText (Just "renamed") txt)
 
 showSpliceExpr :: LHsExpr GhcTc -> TcM ConsoleReply
 showSpliceExpr expr = do
   dflags <- getDynFlags
   let txt = T.pack (showPpr dflags expr)
-  pure (ConsoleReplyText txt)
+  pure (ConsoleReplyText (Just "splice") txt)


### PR DESCRIPTION
Call graph, :show-expr, :show-renamed results are now also shown in supplementary view (right pane in the source view).
The results are accumulated and can be navigated via tabs.