### PR TITLE
ghc-debug included in dev env

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -107,6 +107,23 @@
         "type": "github"
       }
     },
+    "ghc-debug": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668721384,
+        "narHash": "sha256-lVp2XCjAc9mpOdCOExVGhSOk16XXf6YgdwOCgr4GyWA=",
+        "ref": "wavewave/ghc94",
+        "rev": "8800c82dd6ef60e117751d196b9cc49aa56494db",
+        "revCount": 493,
+        "type": "git",
+        "url": "https://gitlab.haskell.org/wavewave/ghc-debug.git"
+      },
+      "original": {
+        "ref": "wavewave/ghc94",
+        "type": "git",
+        "url": "https://gitlab.haskell.org/wavewave/ghc-debug.git"
+      }
+    },
     "hs-ogdf": {
       "inputs": {
         "fficxx": [
@@ -175,6 +192,7 @@
         "file-embed": "file-embed",
         "flake-utils": "flake-utils",
         "fourmolu": "fourmolu",
+        "ghc-debug": "ghc-debug",
         "hs-ogdf": "hs-ogdf",
         "nixpkgs": "nixpkgs",
         "replica": "replica"

--- a/flake.lock
+++ b/flake.lock
@@ -151,6 +151,23 @@
         "type": "github"
       }
     },
+    "microlens": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1660843290,
+        "narHash": "sha256-3MmkZKNFDRlL63GDE2EObCzzL4UfEn5hx+2aQqiylp8=",
+        "owner": "stevenfontanella",
+        "repo": "microlens",
+        "rev": "e117e429bcfca033527c4393ebb522364a83e3c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stevenfontanella",
+        "ref": "master",
+        "repo": "microlens",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1666371646,
@@ -194,8 +211,27 @@
         "fourmolu": "fourmolu",
         "ghc-debug": "ghc-debug",
         "hs-ogdf": "hs-ogdf",
+        "microlens": "microlens",
         "nixpkgs": "nixpkgs",
-        "replica": "replica"
+        "replica": "replica",
+        "vty": "vty"
+      }
+    },
+    "vty": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1663380348,
+        "narHash": "sha256-lrqlKS+8EeImX73A9KHzkTph/o9vzQ2yHi5xfbHVZfs=",
+        "owner": "jtdaugherty",
+        "repo": "vty",
+        "rev": "db5f55caf3321d9e015fa99cc41908c12ef172a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jtdaugherty",
+        "ref": "5.37",
+        "repo": "vty",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -39,9 +39,18 @@
         "git+https://gitlab.haskell.org/wavewave/ghc-debug.git?ref=wavewave/ghc94";
       flake = false;
     };
+    microlens = {
+      url = "github:stevenfontanella/microlens/master";
+      flake = false;
+    };
+    vty = {
+      url = "github:jtdaugherty/vty/5.37";
+      flake = false;
+    };
+
   };
   outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica
-    , fficxx, hs-ogdf, file-embed, fourmolu, ghc-debug }:
+    , fficxx, hs-ogdf, file-embed, fourmolu, ghc-debug, microlens, vty }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -73,12 +82,27 @@
                 libraryHaskellDepends = drv.libraryHaskellDepends
                   ++ [ hself.file-embed ];
               }));
+
           # ghc-debug related deps
+          "bimap" = hsuper.bimap_0_5_0;
           "bitwise" = final.haskell.lib.doJailbreak hsuper.bitwise;
+          "brick" = hsuper.brick_1_3;
+          "eventlog2html" = final.haskell.lib.doJailbreak hsuper.eventlog2html;
           "ghc-events" = final.haskell.lib.doJailbreak hsuper.ghc-events;
           "monoidal-containers" =
             final.haskell.lib.doJailbreak hsuper.monoidal-containers;
-          "eventlog2html" = final.haskell.lib.doJailbreak hsuper.eventlog2html;
+          "microlens" =
+            hself.callCabal2nix "microlens" "${microlens}/microlens" { };
+          "microlens-ghc" =
+            hself.callCabal2nix "microlens-ghc" "${microlens}/microlens-ghc"
+            { };
+          "microlens-platform" = hself.callCabal2nix "microlens-platform"
+            "${microlens}/microlens-platform" { };
+          "string-qq" = final.haskell.lib.doJailbreak hsuper.string-qq;
+          "text-zipper" = hsuper.text-zipper_0_12;
+          "vty" = hself.callCabal2nix "vty" vty { };
+
+          # ghc-debug-*
           "ghc-debug-common" =
             hself.callCabal2nix "ghc-debug-common" "${ghc-debug}/common" { };
           "ghc-debug-stub" = final.haskell.lib.doJailbreak
@@ -90,7 +114,9 @@
           #  hself.callCabal2nix "ghc-debugger" "${ghc-debug}/test" { };
           "dyepack-test" =
             hself.callCabal2nix "dyepack-test" "${ghc-debug}/dyepack-test" { };
-          #"ghc-debug-brick" = hself.callCabal2nix "ghc-debug-brick" "${ghc-debug}/brick" { };
+          "ghc-debug-brick" =
+            hself.callCabal2nix "ghc-debug-brick" "${ghc-debug}/ghc-debug-brick"
+            { };
           "ghc-debug-convention" =
             hself.callCabal2nix "ghc-debug-convention" "${ghc-debug}/convention"
             { };
@@ -117,9 +143,9 @@
                 p.ghc-debug-stub
                 p.ghc-debug-client
                 # this seems outdated.
-                #p.ghc-debugger
+                # p.ghc-debugger
                 p.dyepack-test
-                #p.ghc-debug-brick
+                p.ghc-debug-brick
                 p.ghc-debug-convention
                 p.hiedb
                 p.hpack

--- a/flake.nix
+++ b/flake.nix
@@ -85,11 +85,11 @@
             (hself.callCabal2nix "ghc-debug-stub" "${ghc-debug}/stub" { });
           "ghc-debug-client" = final.haskell.lib.doJailbreak
             (hself.callCabal2nix "ghc-debug-client" "${ghc-debug}/client" { });
-          "ghc-debug-test" =
-            hself.callCabal2nix "ghc-debug-test" "${ghc-debug}/test" { };
-          "ghc-debug-dyepack-test" =
-            hself.callCabal2nix "ghc-debug-dyepack-test"
-            "${ghc-debug}/dyepack-test" { };
+          # ghc-debugger seems outdated.
+          #"ghc-debugger" =
+          #  hself.callCabal2nix "ghc-debugger" "${ghc-debug}/test" { };
+          "dyepack-test" =
+            hself.callCabal2nix "dyepack-test" "${ghc-debug}/dyepack-test" { };
           #"ghc-debug-brick" = hself.callCabal2nix "ghc-debug-brick" "${ghc-debug}/brick" { };
           "ghc-debug-convention" =
             hself.callCabal2nix "ghc-debug-convention" "${ghc-debug}/convention"
@@ -116,8 +116,9 @@
                 p.ghc-debug-common
                 p.ghc-debug-stub
                 p.ghc-debug-client
-                #p.ghc-debug-test
-                #p.ghc-debug-dyepack-test
+                # this seems outdated.
+                #p.ghc-debugger
+                p.dyepack-test
                 #p.ghc-debug-brick
                 p.ghc-debug-convention
                 p.hiedb

--- a/flake.nix
+++ b/flake.nix
@@ -100,7 +100,8 @@
             "${microlens}/microlens-platform" { };
           "string-qq" = final.haskell.lib.doJailbreak hsuper.string-qq;
           "text-zipper" = hsuper.text-zipper_0_12;
-          "vty" = hself.callCabal2nix "vty" vty { };
+          "vty" =
+            final.haskell.lib.dontCheck (hself.callCabal2nix "vty" vty { });
 
           # ghc-debug-*
           "ghc-debug-common" =

--- a/flake.nix
+++ b/flake.nix
@@ -73,13 +73,18 @@
                 libraryHaskellDepends = drv.libraryHaskellDepends
                   ++ [ hself.file-embed ];
               }));
-          # ghc-debug
+          # ghc-debug related deps
+          "bitwise" = final.haskell.lib.doJailbreak hsuper.bitwise;
+          "ghc-events" = final.haskell.lib.doJailbreak hsuper.ghc-events;
+          "monoidal-containers" =
+            final.haskell.lib.doJailbreak hsuper.monoidal-containers;
+          "eventlog2html" = final.haskell.lib.doJailbreak hsuper.eventlog2html;
           "ghc-debug-common" =
             hself.callCabal2nix "ghc-debug-common" "${ghc-debug}/common" { };
           "ghc-debug-stub" = final.haskell.lib.doJailbreak
             (hself.callCabal2nix "ghc-debug-stub" "${ghc-debug}/stub" { });
-          "ghc-debug-client" =
-            hself.callCabal2nix "ghc-debug-client" "${ghc-debug}/client" { };
+          "ghc-debug-client" = final.haskell.lib.doJailbreak
+            (hself.callCabal2nix "ghc-debug-client" "${ghc-debug}/client" { });
           "ghc-debug-test" =
             hself.callCabal2nix "ghc-debug-test" "${ghc-debug}/test" { };
           "ghc-debug-dyepack-test" =
@@ -110,7 +115,7 @@
                 p.extra
                 p.ghc-debug-common
                 p.ghc-debug-stub
-                #p.ghc-debug-client
+                p.ghc-debug-client
                 #p.ghc-debug-test
                 #p.ghc-debug-dyepack-test
                 #p.ghc-debug-brick


### PR DESCRIPTION
An up-to-date version (fixed for GHC 9.2 and 9.4) of ghc-debug is now integrated into devShell.