### PR TITLE
Hiding queue and modNameRef from function arguments

### DIFF
--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -77,7 +77,7 @@ import GHCSpecter.UI.Types.Event
     Tab (..),
     TimingEvent (..),
   )
-import GHCSpecter.Util.Map
+import GHCSpecter.Data.Map
   ( alterToKeyMap,
     forwardLookup,
   )

--- a/daemon/src/GHCSpecter/Control/Runner.hs
+++ b/daemon/src/GHCSpecter/Control/Runner.hs
@@ -127,11 +127,17 @@ stepControl (Free (GetUI cont)) = do
 stepControl (Free (PutUI ui next)) = do
   putUI' ui
   pure (Left next)
+stepControl (Free (ModifyUI upd next)) = do
+  modifyUI' upd
+  pure (Left next)
 stepControl (Free (GetSS cont)) = do
   ss <- getSS'
   pure (Left (cont ss))
 stepControl (Free (PutSS ss next)) = do
   putSS' ss
+  pure (Left next)
+stepControl (Free (ModifySS upd next)) = do
+  modifySS' upd
   pure (Left next)
 stepControl (Free (SendRequest b next)) = do
   sendRequest' b

--- a/daemon/src/GHCSpecter/Control/Types.hs
+++ b/daemon/src/GHCSpecter/Control/Types.hs
@@ -6,8 +6,10 @@ module GHCSpecter.Control.Types
     -- * Primitive operations of eDSL
     getUI,
     putUI,
+    modifyUI,
     getSS,
     putSS,
+    modifySS,
     sendRequest,
     nextEvent,
     printMsg,
@@ -30,11 +32,15 @@ import GHCSpecter.UI.Types (UIState)
 import GHCSpecter.UI.Types.Event (Event)
 
 -- | Pattern functor for effects of Control DSL.
+-- TODO: remove PutUI and PutSS in the end
+-- to guarantee atomic updates.
 data ControlF r
   = GetUI (UIState -> r)
   | PutUI UIState r
+  | ModifyUI (UIState -> UIState) r
   | GetSS (ServerState -> r)
   | PutSS ServerState r
+  | ModifySS (ServerState -> ServerState) r
   | SendRequest Request r
   | NextEvent (Event -> r)
   | PrintMsg Text r
@@ -54,11 +60,17 @@ getUI = liftF (GetUI id)
 putUI :: UIState -> Control ()
 putUI ui = liftF (PutUI ui ())
 
+modifyUI :: (UIState -> UIState) -> Control ()
+modifyUI upd = liftF (ModifyUI upd ())
+
 getSS :: Control ServerState
 getSS = liftF (GetSS id)
 
 putSS :: ServerState -> Control ()
 putSS ss = liftF (PutSS ss ())
+
+modifySS :: (ServerState -> ServerState) -> Control ()
+modifySS upd = liftF (ModifySS upd ())
 
 sendRequest :: Request -> Control ()
 sendRequest b = liftF (SendRequest b ())

--- a/daemon/src/GHCSpecter/Data/Timing/Util.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Util.hs
@@ -37,20 +37,20 @@ import GHCSpecter.Channel.Outbound.Types
     getHscOutTime,
     getStartTime,
   )
-import GHCSpecter.Data.Timing.Types
-  ( HasTimingInfo (..),
-    HasTimingTable (..),
-    TimingInfo (..),
-    TimingTable,
-    emptyTimingTable,
-  )
-import GHCSpecter.Util.Map
+import GHCSpecter.Data.Map
   ( BiKeyMap,
     KeyMap,
     backwardLookup,
     forwardLookup,
     keyMapToList,
     lookupKey,
+  )
+import GHCSpecter.Data.Timing.Types
+  ( HasTimingInfo (..),
+    HasTimingTable (..),
+    TimingInfo (..),
+    TimingTable,
+    emptyTimingTable,
   )
 
 isTimeInTimerRange :: (Ord a) => a -> TimingInfo a -> Bool

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -35,6 +35,11 @@ import GHCSpecter.Comm
     runServer,
     sendObject,
   )
+import GHCSpecter.Data.Map
+  ( alterToKeyMap,
+    forwardLookup,
+    insertToBiKeyMap,
+  )
 import GHCSpecter.Driver.Session.Types
   ( HasServerSession (..),
     ServerSession (..),
@@ -46,11 +51,6 @@ import GHCSpecter.Server.Types
     ServerState (..),
     SupplementaryView (..),
     incrementSN,
-  )
-import GHCSpecter.Util.Map
-  ( alterToKeyMap,
-    forwardLookup,
-    insertToBiKeyMap,
   )
 import GHCSpecter.Worker.Hie
   ( hieWorker,

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -58,7 +58,7 @@ import GHCSpecter.UI.Types.Event
     Event (..),
     Tab (..),
   )
-import GHCSpecter.Util.Map (forwardLookup, keyMapToList, lookupKey)
+import GHCSpecter.Data.Map (forwardLookup, keyMapToList, lookupKey)
 import Prelude hiding (div, span)
 
 renderBanner :: Text -> Double -> Widget IHTML a

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -16,6 +16,11 @@ import Concur.Replica.DOM.Events qualified as DE
 import Control.Monad (join)
 import Data.Maybe (fromMaybe, maybeToList)
 import Data.Text (Text)
+import GHCSpecter.Data.Map
+  ( IsKey (..),
+    KeyMap,
+    lookupKey,
+  )
 import GHCSpecter.Render.Components.ConsoleItem qualified as CI (render)
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types (ConsoleItem (..))
@@ -31,11 +36,6 @@ import GHCSpecter.UI.ConcurReplica.DOM
   )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types.Event (ConsoleEvent (..))
-import GHCSpecter.Util.Map
-  ( IsKey (..),
-    KeyMap,
-    lookupKey,
-  )
 import Prelude hiding (div)
 
 render ::

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -27,6 +27,7 @@ import GHCSpecter.Channel.Outbound.Types
     SessionInfo (..),
     Timer,
   )
+import GHCSpecter.Data.Map (BiKeyMap, KeyMap)
 import GHCSpecter.Data.Timing.Util (isModuleCompilationDone)
 import GHCSpecter.GraphLayout.Types (GraphVisInfo (..))
 import GHCSpecter.Render.Components.GraphView qualified as GraphView
@@ -56,7 +57,6 @@ import GHCSpecter.UI.Types.Event
     Event (..),
     SubModuleEvent (..),
   )
-import GHCSpecter.Util.Map (BiKeyMap, KeyMap)
 import Text.Printf (printf)
 import Prelude hiding (div)
 

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -25,6 +25,13 @@ import GHCSpecter.Channel.Outbound.Types
     Timer,
     getEndTime,
   )
+import GHCSpecter.Data.Map
+  ( BiKeyMap,
+    KeyMap,
+    forwardLookup,
+    keyMapToList,
+    lookupKey,
+  )
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
@@ -43,13 +50,6 @@ import GHCSpecter.UI.Constants (widgetHeight)
 import GHCSpecter.UI.Types.Event
   ( Event (..),
     SessionEvent (..),
-  )
-import GHCSpecter.Util.Map
-  ( BiKeyMap,
-    KeyMap,
-    forwardLookup,
-    keyMapToList,
-    lookupKey,
   )
 import Prelude hiding (div)
 

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -54,11 +54,11 @@ import GHCSpecter.Channel.Outbound.Types
     Timer,
     emptySessionInfo,
   )
+import GHCSpecter.Data.Map (BiKeyMap, KeyMap, emptyBiKeyMap, emptyKeyMap)
 import GHCSpecter.Data.GHC.Hie (ModuleHieInfo)
 import GHCSpecter.Data.Timing.Types (TimingTable, emptyTimingTable)
 import GHCSpecter.GraphLayout.Types (GraphVisInfo)
 import GHCSpecter.UI.Types.Event (DetailLevel)
-import GHCSpecter.Util.Map (BiKeyMap, KeyMap, emptyBiKeyMap, emptyKeyMap)
 
 type ChanModule = (Channel, Text)
 

--- a/flake.lock
+++ b/flake.lock
@@ -34,23 +34,6 @@
         "type": "github"
       }
     },
-    "discrimination": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1660747417,
-        "narHash": "sha256-+ATHOl3SMCyKaS/MA8LK1O1M5iRc8rKOYLqC/ze2xL0=",
-        "owner": "ekmett",
-        "repo": "discrimination",
-        "rev": "7b691d6dc8125d803f1e306ca800a001ae64e84a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ekmett",
-        "ref": "master",
-        "repo": "discrimination",
-        "type": "github"
-      }
-    },
     "fficxx": {
       "inputs": {
         "flake-utils": [
@@ -171,7 +154,6 @@
       "inputs": {
         "concur": "concur",
         "concur-replica": "concur-replica",
-        "discrimination": "discrimination",
         "fficxx": "fficxx",
         "flake-utils": "flake-utils",
         "fourmolu": "fourmolu",

--- a/flake.nix
+++ b/flake.nix
@@ -16,10 +16,6 @@
       url = "github:wavewave/replica/ghc-9.2";
       flake = false;
     };
-    discrimination = {
-      url = "github:ekmett/discrimination/master";
-      flake = false;
-    };
     fficxx = {
       url = "github:wavewave/fficxx/master";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -37,7 +33,7 @@
     };
   };
   outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica
-    , discrimination, fficxx, hs-ogdf, fourmolu }:
+    , fficxx, hs-ogdf, fourmolu }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
@@ -49,7 +45,7 @@
           "concur-replica" =
             hself.callCabal2nix "concur-replica" concur-replica { };
           "discrimination" =
-            hself.callCabal2nix "discrimination" discrimination { };
+            hself.callHackage "discrimination" "0.5" { };
           "http2" = final.haskell.lib.dontCheck hsuper.http2;
           "newtype-generics" = final.haskell.lib.doJailbreak hsuper.newtype-generics;
            "replica" = hself.callCabal2nix "replica" replica { };

--- a/plugin/src/GHCSpecter/Data/Map.hs
+++ b/plugin/src/GHCSpecter/Data/Map.hs
@@ -1,4 +1,4 @@
-module GHCSpecter.Util.Map
+module GHCSpecter.Data.Map
   ( -- * IsKey class
     IsKey (..),
 

--- a/plugin/src/Plugin/GHCSpecter/Comm.hs
+++ b/plugin/src/Plugin/GHCSpecter/Comm.hs
@@ -36,6 +36,7 @@ import Network.Socket (Socket)
 import Plugin.GHCSpecter.Types
   ( MsgQueue (..),
     PluginSession (..),
+    getMsgQueue,
     sessionRef,
   )
 import System.Directory (doesFileExist)
@@ -91,7 +92,9 @@ runMessageQueue cfg queue = do
             ConsoleReq drvId' creq ->
               writeTVar (msgReceiverQueue queue) (Just (drvId', creq))
 
-queueMessage :: MsgQueue -> ChanMessage a -> IO ()
-queueMessage queue !msg =
-  atomically $
-    modifyTVar' (msgSenderQueue queue) (|> CMBox msg)
+queueMessage :: ChanMessage a -> IO ()
+queueMessage !msg = do
+  mqueue <- getMsgQueue
+  for_ mqueue $ \queue ->
+    atomically $
+      modifyTVar' (msgSenderQueue queue) (|> CMBox msg)

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -22,15 +22,11 @@ import Control.Monad (forever, when)
 import Control.Monad.Extra (loopM)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Foldable (for_)
-import Data.IORef (IORef, readIORef)
 import Data.List qualified as L
 import Data.Maybe (isNothing)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
-import GHCSpecter.Channel.Common.Types
-  ( DriverId (..),
-    type ModuleName,
-  )
+import GHCSpecter.Channel.Common.Types (DriverId)
 import GHCSpecter.Channel.Inbound.Types
   ( ConsoleRequest (..),
   )

--- a/plugin/src/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src/Plugin/GHCSpecter/Hooks.hs
@@ -10,13 +10,13 @@ where
 
 import Control.Monad.IO.Class (liftIO)
 import Data.IORef (IORef)
-import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time.Clock (getCurrentTime)
 import GHC.Core.Opt.Monad (getDynFlags)
 import GHC.Driver.Phases (Phase (As, StopLn))
 import GHC.Driver.Pipeline (runPhase)
 #if MIN_VERSION_ghc(9, 4, 0)
+import Data.Text (Text)
 import GHC.Driver.Pipeline.Phases
   ( PhaseHook (..),
     TPhase (..),

--- a/plugin/src/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src/Plugin/GHCSpecter/Hooks.hs
@@ -8,21 +8,9 @@ module Plugin.GHCSpecter.Hooks
   )
 where
 
-import Control.Monad.IO.Class (liftIO)
-import Data.Text qualified as T
 import Data.Time.Clock (getCurrentTime)
 import GHC.Core.Opt.Monad (getDynFlags)
-import GHC.Driver.Phases (Phase (As, StopLn))
 import GHC.Driver.Pipeline (runPhase)
-#if MIN_VERSION_ghc(9, 4, 0)
-import Data.Text (Text)
-import GHC.Driver.Pipeline.Phases
-  ( PhaseHook (..),
-    TPhase (..),
-  )
-#elif MIN_VERSION_ghc(9, 2, 0)
-import GHC.Driver.Pipeline (CompPipeline, PhasePlus (HscOut, RealPhase))
-#endif
 import GHC.Driver.Session (DynFlags)
 import GHC.Hs.Extension (GhcRn)
 import GHC.Tc.Gen.Splice (defaultRunMeta)
@@ -36,7 +24,6 @@ import GHCSpecter.Channel.Outbound.Types
     Timer (..),
     TimerTag (..),
   )
-import GHCSpecter.Util.GHC (showPpr)
 import Language.Haskell.Syntax.Expr (HsSplice)
 import Plugin.GHCSpecter.Comm (queueMessage)
 import Plugin.GHCSpecter.Console (breakPoint)
@@ -48,6 +35,21 @@ import Plugin.GHCSpecter.Tasks
     rnSpliceCommands,
   )
 import System.IO.Unsafe (unsafePerformIO)
+-- GHC version dependent imports
+#if MIN_VERSION_ghc(9, 4, 0)
+import Data.Text (Text)
+import GHC.Driver.Pipeline.Phases
+  ( PhaseHook (..),
+    TPhase (..),
+  )
+#elif MIN_VERSION_ghc(9, 2, 0)
+import Control.Monad.IO.Class (liftIO)
+import Data.Text qualified as T
+import GHC.Driver.Phases (Phase (As, StopLn))
+import GHC.Driver.Pipeline (CompPipeline, PhasePlus (HscOut, RealPhase))
+import GHCSpecter.Util.GHC (showPpr)
+#endif
+
 
 data PhasePoint = PhaseStart | PhaseEnd
 

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -13,12 +13,17 @@ module Plugin.GHCSpecter.Types
 
     -- * global variable
     sessionRef,
+
+    -- * utilities
+    getMsgQueue,
   )
 where
 
 import Control.Concurrent.STM
   ( TVar,
+    atomically,
     newTVarIO,
+    readTVar,
   )
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
@@ -78,3 +83,8 @@ emptyPluginSession =
 sessionRef :: TVar PluginSession
 {-# NOINLINE sessionRef #-}
 sessionRef = unsafePerformIO (newTVarIO emptyPluginSession)
+
+
+getMsgQueue :: IO (Maybe MsgQueue)
+getMsgQueue =
+  psMessageQueue <$> atomically (readTVar sessionRef)

--- a/plugin/src/Plugin/GHCSpecter/Util.hs
+++ b/plugin/src/Plugin/GHCSpecter/Util.hs
@@ -21,10 +21,10 @@ import Data.Map qualified as M
 import Data.Maybe (catMaybes, mapMaybe)
 import Data.Text qualified as T
 import Data.Tuple (swap)
-import GHC.Data.Bag (bagToList)
 import GHC.Data.Graph.Directed qualified as G
 import GHC.Driver.Make (topSortModuleGraph)
 #if MIN_VERSION_ghc(9, 4, 0)
+import GHC.Data.Bag (bagToList)
 import GHC.Unit.Module.Graph (moduleGraphNodes)
 #elif MIN_VERSION_ghc(9, 2, 0)
 import GHC.Driver.Make (moduleGraphNodes)
@@ -49,8 +49,8 @@ import GHC.Unit.Module.Graph
     mgModSummaries',
   )
 import GHC.Unit.Module.Location (ModLocation (..))
-import GHC.Unit.Module.ModIface (ModIface_ (mi_module))
 #if MIN_VERSION_ghc(9, 4, 0)
+import GHC.Unit.Module.ModIface (ModIface_ (mi_module))
 #elif MIN_VERSION_ghc(9, 2, 0)
 import GHC.Unit.Module.ModSummary (ExtendedModSummary (..))
 #endif


### PR DESCRIPTION
MsgQueue is a session-level singleton, and accessible from the global state `sessionRef`, so I remove the redundant parameter.
DriverId - ModuleName  map is now held in the `sessionRef`,  and again removed the parameter. 
This prepares for the new module compilation initialization process that works for GHC 9.4.