### PR TITLE
Adjust qualified Core representation for GHC 9.4.

### DIFF
--- a/daemon/src/GHCSpecter/Data/GHC/Core.hs
+++ b/daemon/src/GHCSpecter/Data/GHC/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiWayIf #-}
 
 module GHCSpecter.Data.GHC.Core (
@@ -87,7 +88,11 @@ toVar (Node (typ, val) xs)
 
 toBind :: Tree (Text, Text) -> Either Text Bind
 toBind (Node (typ, val) xs)
+#if MIN_VERSION_ghc(9, 4, 0)
+  | typ == "GHC.Core.Bind" =
+#else
   | typ == "Bind" =
+#endif
       if
           | val == "NonRec" ->
               case xs of
@@ -113,7 +118,11 @@ toBind (Node (typ, val) xs)
 
 toLiteral :: Tree (Text, Text) -> Either Text Literal
 toLiteral x@(Node (typ, val) xs)
+#if MIN_VERSION_ghc(9, 4, 0)
+  | typ == "GHC.Types.Literal.Literal" =
+#else
   | typ == "Literal" =
+#endif
       if
           | val == "LitString" ->
               case xs of
@@ -133,7 +142,11 @@ toLiteral x@(Node (typ, val) xs)
 
 toAltCon :: Tree (Text, Text) -> Either Text AltCon
 toAltCon (Node (typ, val) xs)
+#if MIN_VERSION_ghc(9, 4, 0)
+  | typ == "GHC.Core.AltCon" =
+#else
   | typ == "AltCon" =
+#endif
       if
           | val == "DataAlt" ->
               case xs of
@@ -149,7 +162,11 @@ toAltCon (Node (typ, val) xs)
 
 toAlt :: Tree (Text, Text) -> Either Text Alt
 toAlt (Node (typ, _val) xs)
+#if MIN_VERSION_ghc(9, 4, 0)
+  | typ == "GHC.Core.Alt" =
+#else
   | typ == "Alt" =
+#endif
       case xs of
         a : is : e : [] ->
           Alt
@@ -161,7 +178,11 @@ toAlt (Node (typ, _val) xs)
 
 toExpr :: Tree (Text, Text) -> Either Text Expr
 toExpr (Node (typ, val) xs)
+#if MIN_VERSION_ghc(9, 4, 0)
+  | typ == "GHC.Core.Expr" =
+#else
   | typ == "Expr" =
+#endif
       if
           | val == "Var" ->
               case xs of

--- a/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ConsoleItem.hs
@@ -59,11 +59,11 @@ render (ConsoleCore forest) =
     render1 tr =
       let
         -- for debug
-        -- txt = T.pack $ drawTree $ fmap show tr
+        txt = T.pack $ drawTree $ fmap show tr
         ebind = toBind tr
         rendered =
           case ebind of
-            Left err -> renderErr err
+            Left err -> renderErr (err <> "\n" <> txt)
             Right bind -> renderTopBind bind
        in
         div


### PR DESCRIPTION
A few primitive types are now represented with a module qualifier in GHC 9.4.
Bind -> GHC.Core.Bind
Literal -> GHC.Types.Literal.Literal
AltCon -> GHC.Core.AltCon
Alt -> GHC.Core.Alt
Expr -> GHC.Core.Expr
This fixes the Core viewer in ghc-specter-daemon.