### PR TITLE
Fix incorrect paused module behavior

### DIFF
--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -37,6 +37,7 @@ import GHCSpecter.Control.Types (
  )
 import GHCSpecter.Data.Map (
   alterToKeyMap,
+  emptyKeyMap,
   forwardLookup,
  )
 import GHCSpecter.Data.Timing.Types (HasTimingTable (..))
@@ -144,6 +145,7 @@ defaultUpdateModel topEv (oldModel, oldSS) =
           sinfo' = sinfo {sessionIsPaused = False}
           newSS =
             (serverSessionInfo .~ sinfo')
+              . (serverPaused .~ emptyKeyMap)
               . (serverShouldUpdate .~ True)
               $ oldSS
           newModel = (modelConsole . consoleFocus .~ Nothing) oldModel

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -89,10 +89,6 @@ updateInbox chanMsg = incrementSN . updater
          in (serverSessionInfo %~ updateSessionInfo)
               . (serverPaused %~ alterToKeyMap (const (Just loc)) drvId)
               . (serverConsole %~ alterToKeyMap (appendConsoleMsg msg) drvId)
-      CMBox (CMResumed drvId) ->
-        let msg = ConsoleText "resume"
-         in (serverPaused %~ alterToKeyMap (const Nothing) drvId)
-              . (serverConsole %~ alterToKeyMap (appendConsoleMsg msg) drvId)
       CMBox (CMConsole drvId creply) ->
         case creply of
           ConsoleReplyText mtab txt ->
@@ -151,21 +147,6 @@ invokeWorker ssRef workQ (CMBox o) =
               <> modu
               <> ": "
               <> T.pack (show loc)
-    CMResumed drvId -> do
-      mmodu <-
-        atomically $ do
-          ss <- readTVar ssRef
-          let drvModMap = ss ^. serverDriverModuleMap
-          pure $ forwardLookup drvId drvModMap
-      case mmodu of
-        Nothing -> do
-          TIO.putStrLn $
-            "resumed GHC at driverId = "
-              <> T.pack (show (unDriverId drvId))
-        Just modu ->
-          TIO.putStrLn $
-            "resumed GHC at moduleName = "
-              <> modu
     CMConsole {} -> pure ()
 
 listener ::

--- a/daemon/src/GHCSpecter/Render.hs
+++ b/daemon/src/GHCSpecter/Render.hs
@@ -42,6 +42,7 @@ import GHCSpecter.UI.ConcurReplica.DOM (
   text,
  )
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
+import GHCSpecter.UI.Help (consoleCommandList)
 import GHCSpecter.UI.Types (
   HasConsoleUI (..),
   HasMainView (..),
@@ -51,7 +52,6 @@ import GHCSpecter.UI.Types (
   UIModel (..),
   UIState (..),
   UIView (..),
-  consoleCommandList,
  )
 import GHCSpecter.UI.Types.Event (
   ConsoleEvent (..),

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -37,9 +37,6 @@ import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types.Event (ConsoleEvent (..))
 import Prelude hiding (div)
 
--- import Control.Monad.IO.Class (liftIO)
-import Concur.Core (unsafeBlockingIO)
-
 render ::
   (IsKey k, Eq k) =>
   [(k, Text)] ->
@@ -49,9 +46,7 @@ render ::
   Maybe k ->
   Text ->
   Widget IHTML (ConsoleEvent k)
-render tabs contents getHelp mfocus inputEntry = do
-    unsafeBlockingIO (putStrLn $ "Console.render" ++ show (fmap snd tabs))
-    div [] [consoleTabs, console]
+render tabs contents getHelp mfocus inputEntry = div [] [consoleTabs, console]
   where
     navbarMenu = divClass "navbar-menu" []
     navbarStart = divClass "navbar-start" []

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -37,6 +37,9 @@ import GHCSpecter.UI.ConcurReplica.Types (IHTML)
 import GHCSpecter.UI.Types.Event (ConsoleEvent (..))
 import Prelude hiding (div)
 
+-- import Control.Monad.IO.Class (liftIO)
+import Concur.Core (unsafeBlockingIO)
+
 render ::
   (IsKey k, Eq k) =>
   [(k, Text)] ->
@@ -46,7 +49,9 @@ render ::
   Maybe k ->
   Text ->
   Widget IHTML (ConsoleEvent k)
-render tabs contents getHelp mfocus inputEntry = div [] [consoleTabs, console]
+render tabs contents getHelp mfocus inputEntry = do
+    unsafeBlockingIO (putStrLn $ "Console.render" ++ show (fmap snd tabs))
+    div [] [consoleTabs, console]
   where
     navbarMenu = divClass "navbar-menu" []
     navbarStart = divClass "navbar-start" []

--- a/daemon/src/GHCSpecter/UI/Help.hs
+++ b/daemon/src/GHCSpecter/UI/Help.hs
@@ -1,0 +1,26 @@
+module GHCSpecter.UI.Help (
+  -- * list of allowed console commands
+  consoleCommandList,
+) where
+
+import Data.Text (Text)
+import GHCSpecter.Channel.Outbound.Types (BreakpointLoc (..))
+
+-- | list of allowed console commands
+consoleCommandList :: BreakpointLoc -> [Text]
+consoleCommandList bp =
+  case bp of
+    StartDriver -> [":next", ":dump-heap", ":exit-ghc-debug"]
+    ParsedResultAction -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
+    RenamedResultAction -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-renamed"]
+    PreRunMeta -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-expr"]
+    SpliceRunAction -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-expr"]
+    RnSplice -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-splice"]
+    PostRunMeta -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-result"]
+    TypecheckInit -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
+    TypecheckSolve -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
+    TypecheckStop -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
+    TypecheckResultAction -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":unqualified"]
+    Core2Core {} -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":list-core", ":print-core"]
+    PreRunPhase {} -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
+    PostRunPhase {} -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -25,8 +25,6 @@ module GHCSpecter.UI.Types (
   HasUIState (..),
   emptyUIState,
 
-  -- * list of allowed console commands
-  consoleCommandList,
 ) where
 
 import Control.Lens (makeClassy)
@@ -170,22 +168,3 @@ emptyUIState assets now =
     , _uiView = BannerMode 0
     , _uiAssets = assets
     }
-
--- | list of allowed console commands
-consoleCommandList :: BreakpointLoc -> [Text]
-consoleCommandList bp =
-  case bp of
-    StartDriver -> [":next", ":dump-heap", ":exit-ghc-debug"]
-    ParsedResultAction -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
-    RenamedResultAction -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-renamed"]
-    PreRunMeta -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-expr"]
-    SpliceRunAction -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-expr"]
-    RnSplice -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-splice"]
-    PostRunMeta -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":show-result"]
-    TypecheckInit -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
-    TypecheckSolve -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
-    TypecheckStop -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
-    TypecheckResultAction -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":unqualified"]
-    Core2Core {} -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source", ":list-core", ":print-core"]
-    PreRunPhase {} -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]
-    PostRunPhase {} -> [":next", ":dump-heap", ":exit-ghc-debug", ":goto-source"]

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -53,6 +53,7 @@ data Channel
   | Session
   | HsHie
   | Paused
+  | Resumed
   | Console
   deriving (Enum, Eq, Ord, Show, Generic)
 
@@ -224,7 +225,10 @@ data ChanMessage (a :: Channel) where
   CMTiming :: DriverId -> Timer -> ChanMessage 'Timing
   CMSession :: SessionInfo -> ChanMessage 'Session
   CMHsHie :: DriverId -> FilePath -> ChanMessage 'HsHie
-  CMPaused :: DriverId -> Maybe BreakpointLoc -> ChanMessage 'Paused
+  -- | a module is paused at a breakpoint position.
+  CMPaused :: DriverId -> BreakpointLoc -> ChanMessage 'Paused
+  -- | a module is resumed from a paused state.
+  CMResumed :: DriverId -> ChanMessage 'Resumed
   CMConsole :: DriverId -> ConsoleReply -> ChanMessage 'Console
 
 data ChanMessageBox = forall (a :: Channel). CMBox !(ChanMessage a)
@@ -236,6 +240,7 @@ instance Show ChanMessageBox where
   show (CMBox (CMSession {})) = "CMSession"
   show (CMBox (CMHsHie {})) = "CMHsHie"
   show (CMBox (CMPaused {})) = "CMPaused"
+  show (CMBox (CMResumed {})) = "CMResumed"
   show (CMBox (CMConsole {})) = "CMConsole"
 
 instance Binary ChanMessageBox where
@@ -257,6 +262,9 @@ instance Binary ChanMessageBox where
   put (CMBox (CMPaused i ml)) = do
     put (fromEnum Paused)
     put (i, ml)
+  put (CMBox (CMResumed i)) = do
+    put (fromEnum Resumed)
+    put i
   put (CMBox (CMConsole i t)) = do
     put (fromEnum Console)
     put (i, t)
@@ -270,4 +278,5 @@ instance Binary ChanMessageBox where
       Session -> CMBox . CMSession <$> get
       HsHie -> CMBox . uncurry CMHsHie <$> get
       Paused -> CMBox . uncurry CMPaused <$> get
+      Resumed -> CMBox . CMResumed <$> get
       Console -> CMBox . uncurry CMConsole <$> get

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -53,7 +53,6 @@ data Channel
   | Session
   | HsHie
   | Paused
-  | Resumed
   | Console
   deriving (Enum, Eq, Ord, Show, Generic)
 
@@ -227,8 +226,6 @@ data ChanMessage (a :: Channel) where
   CMHsHie :: DriverId -> FilePath -> ChanMessage 'HsHie
   -- | a module is paused at a breakpoint position.
   CMPaused :: DriverId -> BreakpointLoc -> ChanMessage 'Paused
-  -- | a module is resumed from a paused state.
-  CMResumed :: DriverId -> ChanMessage 'Resumed
   CMConsole :: DriverId -> ConsoleReply -> ChanMessage 'Console
 
 data ChanMessageBox = forall (a :: Channel). CMBox !(ChanMessage a)
@@ -240,7 +237,6 @@ instance Show ChanMessageBox where
   show (CMBox (CMSession {})) = "CMSession"
   show (CMBox (CMHsHie {})) = "CMHsHie"
   show (CMBox (CMPaused {})) = "CMPaused"
-  show (CMBox (CMResumed {})) = "CMResumed"
   show (CMBox (CMConsole {})) = "CMConsole"
 
 instance Binary ChanMessageBox where
@@ -262,9 +258,6 @@ instance Binary ChanMessageBox where
   put (CMBox (CMPaused i ml)) = do
     put (fromEnum Paused)
     put (i, ml)
-  put (CMBox (CMResumed i)) = do
-    put (fromEnum Resumed)
-    put i
   put (CMBox (CMConsole i t)) = do
     put (fromEnum Console)
     put (i, t)
@@ -278,5 +271,4 @@ instance Binary ChanMessageBox where
       Session -> CMBox . CMSession <$> get
       HsHie -> CMBox . uncurry CMHsHie <$> get
       Paused -> CMBox . uncurry CMPaused <$> get
-      Resumed -> CMBox . CMResumed <$> get
       Console -> CMBox . uncurry CMConsole <$> get

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -225,10 +225,12 @@ parsedResultActionPlugin ::
   HsParsedModule ->
   Hsc HsParsedModule
 #endif
+#if MIN_VERSION_ghc(9, 4, 0)
+parsedResultActionPlugin opts _ parsed = do
+  for_ (DriverId <$> (readMay =<< headMay opts)) $ \drvId -> do
+#elif MIN_VERSION_ghc(9, 2, 0)
 parsedResultActionPlugin opts modSummary parsed = do
   for_ (DriverId <$> (readMay =<< headMay opts)) $ \drvId -> do
-#if MIN_VERSION_ghc(9, 4, 0)
-#elif MIN_VERSION_ghc(9, 2, 0)
     -- NOTE: on GHC 9.2, we send module name information here.
     let modName = getModuleName modSummary
         msrcFile = ml_hs_file $ ms_location modSummary

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -6,7 +6,7 @@ module Plugin.GHCSpecter.Console (
   breakPoint,
 ) where
 
-import Control.Concurrent (forkIO, killThread, threadDelay)
+import Control.Concurrent (forkIO, killThread)
 import Control.Concurrent.STM (
   TVar,
   atomically,
@@ -135,9 +135,10 @@ sessionInPause drvId loc cmds actionRef = do
     isPaused <- sessionIsPaused . psSessionInfo <$> readTVar sessionRef
     -- proceed when the session is paused.
     STM.check isPaused
-  queueMessage (CMPaused drvId (Just loc))
+  queueMessage (CMPaused drvId loc)
+  -- TODO: This needs explanation.
   (forever $ consoleAction drvId loc cmds actionRef)
-    `catch` (\(_e :: AsyncException) -> queueMessage (CMPaused drvId Nothing))
+    `catch` (\(_e :: AsyncException) -> queueMessage (CMResumed drvId))
 
 breakPoint ::
   forall m.

--- a/plugin/src/Plugin/GHCSpecter/Console.hs
+++ b/plugin/src/Plugin/GHCSpecter/Console.hs
@@ -17,7 +17,6 @@ import Control.Concurrent.STM (
   writeTVar,
  )
 import Control.Concurrent.STM qualified as STM
-import Control.Exception (AsyncException, catch)
 import Control.Monad (forever, when)
 import Control.Monad.Extra (loopM)
 import Control.Monad.IO.Class (MonadIO (..))
@@ -136,9 +135,8 @@ sessionInPause drvId loc cmds actionRef = do
     -- proceed when the session is paused.
     STM.check isPaused
   queueMessage (CMPaused drvId loc)
-  -- TODO: This needs explanation.
-  (forever $ consoleAction drvId loc cmds actionRef)
-    `catch` (\(_e :: AsyncException) -> queueMessage (CMResumed drvId))
+  -- NOTE: the paused session is escaped by killThread.
+  forever $ consoleAction drvId loc cmds actionRef
 
 breakPoint ::
   forall m.
@@ -151,6 +149,7 @@ breakPoint drvId loc cmds = do
   actionRef <- liftIO $ newTVarIO Nothing
   tid <- liftIO $ forkIO $ sessionInPause drvId loc cmds actionRef
   loopM (go actionRef) (pure (), True)
+  -- NOTE: the paused session is escaped by killThread.
   liftIO $ killThread tid
   where
     go :: TVar (Maybe (m ())) -> (m (), Bool) -> m (Either (m (), Bool) ())


### PR DESCRIPTION
Previously, resumed module from pause was detected by an asynchronous "killed thread" exception as the resume is made through killThread. However, this mechanism is too brittle to rely on and there are no need to notify the resume. 
Instead, the paused module list is just to be managed on the daemon side and resume button will wipe out the paused modules.