### PR TITLE
GHC 9.4: driverId assigned to each module compilation through runPhaseHook

### DIFF
--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -120,9 +120,7 @@ invokeWorker ssRef workQ (CMBox o) =
   case o of
     CMCheckImports {} -> pure ()
     CMModuleInfo {} -> pure ()
-    CMTiming drvId timer' -> do
-      print (drvId, timer')
-      pure ()
+    CMTiming {} -> pure ()
     CMSession s' -> do
       let modSrcs = sessionModuleSources s'
           mgi = sessionModuleGraph s'

--- a/daemon/src/GHCSpecter/Worker/Hie.hs
+++ b/daemon/src/GHCSpecter/Worker/Hie.hs
@@ -23,10 +23,6 @@ import Data.Text.Encoding (decodeUtf8With)
 import Data.Text.IO qualified as TIO
 import GHC.Iface.Ext.Binary
   ( HieFileResult (..),
-#if MIN_VERSION_ghc(9, 4, 0)
-#elif MIN_VERSION_ghc(9, 2, 0)
-    NameCacheUpdater (NCU),
-#endif
     readHieFile,
   )
 import GHC.Iface.Ext.Types (HieFile (..), getAsts)
@@ -47,13 +43,17 @@ import GHCSpecter.Server.Types
   )
 import GHCSpecter.Worker.CallGraph qualified as CallGraph
 import HieDb.Compat
-  ( mkSplitUniqSupply,
-    moduleName,
+  ( moduleName,
     moduleNameString,
     occNameString,
   )
 import HieDb.Types (DeclRow (..), DefRow (..), RefRow (..))
 import HieDb.Utils (genDefRow, genRefsAndDecls)
+#if MIN_VERSION_ghc(9, 4, 0)
+#elif MIN_VERSION_ghc(9, 2, 0)
+import GHC.Iface.Ext.Binary (NameCacheUpdater (NCU))
+import HieDb.Compat (mkSplitUniqSupply)
+#endif
 
 convertRefRow :: RefRow -> RefRow'
 convertRefRow RefRow {..} =

--- a/plugin/package.yaml
+++ b/plugin/package.yaml
@@ -89,6 +89,7 @@ library:
     - hiedb
     - network
     - process
+    - safe
     - stm
     - time
     - transformers

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -86,6 +86,7 @@ import Plugin.GHCSpecter.Tasks
 import Plugin.GHCSpecter.Types
   ( PluginSession (..),
     assignModuleToDriverId,
+    assignModuleFileToDriverId,
     initMsgQueue,
     sessionRef,
   )
@@ -211,7 +212,7 @@ parsedResultActionPlugin opts modSummary parsed = do
       msrcFile' <- traverse canonicalizePath msrcFile
       assignModuleToDriverId drvId modName
       for_ msrcFile $ \srcFile ->
-        assignModuleFileToDriverId driId srcFile
+        assignModuleFileToDriverId drvId srcFile
       sendModuleName drvId modName msrcFile'
 #endif
     breakPoint drvId ParsedResultAction parsedResultActionCommands

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -372,15 +372,6 @@ driver opts env0 = do
           }
       splugin = StaticPlugin (PluginWithArgs newPlugin opts)
       env = env0 {hsc_plugins = (hsc_plugins env0) {staticPlugins = [splugin]}}
-  let hooks = hsc_hooks env
-      hooks' =
-        hooks
-          { runRnSpliceHook = Just runRnSpliceHook'
-          , runMetaHook = Just runMetaHook'
-          , runPhaseHook = Just runPhaseHook'
-          }
-      env' = env {hsc_hooks = hooks'}
-  pure env'
 #elif MIN_VERSION_ghc(9, 2, 0)
   drvId <- initDriverSession
   let opts' = [show (unDriverId drvId)] -- ignore opts
@@ -399,6 +390,7 @@ driver opts env0 = do
   startTime <- getCurrentTime
   sendModuleStart drvId startTime
   breakPoint drvId StartDriver driverCommands
+#endif
   let hooks = hsc_hooks env
       hooks' =
         hooks
@@ -408,7 +400,7 @@ driver opts env0 = do
           }
       env' = env {hsc_hooks = hooks'}
   pure env'
-#endif
+
 
 --
 -- Main entry point

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -382,10 +382,10 @@ driver opts env0 = do
   let hooks = hsc_hooks env
       hooks' =
         hooks
-         --        { runRnSpliceHook = Just (runRnSpliceHook' drvId)
-         --        , runMetaHook = Just (runMetaHook' drvId)
-         --        , runPhaseHook = Just (runPhaseHook' drvId)
-         --        }
+          { runRnSpliceHook = Just runRnSpliceHook'
+          , runMetaHook = Just runMetaHook'
+          , runPhaseHook = Just runPhaseHook'
+          }
       env' = env {hsc_hooks = hooks'}
   pure env'
 #elif MIN_VERSION_ghc(9, 2, 0)
@@ -409,9 +409,9 @@ driver opts env0 = do
   let hooks = hsc_hooks env
       hooks' =
         hooks
-          { runRnSpliceHook = Just (runRnSpliceHook' drvId)
-          , runMetaHook = Just (runMetaHook' drvId)
-          , runPhaseHook = Just (runPhaseHook' drvId)
+          { runRnSpliceHook = Just runRnSpliceHook'
+          , runMetaHook = Just runMetaHook'
+          , runPhaseHook = Just runPhaseHook'
           }
       env' = env {hsc_hooks = hooks'}
   pure env'

--- a/plugin/src/Plugin/GHCSpecter/Comm.hs
+++ b/plugin/src/Plugin/GHCSpecter/Comm.hs
@@ -94,7 +94,7 @@ runMessageQueue cfg queue = do
 
 queueMessage :: ChanMessage a -> IO ()
 queueMessage !msg = do
-  mqueue <- getMsgQueue
+  mqueue <- atomically getMsgQueue
   for_ mqueue $ \queue ->
     atomically $
       modifyTVar' (msgSenderQueue queue) (|> CMBox msg)

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -55,7 +55,7 @@ consoleAction ::
   TVar (Maybe (m ())) ->
   IO ()
 consoleAction drvId loc cmds actionRef = liftIO $ do
-  mqueue <- getMsgQueue
+  mqueue <- atomically getMsgQueue
   for_ mqueue $ \queue -> do
     let rQ = msgReceiverQueue queue
     req <-
@@ -141,7 +141,8 @@ breakPoint drvId loc cmds = do
     go actionRef (action, isBlocked) = do
       action
       liftIO $ do
-        mmodName <- getModuleFromDriverId drvId
+        -- TODO: a series of @atomically@ looks fishy. combine them if okay.
+        mmodName <- atomically $ getModuleFromDriverId drvId
         atomically $ do
           psess <- readTVar sessionRef
           let modBreakpoints = psModuleBreakpoints psess

--- a/plugin/src/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src/Plugin/GHCSpecter/Hooks.hs
@@ -251,8 +251,8 @@ sendCompStateOnPhase drvId phase pt = do
           startTime <- getCurrentTime
           sendModuleStart drvId startTime
           -- send module name information
-          mmodName <- getModuleFromDriverId drvId
-          msrcFile <- getModuleFileFromDriverId drvId
+          mmodName <- atomically $ getModuleFromDriverId drvId
+          msrcFile <- atomically $ getModuleFileFromDriverId drvId
           msrcFile' <- traverse canonicalizePath msrcFile
           for_ mmodName $ \modName ->
             sendModuleName drvId modName msrcFile'

--- a/plugin/src/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src/Plugin/GHCSpecter/Hooks.hs
@@ -328,7 +328,7 @@ runPhaseHook' = PhaseHook $ \phase -> do
         let -- NOTE: This rewrite all the arguments regardless of what the plugin is.
            -- TODO: find way to update the plugin options only for ghc-specter-plugin.
            provideContext (StaticPlugin pa) =
-             let pa' = pa {paArguments = [T.unpack (getModuleName modSummary)]}
+             let pa' = pa {paArguments = maybe [] (\x -> [show (unDriverId x)]) mdrvId'}
               in StaticPlugin pa'
            plugins = hsc_plugins env
            splugins = staticPlugins plugins

--- a/plugin/src/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src/Plugin/GHCSpecter/Hooks.hs
@@ -279,12 +279,6 @@ sendCompStateOnPhase drvId phase pt = do
           startTime <- getCurrentTime
           sendModuleStart drvId startTime
           -- send module name information
-          {- let modName = getModuleName modSummary
-              msrcFile = ml_hs_file $ ms_location modSummary
-          msrcFile' <- traverse canonicalizePath msrcFile
-          assignModuleToDriverId drvId modName
-          for_ msrcFile $ \srcFile ->
-            assignModuleFileToDriverId drvId srcFile -}
           mmodName <- getModuleFromDriverId drvId
           msrcFile <- getModuleFileFromDriverId drvId
           msrcFile' <- traverse canonicalizePath msrcFile
@@ -327,16 +321,12 @@ runPhaseHook' :: PhaseHook
 runPhaseHook' = PhaseHook $ \phase -> do
   let (hscenv, mpenv, mname) = envFromTPhase phase
       phaseTxt = tphase2Text phase
-      -- mdrvId = getDriverIdFromHscEnv hscenv
-
-  print (phaseTxt, fmap showPipeEnv mpenv)
-  print (phaseTxt, mname)
   (phase', mdrvId) <-
     case phase of
       T_Hsc env modSummary -> do
         mdrvId' <- Just <$> issueNewDriverId modSummary
         let -- NOTE: This rewrite all the arguments regardless of what the plugin is.
-           -- TODO: find way to update only the ghc-specter-plugin plugin.
+           -- TODO: find way to update the plugin options only for ghc-specter-plugin.
            provideContext (StaticPlugin pa) =
              let pa' = pa {paArguments = [T.unpack (getModuleName modSummary)]}
               in StaticPlugin pa'

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -113,7 +113,7 @@ assignModuleToDriverId drvId modName =
     s <- readTVar sessionRef
     let drvModMap = psDrvIdModuleMap s
         drvModMap' = insertToBiKeyMap (drvId, modName) drvModMap
-    modifyTVar' sessionRef $ \s -> s {psDrvIdModuleMap = drvModMap'}
+    modifyTVar' sessionRef $ \s' -> s' {psDrvIdModuleMap = drvModMap'}
 
 assignModuleFileToDriverId :: DriverId -> FilePath -> IO ()
 assignModuleFileToDriverId drvId modFile =
@@ -121,7 +121,7 @@ assignModuleFileToDriverId drvId modFile =
     s <- readTVar sessionRef
     let drvModFileMap = psDrvIdModuleFileMap s
         drvModFileMap' = insertToBiKeyMap (drvId, modFile) drvModFileMap
-    modifyTVar' sessionRef $ \s -> s {psDrvIdModuleFileMap = drvModFileMap'}
+    modifyTVar' sessionRef $ \s' -> s' {psDrvIdModuleFileMap = drvModFileMap'}
 
 getModuleFromDriverId :: DriverId -> IO (Maybe ModuleName)
 getModuleFromDriverId drvId = do


### PR DESCRIPTION
ghc-specter-plugin didn't work with GHC 9.4 as it did with GHC 9.2 because the driver plugin runs only once per session with GHC 9.4 while it happpened to run per every module compilation with GHC 9.4. This basically broke all the existing state-sharing method across different plugins in a single module compilation pipeline as I used plugin closures constructed at the driver initiatialization timing. 
Now, a new state-sharing mechanism is introduced via CommandLineOption.  From GHC 9.4, the TPhase used for runPhase is more consistently defined in a type-safe manner (using GADT), and customized HscEnv can be shared in a single phase. I made a preprocess at the beginning of each runPhase to pass the shared driver id through CommandLineOption passed to each sub-phase plugin.
In this way, the original functionalities of ghc-specter on GHC 9.2 are restored.    