### PR TITLE
View memory allocation per phase in a single module compilation

### DIFF
--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -81,7 +81,7 @@ nav {
     width: 50%;
 }
 
-.column.is-one-fifths {
+.column.is-one-fifth {
     width: 20%;
 }
 

--- a/daemon/assets/ghc-specter.css
+++ b/daemon/assets/ghc-specter.css
@@ -5,6 +5,16 @@ body {
     background: white;
 }
 
+.control {
+    font-size: 8px;
+    padding: 0px;
+}
+
+.checkbox input {
+    width: 6px;
+    height: 6px;
+}
+
 button {
     font-size: 8px;
     padding: 0px;

--- a/daemon/src/GHCSpecter/Data/Timing/Types.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Types.hs
@@ -20,6 +20,7 @@ import Data.Map.Strict qualified as M
 import Data.Time.Clock (NominalDiffTime)
 import GHC.Generics (Generic)
 import GHCSpecter.Channel.Common.Types (DriverId, ModuleName)
+import GHCSpecter.Channel.Outbound.Types (MemInfo)
 
 -- | Information along the compilation pipeline for a single module
 data PipelineInfo a = PipelineInfo
@@ -28,7 +29,7 @@ data PipelineInfo a = PipelineInfo
   , _plAs :: a
   , _plEnd :: a
   }
-  deriving (Show, Generic)
+  deriving (Show, Generic, Functor)
 
 makeClassy ''PipelineInfo
 
@@ -37,7 +38,8 @@ instance FromJSON a => FromJSON (PipelineInfo a)
 instance ToJSON a => ToJSON (PipelineInfo a)
 
 data TimingTable = TimingTable
-  { _ttableTimingInfos :: [(DriverId, PipelineInfo NominalDiffTime)]
+  { -- | Start-time-ordered info table.
+    _ttableTimingInfos :: [(DriverId, PipelineInfo (NominalDiffTime, Maybe MemInfo))]
   , _ttableBlockingUpstreamDependency :: Map ModuleName ModuleName
   , _ttableBlockedDownstreamDependency :: Map ModuleName [ModuleName]
   }

--- a/daemon/src/GHCSpecter/Data/Timing/Util.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Util.hs
@@ -13,7 +13,6 @@ module GHCSpecter.Data.Timing.Util
 where
 
 import Control.Lens (to, (&), (.~), (^.), (^?), _1, _2, _Just)
-import Data.Bifunctor (first)
 import Data.Function (on)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IM

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -120,12 +120,7 @@ invokeWorker ssRef workQ (CMBox o) =
   case o of
     CMCheckImports {} -> pure ()
     CMModuleInfo {} -> pure ()
-    CMTiming _ timer -> do
-      let memInfos = mapMaybe (^. _2 . _2) (unTimer timer)
-          {- format bytes =
-            let n = fromIntegral (bytes `div` (100_000_000))
-             in (replicate n '#' ++ "     " ++ show bytes) -}
-      F.traverse_ {- (putStrLn . format) -} print memInfos
+    CMTiming {} -> pure ()
     CMSession s' -> do
       let modSrcs = sessionModuleSources s'
           mgi = sessionModuleGraph s'

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -14,7 +14,7 @@ import Control.Concurrent.STM
     readTChan,
     readTVar,
   )
-import Control.Lens ((%~), (.~), (^.), _1, _2)
+import Control.Lens ((%~), (.~), (^.), _2)
 import Control.Monad (forever, void)
 import Data.Foldable qualified as F
 import Data.Map.Strict qualified as M
@@ -121,11 +121,11 @@ invokeWorker ssRef workQ (CMBox o) =
     CMCheckImports {} -> pure ()
     CMModuleInfo {} -> pure ()
     CMTiming _ timer -> do
-      let liveBytes = mapMaybe (^. _2 . _2) (unTimer timer)
-          format bytes =
+      let memInfos = mapMaybe (^. _2 . _2) (unTimer timer)
+          {- format bytes =
             let n = fromIntegral (bytes `div` (100_000_000))
-             in (replicate n '#' ++ "     " ++ show bytes)
-      F.traverse_ (putStrLn . format) liveBytes
+             in (replicate n '#' ++ "     " ++ show bytes) -}
+      F.traverse_ {- (putStrLn . format) -} print memInfos
     CMSession s' -> do
       let modSrcs = sessionModuleSources s'
           mgi = sessionModuleGraph s'

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -14,11 +14,11 @@ import Control.Concurrent.STM
     readTChan,
     readTVar,
   )
-import Control.Lens ((%~), (.~), (^.), _2)
+import Control.Lens ((%~), (.~), (^.))
 import Control.Monad (forever, void)
 import Data.Foldable qualified as F
 import Data.Map.Strict qualified as M
-import Data.Maybe (fromMaybe, mapMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import GHCSpecter.Channel.Common.Types (DriverId (..))

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -163,7 +163,7 @@ renderMainView (view, model, ss) = do
         | otherwise =
             ( section
                 [ style
-                    [ ("max-height", "70vh")
+                    [ ("max-height", "95vh")
                     , ("overflow", "hidden")
                     ]
                 ]

--- a/daemon/src/GHCSpecter/Render/Components/TimingView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TimingView.hs
@@ -422,16 +422,13 @@ renderMemChart drvModMap tui ttable =
     filteredItems =
       filter (`isInRange` (viewPortY tui, viewPortY tui + timingHeight)) allItems
 
-    nMods = length timingInfos
-    totalHeight = 5 * nMods
-
     topOfBox :: Int -> Int
     topOfBox = floor . module2Y . fromIntegral
 
     alloc2X alloc =
       let -- ratio to 4 GiB
           allocRatio :: Double
-          allocRatio = fromIntegral alloc / fromIntegral (4 * 1024 * 1024 * 1024)
+          allocRatio = fromIntegral alloc / (4 * 1024 * 1024 * 1024)
        in floor (allocRatio * 150) :: Int
 
     widthOfBox minfo = alloc2X (negate (memAllocCounter minfo))
@@ -451,7 +448,7 @@ renderMemChart drvModMap tui ttable =
               []
           ]
 
-    moduleText (i, item@(mmodu, _)) =
+    moduleText (i, (mmodu, _)) =
       let moduTxt = fromMaybe "" mmodu
        in S.text
             [ SP.x "150"

--- a/daemon/src/GHCSpecter/Render/Components/TimingView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TimingView.hs
@@ -1,0 +1,322 @@
+module GHCSpecter.Render.Components.TimingView
+  ( -- * utility
+    viewPortX,
+    viewPortY,
+    diffTime2X,
+    module2Y,
+
+    -- * render
+    renderTimingChart,
+  )
+where
+
+import Concur.Core (Widget)
+import Concur.Replica
+  ( classList,
+    height,
+    onMouseEnter,
+    onMouseLeave,
+    style,
+    width,
+  )
+import Concur.Replica.SVG.Props qualified as SP
+import Control.Lens (to, (^.), (%~), _1, _2)
+import Control.Monad (join)
+import Data.List qualified as L
+import Data.Map.Strict qualified as M
+import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Time.Clock
+  ( NominalDiffTime,
+    nominalDiffTimeToSeconds,
+    secondsToNominalDiffTime,
+  )
+import GHCSpecter.Channel.Common.Types (DriverId, ModuleName)
+import GHCSpecter.Data.Map
+  ( BiKeyMap,
+    forwardLookup,
+  )
+import GHCSpecter.Data.Timing.Types
+  ( HasPipelineInfo (..),
+    HasTimingTable (..),
+    TimingTable,
+  )
+import GHCSpecter.Data.Timing.Util (isTimeInTimerRange)
+import GHCSpecter.Render.Util (divClass, xmlns)
+import GHCSpecter.UI.ConcurReplica.DOM
+  ( div,
+    text,
+  )
+import GHCSpecter.UI.ConcurReplica.DOM.Events
+  ( onMouseDown,
+    onMouseMove,
+    onMouseUp,
+  )
+import GHCSpecter.UI.ConcurReplica.SVG qualified as S
+import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import GHCSpecter.UI.Constants
+  ( timingBarHeight,
+    timingHeight,
+    timingMaxWidth,
+    timingWidth,
+  )
+import GHCSpecter.UI.Types
+  ( HasTimingUI (..),
+    TimingUI,
+  )
+import GHCSpecter.UI.Types.Event
+  ( ComponentTag (TimingView),
+    Event (..),
+    MouseEvent (..),
+    TimingEvent (..),
+  )
+import Prelude hiding (div)
+
+viewPortX :: TimingUI -> Int
+viewPortX tui = tui ^. timingUIViewPortTopLeft . _1 . to floor
+
+viewPortY :: TimingUI -> Int
+viewPortY tui = tui ^. timingUIViewPortTopLeft . _2 . to floor
+
+diffTime2X :: NominalDiffTime -> NominalDiffTime -> Double
+diffTime2X totalTime time =
+  realToFrac (time / totalTime) * timingMaxWidth
+
+module2Y :: Double -> Double
+module2Y i = 5.0 * i + 1.0
+
+colorCodes :: [Text]
+colorCodes =
+  [ "#EC7063"
+  , "#F1948A"
+  , "#F5B7B1"
+  , "#FADBD8"
+  , "#FDEDEC"
+  , "#FFFFFF"
+  ]
+
+renderRules ::
+  Bool ->
+  TimingTable ->
+  Int ->
+  NominalDiffTime ->
+  [Widget IHTML a]
+renderRules showParallel table totalHeight totalTime =
+  ( if showParallel
+      then fmap box rangesWithCPUUsage
+      else []
+  )
+    ++ fmap line ruleTimes
+  where
+    totalTimeInSec = nominalDiffTimeToSeconds totalTime
+    ruleTimes = [0, 1 .. totalTimeInSec]
+    ranges = zip ruleTimes (tail ruleTimes)
+    getParallelCompilation (sec1, sec2) =
+      let avg = secondsToNominalDiffTime $ realToFrac $ 0.5 * (sec1 + sec2)
+          filtered =
+            filter
+              (\x -> x ^. _2 . to (isTimeInTimerRange avg))
+              (table ^. ttableTimingInfos)
+       in length filtered
+    rangesWithCPUUsage =
+      fmap (\range -> (range, getParallelCompilation range)) ranges
+    nCPU2Color n
+      | n <= 2 = colorCodes !! 0
+      | n > 2 && n <= 4 = colorCodes !! 1
+      | n > 4 && n <= 6 = colorCodes !! 2
+      | n > 6 && n <= 8 = colorCodes !! 3
+      | n > 8 && n <= 10 = colorCodes !! 4
+      | otherwise = colorCodes !! 5
+    line sec =
+      S.line
+        [ SP.x1 (T.pack $ show $ sec2X sec)
+        , SP.x2 (T.pack $ show $ sec2X sec)
+        , SP.y1 "0"
+        , SP.y2 (T.pack $ show totalHeight)
+        , SP.stroke "gray"
+        , SP.strokeWidth "0.25"
+        ]
+        []
+    sec2X sec =
+      floor (diffTime2X totalTime (secondsToNominalDiffTime sec)) :: Int
+    box ((sec1, _), n) =
+      S.rect
+        [ SP.x (T.pack $ show $ sec2X sec1)
+        , SP.y "0"
+        , SP.width (T.pack $ show $ sec2X (1.01))
+        , SP.height (T.pack $ show totalHeight)
+        , SP.fill (nCPU2Color n)
+        ]
+        []
+
+renderTimingChart ::
+  BiKeyMap DriverId ModuleName ->
+  TimingUI ->
+  TimingTable ->
+  Widget IHTML Event
+renderTimingChart drvModMap tui ttable =
+  divClass
+    "box"
+    [ style
+        [ ("width", T.pack (show timingWidth))
+        , ("height", T.pack (show timingHeight))
+        , ("overflow", "hidden")
+        ]
+    ]
+    [svgElement]
+  where
+    timingInfos = ttable ^. ttableTimingInfos
+    mhoveredMod = tui ^. timingUIHoveredModule
+    nMods = length timingInfos
+    modEndTimes = fmap (^. _2 . plEnd . _1) timingInfos
+    totalTime =
+      case modEndTimes of
+        [] -> secondsToNominalDiffTime 1 -- default time length = 1 sec
+        _ -> maximum modEndTimes
+    totalHeight = 5 * nMods
+    topOfBox :: Int -> Int
+    topOfBox = floor . module2Y . fromIntegral
+    leftOfBox (_, tinfo) =
+      let startTime = tinfo ^. plStart . _1
+       in floor (diffTime2X totalTime startTime) :: Int
+    rightOfBox (_, tinfo) =
+      let endTime = tinfo ^. plEnd . _1
+       in floor (diffTime2X totalTime endTime) :: Int
+    widthOfBox (_, tinfo) =
+      let startTime = tinfo ^. plStart . _1
+          endTime = tinfo ^. plEnd . _1
+       in floor (diffTime2X totalTime (endTime - startTime)) :: Int
+    widthHscOutOfBox (_, tinfo) =
+      let startTime = tinfo ^. plStart . _1
+          hscOutTime = tinfo ^. plHscOut . _1
+       in floor (diffTime2X totalTime (hscOutTime - startTime)) :: Int
+    widthAsOfBox (_, tinfo) =
+      let startTime = tinfo ^. plStart . _1
+          asTime = tinfo ^. plAs . _1
+       in floor (diffTime2X totalTime (asTime - startTime)) :: Int
+    (i, _) `isInRange` (y0, y1) =
+      let y = topOfBox i
+       in y0 <= y && y <= y1
+
+    box (i, item@(mmodu, _)) =
+      let highlighter
+            | mmodu == mhoveredMod = [SP.stroke "orange", SP.strokeWidth "0.5"]
+            | otherwise = []
+       in S.rect
+            ( [ SP.x (T.pack $ show (leftOfBox item))
+              , SP.y (T.pack $ show (topOfBox i))
+              , width (T.pack $ show (widthOfBox item))
+              , height "3"
+              , SP.fill "lightslategray"
+              ]
+                ++ highlighter
+            )
+            []
+    boxHscOut (i, item) =
+      S.rect
+        [ SP.x (T.pack $ show (leftOfBox item))
+        , SP.y (T.pack $ show (topOfBox i))
+        , width (T.pack $ show (widthHscOutOfBox item))
+        , height "3"
+        , SP.fill "royalblue"
+        ]
+        []
+    boxAs (i, item) =
+      S.rect
+        [ SP.x (T.pack $ show (leftOfBox item))
+        , SP.y (T.pack $ show (topOfBox i))
+        , width (T.pack $ show (widthAsOfBox item))
+        , height "3"
+        , SP.fill "deepskyblue"
+        ]
+        []
+    moduleText (i, item@(mmodu, _)) =
+      let moduTxt = fromMaybe "" mmodu
+       in S.text
+            [ SP.x (T.pack $ show (rightOfBox item))
+            , SP.y (T.pack $ show (topOfBox i + 3))
+            , classList [("small", True)]
+            ]
+            [text moduTxt]
+    makeItems x =
+      let mmodu = x ^. _2 . _1
+          props =
+            case mmodu of
+              Nothing -> []
+              Just modu ->
+                [ TimingEv (HoverOnModule modu) <$ onMouseEnter
+                , TimingEv (HoverOffModule modu) <$ onMouseLeave
+                ]
+       in if (tui ^. timingUIPartition)
+            then S.g props [box x, boxAs x, boxHscOut x, moduleText x]
+            else S.g props [box x, moduleText x]
+    svgProps =
+      let viewboxProp =
+            SP.viewBox . T.intercalate " " . fmap (T.pack . show) $
+              [viewPortX tui, viewPortY tui, timingWidth, timingHeight]
+          prop1 =
+            [ MouseEv TimingView . MouseDown <$> onMouseDown
+            , MouseEv TimingView . MouseUp <$> onMouseUp
+            , width (T.pack (show timingWidth))
+            , height (T.pack (show timingHeight))
+            , viewboxProp
+            , SP.version "1.1"
+            , xmlns
+            ]
+          mouseMove
+            | tui ^. timingUIHandleMouseMove =
+                [MouseEv TimingView . MouseMove <$> onMouseMove]
+            | otherwise = []
+       in mouseMove ++ prop1
+
+    timingInfos' = fmap (_1 %~ (`forwardLookup` drvModMap)) timingInfos
+    allItems = zip [0 ..] timingInfos'
+    filteredItems =
+      filter (`isInRange` (viewPortY tui, viewPortY tui + timingHeight)) allItems
+
+    mkLine src tgt = do
+      (srcIdx, srcItem) <-
+        L.find (\(_, (mname, _)) -> mname == Just src) allItems
+      (tgtIdx, tgtItem) <-
+        L.find (\(_, (mname, _)) -> mname == Just tgt) allItems
+      let line =
+            S.line
+              [ SP.x1 (T.pack $ show (leftOfBox srcItem))
+              , SP.y1 (T.pack $ show (topOfBox srcIdx))
+              , SP.x2 (T.pack $ show (rightOfBox tgtItem))
+              , SP.y2 (T.pack $ show (topOfBox tgtIdx))
+              , SP.stroke "red"
+              , SP.strokeWidth "1"
+              ]
+              []
+      pure line
+
+    lineToUpstream = maybeToList $ join $ fmap mkLineToUpstream mhoveredMod
+      where
+        mkLineToUpstream hoveredMod = do
+          upMod <-
+            M.lookup hoveredMod (ttable ^. ttableBlockingUpstreamDependency)
+          mkLine hoveredMod upMod
+
+    linesToDownstream :: [Widget IHTML Event]
+    linesToDownstream = maybe [] (fromMaybe [] . mkLinesToDownstream) mhoveredMod
+      where
+        mkLinesToDownstream :: ModuleName -> Maybe [Widget IHTML Event]
+        mkLinesToDownstream hoveredMod = do
+          downMods <-
+            M.lookup hoveredMod (ttable ^. ttableBlockedDownstreamDependency)
+          pure $ mapMaybe (`mkLine` hoveredMod) downMods
+
+    svgElement =
+      S.svg
+        svgProps
+        [ S.style [] [text ".small { font: 5px sans-serif; } text { user-select: none; }"]
+        , S.g
+            []
+            ( renderRules (tui ^. timingUIHowParallel) ttable totalHeight totalTime
+                ++ (fmap makeItems filteredItems)
+                ++ lineToUpstream
+                ++ linesToDownstream
+            )
+        ]

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -26,7 +26,7 @@ import GHCSpecter.Channel.Outbound.Types
     ProcessInfo (..),
     SessionInfo (..),
     Timer,
-    getEndTime,
+    getEnd,
   )
 import GHCSpecter.Data.Map
   ( BiKeyMap,
@@ -205,6 +205,6 @@ render ss =
       nTot = IM.size (mginfoModuleNameMap mgi)
       timingList = keyMapToList timing
       (timingDone, timingInProg) =
-        partition (\(_, t) -> isJust (getEndTime t)) timingList
+        partition (\(_, t) -> isJust (getEnd t)) timingList
       nDone = length timingDone
       nInProg = length timingInProg

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -291,7 +291,7 @@ render srcUI ss =
     , height "100%"
     ]
     [ divClass
-        "column box is-one-fifths"
+        "column box is-one-fifth"
         [style [("overflow", "scroll")]]
         [SourceViewEv <$> renderModuleTree srcUI ss]
     , divClass

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -1,6 +1,3 @@
--- {-# LANGUAGE FunctionalDependencies #-}
--- {-# LANGUAGE TemplateHaskell #-}
-
 module GHCSpecter.Render.Timing
   ( render,
   )
@@ -16,16 +13,13 @@ import Concur.Replica
     width,
   )
 import Concur.Replica.DOM.Props qualified as DP (checked, name, type_)
-import Concur.Replica.SVG.Props qualified as SP
 import Control.Lens (to, (^.), _1)
 import Data.List qualified as L
-import Data.Map.Strict qualified as M
-import Data.Maybe (fromMaybe, isNothing, maybeToList)
+import Data.Maybe (fromMaybe, isNothing)
 import Data.Text qualified as T
 import Data.Time.Clock
   ( secondsToNominalDiffTime,
   )
-import GHCSpecter.Channel.Common.Types (ModuleName)
 import GHCSpecter.Channel.Outbound.Types
   ( ModuleGraphInfo (..),
     SessionInfo (..),
@@ -34,11 +28,10 @@ import GHCSpecter.Data.Map (backwardLookup)
 import GHCSpecter.Data.Timing.Types
   ( HasPipelineInfo (..),
     HasTimingTable (..),
-    TimingTable,
   )
 import GHCSpecter.Render.Components.GraphView qualified as GraphView
 import GHCSpecter.Render.Components.TimingView qualified as TimingView
-import GHCSpecter.Render.Util (divClass, spanClass, xmlns)
+import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     HasTimingState (..),
@@ -47,23 +40,13 @@ import GHCSpecter.Server.Types
 import GHCSpecter.UI.ConcurReplica.DOM
   ( button,
     div,
-    hr,
     input,
     label,
-    p,
-    span,
     text,
   )
-import GHCSpecter.UI.ConcurReplica.DOM.Events
-  ( onMouseDown,
-    onMouseMove,
-    onMouseUp,
-  )
-import GHCSpecter.UI.ConcurReplica.SVG qualified as S
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Constants
-  ( timingBarHeight,
-    timingHeight,
+  ( timingHeight,
     timingWidth,
     widgetHeight,
   )
@@ -74,9 +57,7 @@ import GHCSpecter.UI.Types
     UIModel,
   )
 import GHCSpecter.UI.Types.Event
-  ( ComponentTag (TimingBar),
-    Event (..),
-    MouseEvent (..),
+  ( Event (..),
     TimingEvent (..),
   )
 import Prelude hiding (div, span)
@@ -152,25 +133,6 @@ renderTimingMode model ss =
         fromMaybe
           (ss ^. serverTiming . tsTimingTable)
           (model ^. modelTiming . timingFrozenTable)
-      mhoveredMod = model ^. modelTiming . timingUIHoveredModule
-      hoverInfo =
-        case mhoveredMod of
-          Nothing -> []
-          Just hoveredMod ->
-            [ divClass
-                "box"
-                [ style
-                    [ ("width", "150px")
-                    , ("height", "120px")
-                    , ("position", "absolute")
-                    , ("bottom", "0")
-                    , ("left", "0")
-                    , ("background", "ivory")
-                    , ("overflow", "hidden")
-                    ]
-                ]
-                [TimingView.renderBlockerLine hoveredMod ttable]
-            ]
    in div
         [ style
             [ ("width", "100%")
@@ -183,7 +145,6 @@ renderTimingMode model ss =
               [style [("position", "absolute"), ("top", "0"), ("right", "0")]]
               [renderCheckbox (model ^. modelTiming)]
           ]
-            ++ hoverInfo
         )
 
 renderBlockerGraph :: ServerState -> Widget IHTML Event

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -177,7 +177,7 @@ renderTimingChart drvModMap tui ttable =
   let timingInfos = ttable ^. ttableTimingInfos
       mhoveredMod = tui ^. timingUIHoveredModule
       nMods = length timingInfos
-      modEndTimes = fmap (^. _2 . plEnd) timingInfos
+      modEndTimes = fmap (^. _2 . plEnd . _1) timingInfos
       totalTime =
         case modEndTimes of
           [] -> secondsToNominalDiffTime 1 -- default time length = 1 sec
@@ -186,22 +186,22 @@ renderTimingChart drvModMap tui ttable =
       topOfBox :: Int -> Int
       topOfBox = floor . module2Y . fromIntegral
       leftOfBox (_, tinfo) =
-        let startTime = tinfo ^. plStart
+        let startTime = tinfo ^. plStart . _1
          in floor (diffTime2X totalTime startTime) :: Int
       rightOfBox (_, tinfo) =
-        let endTime = tinfo ^. plEnd
+        let endTime = tinfo ^. plEnd . _1
          in floor (diffTime2X totalTime endTime) :: Int
       widthOfBox (_, tinfo) =
-        let startTime = tinfo ^. plStart
-            endTime = tinfo ^. plEnd
+        let startTime = tinfo ^. plStart . _1
+            endTime = tinfo ^. plEnd . _1
          in floor (diffTime2X totalTime (endTime - startTime)) :: Int
       widthHscOutOfBox (_, tinfo) =
-        let startTime = tinfo ^. plStart
-            hscOutTime = tinfo ^. plHscOut
+        let startTime = tinfo ^. plStart . _1
+            hscOutTime = tinfo ^. plHscOut . _1
          in floor (diffTime2X totalTime (hscOutTime - startTime)) :: Int
       widthAsOfBox (_, tinfo) =
-        let startTime = tinfo ^. plStart
-            asTime = tinfo ^. plAs
+        let startTime = tinfo ^. plStart . _1
+            asTime = tinfo ^. plAs . _1
          in floor (diffTime2X totalTime (asTime - startTime)) :: Int
       (i, _) `isInRange` (y0, y1) =
         let y = topOfBox i
@@ -554,7 +554,7 @@ renderBlockerGraph ss =
     maxTime =
       case ttable ^. ttableTimingInfos of
         [] -> secondsToNominalDiffTime 1.0
-        ts -> maximum (fmap (\(_, t) -> t ^. plEnd - t ^. plStart) ts)
+        ts -> maximum (fmap (\(_, t) -> t ^. plEnd . _1 - t ^. plStart . _1) ts)
     mblockerGraphViz = ss ^. serverTiming . tsBlockerGraphViz
     contents =
       case mblockerGraphViz of
@@ -564,7 +564,7 @@ renderBlockerGraph ss =
                 fromMaybe 0 $ do
                   i <- backwardLookup name drvModMap
                   t <- L.lookup i (ttable ^. ttableTimingInfos)
-                  pure $ realToFrac ((t ^. plEnd - t ^. plStart) / maxTime)
+                  pure $ realToFrac ((t ^. plEnd . _1 - t ^. plStart . _1) / maxTime)
            in [ TimingEv . BlockerModuleGraphEv
                   <$> GraphView.renderModuleGraph
                     nameMap

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE TemplateHaskell #-}
+-- {-# LANGUAGE FunctionalDependencies #-}
+-- {-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Render.Timing
   ( render,
@@ -12,42 +12,36 @@ import Concur.Replica
     height,
     onChange,
     onClick,
-    onMouseEnter,
-    onMouseLeave,
     style,
     width,
   )
 import Concur.Replica.DOM.Props qualified as DP (checked, name, type_)
 import Concur.Replica.SVG.Props qualified as SP
-import Control.Lens (to, (^.), (%~), _1, _2)
-import Control.Monad (join)
+import Control.Lens (to, (^.), _1)
 import Data.List qualified as L
 import Data.Map.Strict qualified as M
-import Data.Maybe (fromMaybe, isNothing, mapMaybe, maybeToList)
-import Data.Text (Text)
+import Data.Maybe (fromMaybe, isNothing, maybeToList)
 import Data.Text qualified as T
 import Data.Time.Clock
-  ( NominalDiffTime,
-    nominalDiffTimeToSeconds,
-    secondsToNominalDiffTime,
+  ( secondsToNominalDiffTime,
   )
-import GHCSpecter.Channel.Common.Types (DriverId, ModuleName)
+import GHCSpecter.Channel.Common.Types (ModuleName)
 import GHCSpecter.Channel.Outbound.Types
   ( ModuleGraphInfo (..),
     SessionInfo (..),
   )
-import GHCSpecter.Data.Map
-  ( BiKeyMap,
-    backwardLookup,
-    forwardLookup,
-  )
+import GHCSpecter.Data.Map (backwardLookup)
 import GHCSpecter.Data.Timing.Types
   ( HasPipelineInfo (..),
     HasTimingTable (..),
     TimingTable,
   )
-import GHCSpecter.Data.Timing.Util (isTimeInTimerRange)
 import GHCSpecter.Render.Components.GraphView qualified as GraphView
+import GHCSpecter.Render.Components.TimingView
+  ( module2Y,
+    renderTimingChart,
+    viewPortY,
+  )
 import GHCSpecter.Render.Util (divClass, xmlns)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
@@ -73,7 +67,6 @@ import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Constants
   ( timingBarHeight,
     timingHeight,
-    timingMaxWidth,
     timingWidth,
     widgetHeight,
   )
@@ -84,259 +77,12 @@ import GHCSpecter.UI.Types
     UIModel,
   )
 import GHCSpecter.UI.Types.Event
-  ( ComponentTag (TimingBar, TimingView),
+  ( ComponentTag (TimingBar),
     Event (..),
     MouseEvent (..),
     TimingEvent (..),
   )
 import Prelude hiding (div)
-
-colorCodes :: [Text]
-colorCodes =
-  [ "#EC7063"
-  , "#F1948A"
-  , "#F5B7B1"
-  , "#FADBD8"
-  , "#FDEDEC"
-  , "#FFFFFF"
-  ]
-
-renderRules ::
-  Bool ->
-  TimingTable ->
-  Int ->
-  NominalDiffTime ->
-  [Widget IHTML a]
-renderRules showParallel table totalHeight totalTime =
-  ( if showParallel
-      then fmap box rangesWithCPUUsage
-      else []
-  )
-    ++ fmap line ruleTimes
-  where
-    totalTimeInSec = nominalDiffTimeToSeconds totalTime
-    ruleTimes = [0, 1 .. totalTimeInSec]
-    ranges = zip ruleTimes (tail ruleTimes)
-    getParallelCompilation (sec1, sec2) =
-      let avg = secondsToNominalDiffTime $ realToFrac $ 0.5 * (sec1 + sec2)
-          filtered =
-            filter
-              (\x -> x ^. _2 . to (isTimeInTimerRange avg))
-              (table ^. ttableTimingInfos)
-       in length filtered
-    rangesWithCPUUsage =
-      fmap (\range -> (range, getParallelCompilation range)) ranges
-    nCPU2Color n
-      | n <= 2 = colorCodes !! 0
-      | n > 2 && n <= 4 = colorCodes !! 1
-      | n > 4 && n <= 6 = colorCodes !! 2
-      | n > 6 && n <= 8 = colorCodes !! 3
-      | n > 8 && n <= 10 = colorCodes !! 4
-      | otherwise = colorCodes !! 5
-    line sec =
-      S.line
-        [ SP.x1 (T.pack $ show $ sec2X sec)
-        , SP.x2 (T.pack $ show $ sec2X sec)
-        , SP.y1 "0"
-        , SP.y2 (T.pack $ show totalHeight)
-        , SP.stroke "gray"
-        , SP.strokeWidth "0.25"
-        ]
-        []
-    sec2X sec =
-      floor (diffTime2X totalTime (secondsToNominalDiffTime sec)) :: Int
-    box ((sec1, _), n) =
-      S.rect
-        [ SP.x (T.pack $ show $ sec2X sec1)
-        , SP.y "0"
-        , SP.width (T.pack $ show $ sec2X (1.01))
-        , SP.height (T.pack $ show totalHeight)
-        , SP.fill (nCPU2Color n)
-        ]
-        []
-
-viewPortX :: TimingUI -> Int
-viewPortX tui = tui ^. timingUIViewPortTopLeft . _1 . to floor
-
-viewPortY :: TimingUI -> Int
-viewPortY tui = tui ^. timingUIViewPortTopLeft . _2 . to floor
-
-diffTime2X :: NominalDiffTime -> NominalDiffTime -> Double
-diffTime2X totalTime time =
-  realToFrac (time / totalTime) * timingMaxWidth
-
-module2Y :: Double -> Double
-module2Y i = 5.0 * i + 1.0
-
-renderTimingChart ::
-  BiKeyMap DriverId ModuleName ->
-  TimingUI ->
-  TimingTable ->
-  Widget IHTML Event
-renderTimingChart drvModMap tui ttable =
-  let timingInfos = ttable ^. ttableTimingInfos
-      mhoveredMod = tui ^. timingUIHoveredModule
-      nMods = length timingInfos
-      modEndTimes = fmap (^. _2 . plEnd . _1) timingInfos
-      totalTime =
-        case modEndTimes of
-          [] -> secondsToNominalDiffTime 1 -- default time length = 1 sec
-          _ -> maximum modEndTimes
-      totalHeight = 5 * nMods
-      topOfBox :: Int -> Int
-      topOfBox = floor . module2Y . fromIntegral
-      leftOfBox (_, tinfo) =
-        let startTime = tinfo ^. plStart . _1
-         in floor (diffTime2X totalTime startTime) :: Int
-      rightOfBox (_, tinfo) =
-        let endTime = tinfo ^. plEnd . _1
-         in floor (diffTime2X totalTime endTime) :: Int
-      widthOfBox (_, tinfo) =
-        let startTime = tinfo ^. plStart . _1
-            endTime = tinfo ^. plEnd . _1
-         in floor (diffTime2X totalTime (endTime - startTime)) :: Int
-      widthHscOutOfBox (_, tinfo) =
-        let startTime = tinfo ^. plStart . _1
-            hscOutTime = tinfo ^. plHscOut . _1
-         in floor (diffTime2X totalTime (hscOutTime - startTime)) :: Int
-      widthAsOfBox (_, tinfo) =
-        let startTime = tinfo ^. plStart . _1
-            asTime = tinfo ^. plAs . _1
-         in floor (diffTime2X totalTime (asTime - startTime)) :: Int
-      (i, _) `isInRange` (y0, y1) =
-        let y = topOfBox i
-         in y0 <= y && y <= y1
-
-      box (i, item@(mmodu, _)) =
-        let highlighter
-              | mmodu == mhoveredMod = [SP.stroke "orange", SP.strokeWidth "0.5"]
-              | otherwise = []
-         in S.rect
-              ( [ SP.x (T.pack $ show (leftOfBox item))
-                , SP.y (T.pack $ show (topOfBox i))
-                , width (T.pack $ show (widthOfBox item))
-                , height "3"
-                , SP.fill "lightslategray"
-                ]
-                  ++ highlighter
-              )
-              []
-      boxHscOut (i, item) =
-        S.rect
-          [ SP.x (T.pack $ show (leftOfBox item))
-          , SP.y (T.pack $ show (topOfBox i))
-          , width (T.pack $ show (widthHscOutOfBox item))
-          , height "3"
-          , SP.fill "royalblue"
-          ]
-          []
-      boxAs (i, item) =
-        S.rect
-          [ SP.x (T.pack $ show (leftOfBox item))
-          , SP.y (T.pack $ show (topOfBox i))
-          , width (T.pack $ show (widthAsOfBox item))
-          , height "3"
-          , SP.fill "deepskyblue"
-          ]
-          []
-      moduleText (i, item@(mmodu, _)) =
-        let moduTxt = fromMaybe "" mmodu
-         in S.text
-              [ SP.x (T.pack $ show (rightOfBox item))
-              , SP.y (T.pack $ show (topOfBox i + 3))
-              , classList [("small", True)]
-              ]
-              [text moduTxt]
-      makeItems x =
-        let mmodu = x ^. _2 . _1
-            props =
-              case mmodu of
-                Nothing -> []
-                Just modu ->
-                  [ TimingEv (HoverOnModule modu) <$ onMouseEnter
-                  , TimingEv (HoverOffModule modu) <$ onMouseLeave
-                  ]
-         in if (tui ^. timingUIPartition)
-              then S.g props [box x, boxAs x, boxHscOut x, moduleText x]
-              else S.g props [box x, moduleText x]
-      svgProps =
-        let viewboxProp =
-              SP.viewBox . T.intercalate " " . fmap (T.pack . show) $
-                [viewPortX tui, viewPortY tui, timingWidth, timingHeight]
-            prop1 =
-              [ MouseEv TimingView . MouseDown <$> onMouseDown
-              , MouseEv TimingView . MouseUp <$> onMouseUp
-              , width (T.pack (show timingWidth))
-              , height (T.pack (show timingHeight))
-              , viewboxProp
-              , SP.version "1.1"
-              , xmlns
-              ]
-            mouseMove
-              | tui ^. timingUIHandleMouseMove =
-                  [MouseEv TimingView . MouseMove <$> onMouseMove]
-              | otherwise = []
-         in mouseMove ++ prop1
-
-      timingInfos' = fmap (_1 %~ (`forwardLookup` drvModMap)) timingInfos
-      allItems = zip [0 ..] timingInfos'
-      filteredItems =
-        filter (`isInRange` (viewPortY tui, viewPortY tui + timingHeight)) allItems
-
-      mkLine src tgt = do
-        (srcIdx, srcItem) <-
-          L.find (\(_, (mname, _)) -> mname == Just src) allItems
-        (tgtIdx, tgtItem) <-
-          L.find (\(_, (mname, _)) -> mname == Just tgt) allItems
-        let line =
-              S.line
-                [ SP.x1 (T.pack $ show (leftOfBox srcItem))
-                , SP.y1 (T.pack $ show (topOfBox srcIdx))
-                , SP.x2 (T.pack $ show (rightOfBox tgtItem))
-                , SP.y2 (T.pack $ show (topOfBox tgtIdx))
-                , SP.stroke "red"
-                , SP.strokeWidth "1"
-                ]
-                []
-        pure line
-
-      lineToUpstream = maybeToList $ join $ fmap mkLineToUpstream mhoveredMod
-        where
-          mkLineToUpstream hoveredMod = do
-            upMod <-
-              M.lookup hoveredMod (ttable ^. ttableBlockingUpstreamDependency)
-            mkLine hoveredMod upMod
-
-      linesToDownstream :: [Widget IHTML Event]
-      linesToDownstream = maybe [] (fromMaybe [] . mkLinesToDownstream) mhoveredMod
-        where
-          mkLinesToDownstream :: ModuleName -> Maybe [Widget IHTML Event]
-          mkLinesToDownstream hoveredMod = do
-            downMods <-
-              M.lookup hoveredMod (ttable ^. ttableBlockedDownstreamDependency)
-            pure $ mapMaybe (`mkLine` hoveredMod) downMods
-
-      svgElement =
-        S.svg
-          svgProps
-          [ S.style [] [text ".small { font: 5px sans-serif; } text { user-select: none; }"]
-          , S.g
-              []
-              ( renderRules (tui ^. timingUIHowParallel) ttable totalHeight totalTime
-                  ++ (fmap makeItems filteredItems)
-                  ++ lineToUpstream
-                  ++ linesToDownstream
-              )
-          ]
-   in divClass
-        "box"
-        [ style
-            [ ("width", T.pack (show timingWidth))
-            , ("height", T.pack (show timingHeight))
-            , ("overflow", "hidden")
-            ]
-        ]
-        [svgElement]
 
 buttonShowBlocker :: TimingUI -> Widget IHTML Event
 buttonShowBlocker tui = divClass "control" [] [button']

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -42,7 +42,7 @@ import GHCSpecter.Render.Components.TimingView
     renderTimingChart,
     viewPortY,
   )
-import GHCSpecter.Render.Util (divClass, xmlns)
+import GHCSpecter.Render.Util (divClass, spanClass, xmlns)
 import GHCSpecter.Server.Types
   ( HasServerState (..),
     HasTimingState (..),
@@ -55,6 +55,7 @@ import GHCSpecter.UI.ConcurReplica.DOM
     input,
     label,
     p,
+    span,
     text,
   )
 import GHCSpecter.UI.ConcurReplica.DOM.Events
@@ -82,7 +83,7 @@ import GHCSpecter.UI.Types.Event
     MouseEvent (..),
     TimingEvent (..),
   )
-import Prelude hiding (div)
+import Prelude hiding (div, span)
 
 buttonShowBlocker :: TimingUI -> Widget IHTML Event
 buttonShowBlocker tui = divClass "control" [] [button']

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -142,7 +142,13 @@ renderTimingMode model ss =
         ]
         ( [ TimingView.render (ss ^. serverDriverModuleMap) (model ^. modelTiming) ttable
           , div
-              [style [("position", "absolute"), ("top", "0"), ("right", "0")]]
+              [ style
+                  [ ("position", "absolute")
+                  , ("top", "0")
+                  , ("right", "0")
+                  , ("background-color", "white")
+                  ]
+              ]
               [renderCheckbox (model ^. modelTiming)]
           ]
         )

--- a/daemon/src/GHCSpecter/UI/Constants.hs
+++ b/daemon/src/GHCSpecter/UI/Constants.hs
@@ -40,4 +40,4 @@ timingBarHeight = 10
 widgetHeight :: Bool -> Text
 widgetHeight isPaused
   | isPaused = "50vh"
-  | otherwise = "75vh"
+  | otherwise = "95vh"

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -5,6 +5,7 @@ module GHCSpecter.Channel.Outbound.Types
   ( -- * information types
     BreakpointLoc (..),
     TimerTag (..),
+    MemInfo (..),
     Timer (..),
     getStartTime,
     getHscOutTime,
@@ -27,6 +28,7 @@ where
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Binary (Binary (..))
 import Data.Binary.Instances.Time ()
+import Data.Int (Int64)
 import Data.IntMap (IntMap)
 import Data.List qualified as L
 import Data.Map.Strict (Map)
@@ -103,8 +105,19 @@ instance Binary TimerTag where
   put tag = put (fromEnum tag)
   get = toEnum <$> get
 
--- timestamp and live memory from GC.
-newtype Timer = Timer {unTimer :: [(TimerTag, (UTCTime, Maybe Word64))]}
+data MemInfo = MemInfo
+  { memLiveBytes :: Word64
+  , memAllocCounter :: Int64
+  }
+  deriving (Show, Generic)
+
+instance Binary MemInfo
+
+instance FromJSON MemInfo
+
+instance ToJSON MemInfo
+
+newtype Timer = Timer {unTimer :: [(TimerTag, (UTCTime, Maybe MemInfo))]}
   deriving (Show, Generic, Binary, FromJSON, ToJSON)
 
 getStartTime :: Timer -> Maybe UTCTime

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -7,10 +7,10 @@ module GHCSpecter.Channel.Outbound.Types
     TimerTag (..),
     MemInfo (..),
     Timer (..),
-    getStartTime,
-    getHscOutTime,
-    getAsTime,
-    getEndTime,
+    getStart,
+    getHscOut,
+    getAs,
+    getEnd,
     ModuleGraphInfo (..),
     emptyModuleGraphInfo,
     ConsoleReply (..),
@@ -120,17 +120,17 @@ instance ToJSON MemInfo
 newtype Timer = Timer {unTimer :: [(TimerTag, (UTCTime, Maybe MemInfo))]}
   deriving (Show, Generic, Binary, FromJSON, ToJSON)
 
-getStartTime :: Timer -> Maybe UTCTime
-getStartTime (Timer ts) = fmap fst $ L.lookup TimerStart ts
+getStart :: Timer -> Maybe (UTCTime, Maybe MemInfo)
+getStart (Timer ts) = L.lookup TimerStart ts
 
-getHscOutTime :: Timer -> Maybe UTCTime
-getHscOutTime (Timer ts) = fmap fst $ L.lookup TimerHscOut ts
+getHscOut :: Timer -> Maybe (UTCTime, Maybe MemInfo)
+getHscOut (Timer ts) = L.lookup TimerHscOut ts
 
-getAsTime :: Timer -> Maybe UTCTime
-getAsTime (Timer ts) = fmap fst $ L.lookup TimerAs ts
+getAs :: Timer -> Maybe (UTCTime, Maybe MemInfo)
+getAs (Timer ts) = L.lookup TimerAs ts
 
-getEndTime :: Timer -> Maybe UTCTime
-getEndTime (Timer ts) = fmap fst $ L.lookup TimerEnd ts
+getEnd :: Timer -> Maybe (UTCTime, Maybe MemInfo)
+getEnd (Timer ts) = L.lookup TimerEnd ts
 
 data ConsoleReply
   = -- | simple textual reply (with name optionally)

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -34,6 +34,7 @@ import Data.Map.Strict qualified as M
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import Data.Tree (Forest)
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import GHC.RTS.Flags (RTSFlags)
 import GHCSpecter.Channel.Common.Types
@@ -102,20 +103,21 @@ instance Binary TimerTag where
   put tag = put (fromEnum tag)
   get = toEnum <$> get
 
-newtype Timer = Timer {unTimer :: [(TimerTag, UTCTime)]}
+-- timestamp and live memory from GC.
+newtype Timer = Timer {unTimer :: [(TimerTag, (UTCTime, Maybe Word64))]}
   deriving (Show, Generic, Binary, FromJSON, ToJSON)
 
 getStartTime :: Timer -> Maybe UTCTime
-getStartTime (Timer ts) = L.lookup TimerStart ts
+getStartTime (Timer ts) = fmap fst $ L.lookup TimerStart ts
 
 getHscOutTime :: Timer -> Maybe UTCTime
-getHscOutTime (Timer ts) = L.lookup TimerHscOut ts
+getHscOutTime (Timer ts) = fmap fst $ L.lookup TimerHscOut ts
 
 getAsTime :: Timer -> Maybe UTCTime
-getAsTime (Timer ts) = L.lookup TimerAs ts
+getAsTime (Timer ts) = fmap fst $ L.lookup TimerAs ts
 
 getEndTime :: Timer -> Maybe UTCTime
-getEndTime (Timer ts) = L.lookup TimerEnd ts
+getEndTime (Timer ts) = fmap fst $ L.lookup TimerEnd ts
 
 data ConsoleReply
   = -- | simple textual reply (with name optionally)

--- a/plugin/src/GHCSpecter/Data/GHC/Orphans.hs
+++ b/plugin/src/GHCSpecter/Data/GHC/Orphans.hs
@@ -23,6 +23,7 @@ import GHC.RTS.Flags
     TickyFlags,
     TraceFlags,
   )
+import GHC.Stats (GCDetails, RTSStats)
 
 -- orphan instances
 instance Binary GiveGCStats
@@ -124,3 +125,14 @@ instance FromJSON RTSFlags
 
 instance ToJSON RTSFlags
 
+instance Binary GCDetails
+
+instance FromJSON GCDetails
+
+instance ToJSON GCDetails
+
+instance Binary RTSStats
+
+instance FromJSON RTSStats
+
+instance ToJSON RTSStats

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -109,6 +109,7 @@ import Plugin.GHCSpecter.Types
     assignModuleFileToDriverId,
   )
 import Plugin.GHCSpecter.Util (getModuleName)
+import System.Mem (setAllocationCounter)
 #endif
 
 -- TODO: Make the initialization work with GHCi.
@@ -389,6 +390,7 @@ driver opts env0 = do
       env = env0 {hsc_static_plugins = [splugin]}
   -- send module start signal here on GHC 9.2
   startTime <- getCurrentTime
+  setAllocationCounter 0
   mmeminfo <- getMemInfo
   sendModuleStart drvId startTime mmeminfo
   breakPoint drvId StartDriver driverCommands

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -388,7 +388,7 @@ driver opts env0 = do
       env = env0 {hsc_static_plugins = [splugin]}
   -- send module start signal here on GHC 9.2
   startTime <- getCurrentTime
-  sendModuleStart drvId startTime
+  sendModuleStart drvId startTime Nothing
   breakPoint drvId StartDriver driverCommands
 #endif
   let hooks = hsc_hooks env

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -65,8 +65,7 @@ import Language.Haskell.Syntax.Expr (LHsExpr)
 import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
 import Plugin.GHCSpecter.Console (breakPoint)
 import Plugin.GHCSpecter.Hooks
-  ( getMemInfo,
-    runMetaHook',
+  ( runMetaHook',
     runPhaseHook',
     runRnSpliceHook',
   )
@@ -100,7 +99,8 @@ import GHC.Types.Unique.FM (emptyUFM)
 import GHC.Hs (HsParsedModule)
 import GHC.Tc.Types (TcPluginResult (TcPluginOk))
 import Plugin.GHCSpecter.Hooks
-  ( sendModuleName,
+  ( getMemInfo,
+    sendModuleName,
     sendModuleStart,
   )
 import Plugin.GHCSpecter.Tasks (driverCommands)

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -65,7 +65,8 @@ import Language.Haskell.Syntax.Expr (LHsExpr)
 import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
 import Plugin.GHCSpecter.Console (breakPoint)
 import Plugin.GHCSpecter.Hooks
-  ( runMetaHook',
+  ( getMemInfo,
+    runMetaHook',
     runPhaseHook',
     runRnSpliceHook',
   )
@@ -388,7 +389,8 @@ driver opts env0 = do
       env = env0 {hsc_static_plugins = [splugin]}
   -- send module start signal here on GHC 9.2
   startTime <- getCurrentTime
-  sendModuleStart drvId startTime Nothing
+  mmeminfo <- getMemInfo
+  sendModuleStart drvId startTime mmeminfo
   breakPoint drvId StartDriver driverCommands
 #endif
   let hooks = hsc_hooks env

--- a/plugin/src/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src/Plugin/GHCSpecter/Hooks.hs
@@ -61,7 +61,7 @@ import Plugin.GHCSpecter.Tasks
   )
 import Safe (readMay)
 import System.IO.Unsafe (unsafePerformIO)
-import System.Mem (setAllocationCounter, getAllocationCounter)
+import System.Mem (getAllocationCounter)
 -- GHC version dependent imports
 #if MIN_VERSION_ghc(9, 4, 0)
 import Control.Applicative ((<|>))
@@ -86,6 +86,7 @@ import Plugin.GHCSpecter.Types
   )
 import Plugin.GHCSpecter.Util (getModuleName)
 import System.Directory (canonicalizePath)
+import System.Mem (setAllocationCounter)
 #elif MIN_VERSION_ghc(9, 2, 0)
 import Control.Monad.IO.Class (liftIO)
 import GHC.Driver.Phases (Phase (As, StopLn))


### PR DESCRIPTION
By reading RTSStats and allocation counter, the memory allocation information in a single module compilation is collected and shown as bar graph juxtaposed with the timing view.