### PR TITLE
Show GHC Mode and Backend information

### DIFF
--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -116,6 +116,18 @@ renderModuleInProgress drvModMap pausedMap timingInProg =
         ]
         (fmap (\x -> p [] [text x]) msgs)
 
+renderGhcMode :: SessionInfo -> Widget IHTML a
+renderGhcMode sinfo =
+  divClass
+    "session-section"
+    []
+    [ div [] [spanClass "box" [] [text "GHC Mode"], text ": ", text ghcMode]
+    , div [] [spanClass "box" [] [text "Backend"], text ": ", text backend]
+    ]
+  where
+    ghcMode = T.pack $ show $ sessionGhcMode sinfo
+    backend = T.pack $ show $ sessionBackend sinfo
+
 renderProcessInfo :: ProcessInfo -> Widget IHTML a
 renderProcessInfo procinfo =
   divClass
@@ -177,6 +189,11 @@ render ss =
               infoPart =
                 flip (maybe []) (sessionProcess sessionInfo) $ \procinfo ->
                   [ div
+                      []
+                      [ divClass "session-title" [] [text "GHC Mode"]
+                      , renderGhcMode sessionInfo
+                      ]
+                  , div
                       []
                       [ divClass "session-title" [] [text "Process Info"]
                       , renderProcessInfo procinfo

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -15,6 +15,8 @@ module GHCSpecter.Channel.Outbound.Types
     emptyModuleGraphInfo,
     ConsoleReply (..),
     ProcessInfo (..),
+    GhcMode (..),
+    Backend (..),
     SessionInfo (..),
     emptySessionInfo,
 
@@ -176,8 +178,30 @@ instance FromJSON ProcessInfo
 
 instance ToJSON ProcessInfo
 
+-- | This is the same as GHC.Driver.Session.GhcMode
+data GhcMode = CompManager | OneShot | MkDepend
+  deriving (Show, Generic)
+
+instance Binary GhcMode
+
+instance FromJSON GhcMode
+
+instance ToJSON GhcMode
+
+-- | This is the same as GHC.Driver.Backend.Backend
+data Backend = NCG | LLVM | ViaC | Interpreter | NoBackend
+  deriving (Show, Generic)
+
+instance Binary Backend
+
+instance FromJSON Backend
+
+instance ToJSON Backend
+
 data SessionInfo = SessionInfo
   { sessionProcess :: Maybe ProcessInfo
+  , sessionGhcMode :: GhcMode
+  , sessionBackend :: Backend
   , sessionStartTime :: Maybe UTCTime
   , sessionModuleGraph :: ModuleGraphInfo
   , sessionModuleSources :: Map ModuleName FilePath
@@ -193,7 +217,7 @@ instance ToJSON SessionInfo
 
 emptySessionInfo :: SessionInfo
 emptySessionInfo =
-  SessionInfo Nothing Nothing emptyModuleGraphInfo M.empty True
+  SessionInfo Nothing CompManager NCG Nothing emptyModuleGraphInfo M.empty True
 
 data ChanMessage (a :: Channel) where
   CMCheckImports :: ModuleName -> Text -> ChanMessage 'CheckImports


### PR DESCRIPTION
Show what mode and backend the current GHC session is operated on.
GhcMode = CompManager | OneShot | MkDepend
Backend = NCG | LLVM | ViaC | Interpreter | NoBackend
