### PR TITLE
Source file load upfront in the beginning

### DIFF
--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -35,17 +35,12 @@ import GHCSpecter.Comm
     runServer,
     sendObject,
   )
-import GHCSpecter.Data.GHC.Hie
-  ( HasModuleHieInfo (..),
-    emptyModuleHieInfo,
-  )
 import GHCSpecter.Driver.Session.Types
   ( HasServerSession (..),
     ServerSession (..),
   )
 import GHCSpecter.Server.Types
   ( ConsoleItem (..),
-    HasHieState (..),
     HasServerState (..),
     HasTimingState (..),
     ServerState (..),
@@ -124,15 +119,7 @@ invokeWorker :: TVar ServerState -> TQueue (IO ()) -> ChanMessageBox -> IO ()
 invokeWorker ssRef workQ (CMBox o) =
   case o of
     CMCheckImports {} -> pure ()
-    CMModuleInfo {- _ modu mfile -} {} -> pure ()
-    {-
-      src <-
-        case mfile of
-          Nothing -> pure ""
-          Just file -> TIO.readFile file
-      let modHie = (modHieSource .~ src) emptyModuleHieInfo
-      atomically $
-        modifyTVar' ssRef (serverHieState . hieModuleMap %~ M.insert modu modHie) -}
+    CMModuleInfo {} -> pure ()
     CMTiming {} -> pure ()
     CMSession s' -> do
       let modSrcs = sessionModuleSources s'

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -52,7 +52,7 @@ import GHCSpecter.Channel.Outbound.Types
     Channel,
     SessionInfo (..),
     Timer,
-    emptyModuleGraphInfo,
+    emptySessionInfo,
   )
 import GHCSpecter.Data.GHC.Hie (ModuleHieInfo)
 import GHCSpecter.Data.Timing.Types (TimingTable, emptyTimingTable)
@@ -176,7 +176,7 @@ emptyServerState =
     { _serverMessageSN = 0
     , _serverShouldUpdate = True
     , _serverInbox = mempty
-    , _serverSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo False
+    , _serverSessionInfo = emptySessionInfo
     , _serverDriverModuleMap = emptyBiKeyMap
     , _serverTiming = emptyTimingState
     , _serverPaused = emptyKeyMap

--- a/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
@@ -7,7 +7,7 @@ module GHCSpecter.Worker.ModuleGraph
 where
 
 import Control.Concurrent.STM (TVar, atomically, modifyTVar')
-import Control.Lens ((%~), (.~))
+import Control.Lens ((.~))
 import Data.Bifunctor (second)
 import Data.Foldable qualified as F
 import Data.Function (on)
@@ -15,11 +15,8 @@ import Data.Functor.Identity (runIdentity)
 import Data.Graph (buildG)
 import Data.IntMap qualified as IM
 import Data.List qualified as L
-import Data.Map.Strict (Map)
-import Data.Map.Strict qualified as M
 import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
-import Data.Text.IO qualified as TIO
 import GHCSpecter.Channel.Common.Types (type ModuleName)
 import GHCSpecter.Channel.Outbound.Types
   ( ModuleGraphInfo (..),
@@ -38,8 +35,7 @@ import GHCSpecter.GraphLayout.Algorithm.Cluster
 import GHCSpecter.GraphLayout.Sugiyama qualified as Sugiyama
 import GHCSpecter.GraphLayout.Types (GraphVisInfo (..))
 import GHCSpecter.Server.Types
-  ( HasHieState (..),
-    HasModuleGraphState (..),
+  ( HasModuleGraphState (..),
     HasServerState (..),
     ServerState (..),
     incrementSN,

--- a/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/ModuleGraph.hs
@@ -7,7 +7,7 @@ module GHCSpecter.Worker.ModuleGraph
 where
 
 import Control.Concurrent.STM (TVar, atomically, modifyTVar')
-import Control.Lens ((.~))
+import Control.Lens ((%~), (.~))
 import Data.Bifunctor (second)
 import Data.Foldable qualified as F
 import Data.Function (on)
@@ -15,8 +15,11 @@ import Data.Functor.Identity (runIdentity)
 import Data.Graph (buildG)
 import Data.IntMap qualified as IM
 import Data.List qualified as L
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
 import Data.Maybe (mapMaybe)
 import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import GHCSpecter.Channel.Common.Types (type ModuleName)
 import GHCSpecter.Channel.Outbound.Types
   ( ModuleGraphInfo (..),
@@ -35,7 +38,8 @@ import GHCSpecter.GraphLayout.Algorithm.Cluster
 import GHCSpecter.GraphLayout.Sugiyama qualified as Sugiyama
 import GHCSpecter.GraphLayout.Types (GraphVisInfo (..))
 import GHCSpecter.Server.Types
-  ( HasModuleGraphState (..),
+  ( HasHieState (..),
+    HasModuleGraphState (..),
     HasServerState (..),
     ServerState (..),
     incrementSN,

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -4,7 +4,6 @@
 module GHCSpecter.Channel.Outbound.Types
   ( -- * information types
     BreakpointLoc (..),
-    SessionInfo (..),
     TimerTag (..),
     Timer (..),
     getStartTime,
@@ -14,6 +13,8 @@ module GHCSpecter.Channel.Outbound.Types
     ModuleGraphInfo (..),
     emptyModuleGraphInfo,
     ConsoleReply (..),
+    SessionInfo (..),
+    emptySessionInfo,
 
     -- * channel
     Channel (..),
@@ -27,6 +28,8 @@ import Data.Binary (Binary (..))
 import Data.Binary.Instances.Time ()
 import Data.IntMap (IntMap)
 import Data.List qualified as L
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as M
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import Data.Tree (Forest)
@@ -74,36 +77,6 @@ instance FromJSON BreakpointLoc
 
 instance ToJSON BreakpointLoc
 
-data ModuleGraphInfo = ModuleGraphInfo
-  { mginfoModuleNameMap :: IntMap ModuleName
-  , mginfoModuleDep :: IntMap [Int]
-  , mginfoModuleTopSorted :: [Int]
-  }
-  deriving (Show, Read, Generic)
-
-instance FromJSON ModuleGraphInfo
-
-instance ToJSON ModuleGraphInfo
-
-instance Binary ModuleGraphInfo
-
-emptyModuleGraphInfo :: ModuleGraphInfo
-emptyModuleGraphInfo = ModuleGraphInfo mempty mempty []
-
-data SessionInfo = SessionInfo
-  { sessionProcessId :: Int
-  , sessionStartTime :: Maybe UTCTime
-  , sessionModuleGraph :: ModuleGraphInfo
-  , sessionIsPaused :: Bool
-  }
-  deriving (Show, Generic)
-
-instance Binary SessionInfo
-
-instance FromJSON SessionInfo
-
-instance ToJSON SessionInfo
-
 data TimerTag
   = -- | start
     TimerStart
@@ -149,6 +122,41 @@ data ConsoleReply
   deriving (Show, Generic)
 
 instance Binary ConsoleReply
+
+data ModuleGraphInfo = ModuleGraphInfo
+  { mginfoModuleNameMap :: IntMap ModuleName
+  , mginfoModuleDep :: IntMap [Int]
+  , mginfoModuleTopSorted :: [Int]
+  }
+  deriving (Show, Read, Generic)
+
+instance FromJSON ModuleGraphInfo
+
+instance ToJSON ModuleGraphInfo
+
+instance Binary ModuleGraphInfo
+
+emptyModuleGraphInfo :: ModuleGraphInfo
+emptyModuleGraphInfo = ModuleGraphInfo mempty mempty []
+
+data SessionInfo = SessionInfo
+  { sessionProcessId :: Int
+  , sessionStartTime :: Maybe UTCTime
+  , sessionModuleGraph :: ModuleGraphInfo
+  , sessionModuleSources :: Map ModuleName FilePath
+  , sessionIsPaused :: Bool
+  }
+  deriving (Show, Generic)
+
+instance Binary SessionInfo
+
+instance FromJSON SessionInfo
+
+instance ToJSON SessionInfo
+
+emptySessionInfo :: SessionInfo
+emptySessionInfo =
+  SessionInfo 0 Nothing emptyModuleGraphInfo M.empty True
 
 data ChanMessage (a :: Channel) where
   CMCheckImports :: ModuleName -> Text -> ChanMessage 'CheckImports

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -130,13 +130,13 @@ initGhcSession opts env = do
         -- session start
         Nothing -> do
           let modGraph = hsc_mod_graph env
-              !modGraphInfo = extractModuleGraphInfo modGraph
+              (modGraphInfo, modSources) = extractModuleGraphInfo modGraph
               newGhcSessionInfo =
                 SessionInfo
                   { sessionProcessId = pid
                   , sessionStartTime = Just startTime
                   , sessionModuleGraph = modGraphInfo
-                  , sessionModuleSources = M.empty
+                  , sessionModuleSources = modSources
                   , sessionIsPaused = configStartWithBreakpoint cfg2
                   }
           modifyTVar'

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -18,7 +18,6 @@ import Control.Concurrent.STM
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.IORef (IORef, newIORef, writeIORef)
-import Data.Map.Strict qualified as M
 import Data.Text qualified as T
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import GHC.Core.Opt.Monad (CoreM, CoreToDo (..), getDynFlags)
@@ -88,6 +87,7 @@ import Plugin.GHCSpecter.Types
   )
 import Plugin.GHCSpecter.Util
   ( extractModuleGraphInfo,
+    extractModuleSources,
     getModuleName,
   )
 import System.Directory (canonicalizePath)
@@ -130,7 +130,8 @@ initGhcSession opts env = do
         -- session start
         Nothing -> do
           let modGraph = hsc_mod_graph env
-              (modGraphInfo, modSources) = extractModuleGraphInfo modGraph
+              modSources = extractModuleSources modGraph
+              modGraphInfo = extractModuleGraphInfo modGraph
               newGhcSessionInfo =
                 SessionInfo
                   { sessionProcessId = pid

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -18,6 +18,7 @@ import Control.Concurrent.STM
 import Control.Monad (void, when)
 import Control.Monad.IO.Class (liftIO)
 import Data.IORef (IORef, newIORef, writeIORef)
+import Data.Map.Strict qualified as M
 import Data.Text qualified as T
 import Data.Time.Clock (UTCTime, getCurrentTime)
 import GHC.Core.Opt.Monad (CoreM, CoreToDo (..), getDynFlags)
@@ -116,6 +117,9 @@ initGhcSession opts env = do
         case opts of
           ipcfile : _ -> cfg1 {configSocket = ipcfile}
           _ -> cfg1
+  -- modSources <- extractModuleSources modGraph
+  let modSources = M.empty
+          
   -- read/write should be atomic inside a single STM. i.e. no interleaving
   -- IO actions are allowed.
   (isNewStart, queue) <-
@@ -130,7 +134,6 @@ initGhcSession opts env = do
         -- session start
         Nothing -> do
           let modGraph = hsc_mod_graph env
-              modSources = extractModuleSources modGraph
               modGraphInfo = extractModuleGraphInfo modGraph
               newGhcSessionInfo =
                 SessionInfo

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -31,6 +31,7 @@ import GHCSpecter.Channel.Outbound.Types
   ( ChanMessageBox (..),
     SessionInfo (..),
     emptyModuleGraphInfo,
+    emptySessionInfo,
   )
 import GHCSpecter.Config (Config, emptyConfig)
 import System.IO.Unsafe (unsafePerformIO)
@@ -67,7 +68,7 @@ emptyPluginSession :: PluginSession
 emptyPluginSession =
   PluginSession
     { psSessionConfig = emptyConfig
-    , psSessionInfo = SessionInfo 0 Nothing emptyModuleGraphInfo True
+    , psSessionInfo = emptySessionInfo
     , psMessageQueue = Nothing
     , psNextDriverId = 1
     , psConsoleState = emptyConsoleState

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -30,7 +30,6 @@ import GHCSpecter.Channel.Inbound.Types (ConsoleRequest (..))
 import GHCSpecter.Channel.Outbound.Types
   ( ChanMessageBox (..),
     SessionInfo (..),
-    emptyModuleGraphInfo,
     emptySessionInfo,
   )
 import GHCSpecter.Config (Config, emptyConfig)

--- a/plugin/src/Plugin/GHCSpecter/Util.hs
+++ b/plugin/src/Plugin/GHCSpecter/Util.hs
@@ -1,6 +1,7 @@
 module Plugin.GHCSpecter.Util
   ( -- * Utilities
     getTopSortedModules,
+    extractModuleSources,
     extractModuleGraphInfo,
     getModuleName,
     getModuleNameFromPipeState,
@@ -78,7 +79,7 @@ extractModuleSources modGraph = M.fromList $ mapMaybe extract (mgModSummaries mo
     extract ms =
       (getModuleName ms,) <$> ml_hs_file (ms_location ms)
 
-extractModuleGraphInfo :: ModuleGraph -> (ModuleGraphInfo, Map ModuleName FilePath)
+extractModuleGraphInfo :: ModuleGraph -> ModuleGraphInfo
 extractModuleGraphInfo modGraph = do
   let (graph, _) = moduleGraphNodes False (mgModSummaries' modGraph)
       vtxs = G.verticesG graph
@@ -97,9 +98,7 @@ extractModuleGraphInfo modGraph = do
           (\n -> M.lookup n modNameRevMap)
           $ getTopSortedModules modGraph
       modDeps = IM.fromList $ fmap (\v -> (G.node_key v, G.node_dependencies v)) vtxs
-      mgi = ModuleGraphInfo modNameMap modDeps topSorted
-      moduleSources = extractModuleSources modGraph
-   in (mgi, moduleSources)
+   in ModuleGraphInfo modNameMap modDeps topSorted
 
 getModuleNameFromPipeState :: PipeState -> Maybe ModuleName
 getModuleNameFromPipeState pstate =


### PR DESCRIPTION
Previously, source files were loaded as GHC compiles the module, but there is no reason to wait as the file path information is already there when getting the module graph.