### PR TITLE
Race condition in initialization correctly handled

### DIFF
--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -97,8 +97,11 @@ import System.Process (getCurrentPid)
 -- | GHC session-wide initialization
 initGhcSession :: [CommandLineOption] -> HscEnv -> IO MsgQueue
 initGhcSession opts env = do
-  -- unfortunately, with current initialization mechanism,
-  -- this should be done for every driver start to avoid race condition.
+  -- NOTE: Read session and overwrite on the session should be done in a single
+  -- atomic STM operation. As a consequence, unfortunately, the necessary IO
+  -- action should be done outside STM beforehand, which implies the action will
+  -- be done multiple times per every driver start.
+  -- This is because we do not have a plugin insertion at real GHC initialization.
   startTime <- getCurrentTime
   pid <- fromInteger . toInteger <$> getCurrentPid
   queue_ <- initMsgQueue


### PR DESCRIPTION
Read session and overwrite on the session should be done in a single atomic STM operation. 
Unfortunately, as a consequence, the necessary IO action should be done outside beforehand, which means the action will be done multiple times per every driver start. This is due to the limited plugin point (as we cannot put a compatible plugin in the beginning of GHC session. There exists frontend plugin, but that's not compatible with cabal, which uses hard-coded `ghc --make` command yet) The IO operation is nothing but timestamping and reading config, so I put up with a little redundancy here.  