### PR TITLE
User can dynamically see blocker graph with different blocker level 

### DIFF
--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -70,8 +70,7 @@ main = do
       withConfig mconfigFile $ \cfg -> do
         let socketFile = configSocket cfg
             nodeSizeLimit = configModuleClusterSize cfg
-            blockerThreshold = configModuleBlockerThreshold cfg
-        ssRef <- atomically $ newTVar (initServerState nodeSizeLimit blockerThreshold)
+        ssRef <- atomically $ newTVar (initServerState nodeSizeLimit)
         workQ <- newTQueueIO
         chanSignal <- newTChanIO
         let servSess = ServerSession ssRef chanSignal

--- a/daemon/app/Main.hs
+++ b/daemon/app/Main.hs
@@ -70,7 +70,8 @@ main = do
       withConfig mconfigFile $ \cfg -> do
         let socketFile = configSocket cfg
             nodeSizeLimit = configModuleClusterSize cfg
-        ssRef <- atomically $ newTVar (initServerState nodeSizeLimit)
+            blockerThreshold = configModuleBlockerThreshold cfg
+        ssRef <- atomically $ newTVar (initServerState nodeSizeLimit blockerThreshold)
         workQ <- newTQueueIO
         chanSignal <- newTChanIO
         let servSess = ServerSession ssRef chanSignal

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -70,6 +70,7 @@ import GHCSpecter.UI.Types (
  )
 import GHCSpecter.UI.Types.Event (
   BackgroundEvent (..),
+  BlockerModuleGraphEvent (..),
   ComponentTag (..),
   ConsoleEvent (..),
   Event (..),
@@ -204,9 +205,14 @@ defaultUpdateModel topEv (oldModel, oldSS) =
       printMsg "close blocker graph is pressed"
       let newModel = (modelTiming . timingUIBlockerGraph .~ False) oldModel
       pure (newModel, oldSS)
-    TimingEv (BlockerModuleGraphEv e) -> do
+    TimingEv (BlockerModuleGraphEv (BMGGraph e)) -> do
       printMsg ("blocker module graph event: " <> T.pack (show e))
       pure (oldModel, oldSS)
+    TimingEv (BlockerModuleGraphEv (BMGUpdateLevel lvl)) -> do
+      printMsg ("blocker module graph update: " <> T.pack (show lvl))
+      let newSS = (serverTiming . tsBlockerDetailLevel .~ lvl) oldSS
+      asyncWork timingBlockerGraphWorker
+      pure (oldModel, newSS)
     BkgEv MessageChanUpdated -> do
       let newSS = (serverShouldUpdate .~ True) oldSS
       asyncWork timingWorker

--- a/daemon/src/GHCSpecter/Data/Timing/Util.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Util.hs
@@ -123,15 +123,12 @@ makeTimingTable timing drvModMap mgi sessStart =
         upd d' Nothing = Just [d']
         upd d' (Just ds) = Just (d' : ds)
 
--- | minimum number of dependents to be considered as blocker.
-blockerLimit :: Int
-blockerLimit = 5
-
 makeBlockerGraph ::
+  Int ->
   ModuleGraphInfo ->
   TimingTable ->
   IntMap [Int]
-makeBlockerGraph mgi ttable = blockerGraph
+makeBlockerGraph blockerThreshold mgi ttable = blockerGraph
   where
     modNameMap = mginfoModuleNameMap mgi
     -- TODO: This should be cached
@@ -142,5 +139,5 @@ makeBlockerGraph mgi ttable = blockerGraph
     blockers =
       mapMaybe (\k -> M.lookup k nameModMap) $
         M.keys $
-          M.filter (\ds -> length ds >= blockerLimit) blocked
+          M.filter (\ds -> length ds >= blockerThreshold) blocked
     blockerGraph = fmap (filter (`elem` blockers)) $ IM.filterWithKey (\k _ -> k `elem` blockers) modDep

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -1,5 +1,6 @@
 module GHCSpecter.Render.SourceView (
   render,
+  renderUnqualifiedImports,
 ) where
 
 import Concur.Core (Widget)

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -8,6 +8,7 @@ import Concur.Replica (
   height,
   onChange,
   onClick,
+  onInput,
   style,
   width,
  )
@@ -58,6 +59,7 @@ import GHCSpecter.UI.Types (
  )
 import GHCSpecter.UI.Types.Event (
   BlockerDetailLevel (..),
+  BlockerModuleGraphEvent (..),
   Event (..),
   TimingEvent (..),
  )
@@ -182,7 +184,7 @@ renderBlockerGraph ss =
                   i <- backwardLookup name drvModMap
                   t <- L.lookup i (ttable ^. ttableTimingInfos)
                   pure $ realToFrac ((t ^. plEnd . _1 - t ^. plStart . _1) / maxTime)
-           in [ TimingEv . BlockerModuleGraphEv
+           in [ TimingEv . BlockerModuleGraphEv . BMGGraph
                   <$> GraphView.renderModuleGraph
                     nameMap
                     valueFor
@@ -190,23 +192,22 @@ renderBlockerGraph ss =
                     (Nothing, Nothing)
               ]
 
-
 -- | show blocker detail level radio button
 -- blocker detail level, # of blocked modules >=2, >=3, >=4, >=5
 renderBlockerDetailLevel :: TimingState -> Widget IHTML Event
 renderBlockerDetailLevel timing =
-  TimingEv . BlockerModuleGraphEv
-    <$> div
-      [ classList [("control", True)]
-      -- , style [("position", "absolute"), ("top", "0"), ("right", "0")]
-      ]
-      details
+  TimingEv . BlockerModuleGraphEv <$> div [classList [("control", True)]] details
   where
     currLevel = timing ^. tsBlockerDetailLevel
-    mkRadioItem (txt, lvl) = -- isChecked =
+    mkRadioItem (txt, lvl) =
       label
         [classList [("radio", True)]]
-        [ input [DP.type_ "radio", DP.name "detail", DP.checked (lvl == currLevel)] -- DP.checked isChecked, ev <$ onInput]
+        [ input
+            [ DP.type_ "radio"
+            , DP.name "detail"
+            , DP.checked (lvl == currLevel)
+            , BMGUpdateLevel lvl <$ onInput
+            ]
         , text txt
         ]
     details = fmap mkRadioItem [(">=2", Blocking2), (">=3", Blocking3), (">=4", Blocking4), (">=5", Blocking5)]

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -35,6 +35,7 @@ import GHCSpecter.Server.Types (
   HasServerState (..),
   HasTimingState (..),
   ServerState (..),
+  TimingState (..),
  )
 import GHCSpecter.UI.ConcurReplica.DOM (
   button,
@@ -56,6 +57,7 @@ import GHCSpecter.UI.Types (
   UIModel,
  )
 import GHCSpecter.UI.Types.Event (
+  BlockerDetailLevel (..),
   Event (..),
   TimingEvent (..),
  )
@@ -188,6 +190,27 @@ renderBlockerGraph ss =
                     (Nothing, Nothing)
               ]
 
+
+-- | show blocker detail level radio button
+-- blocker detail level, # of blocked modules >=2, >=3, >=4, >=5
+renderBlockerDetailLevel :: TimingState -> Widget IHTML Event
+renderBlockerDetailLevel timing =
+  TimingEv . BlockerModuleGraphEv
+    <$> div
+      [ classList [("control", True)]
+      -- , style [("position", "absolute"), ("top", "0"), ("right", "0")]
+      ]
+      details
+  where
+    currLevel = timing ^. tsBlockerDetailLevel
+    mkRadioItem (txt, lvl) = -- isChecked =
+      label
+        [classList [("radio", True)]]
+        [ input [DP.type_ "radio", DP.name "detail", DP.checked (lvl == currLevel)] -- DP.checked isChecked, ev <$ onInput]
+        , text txt
+        ]
+    details = fmap mkRadioItem [(">=2", Blocking2), (">=3", Blocking3), (">=4", Blocking4), (">=5", Blocking5)]
+
 -- | blocker graph mode
 renderBlockerGraphMode :: UIModel -> ServerState -> Widget IHTML Event
 renderBlockerGraphMode model ss =
@@ -204,7 +227,8 @@ renderBlockerGraphMode model ss =
           [style [("position", "absolute"), ("top", "0"), ("right", "0")]]
           [ div
               []
-              [ button [TimingEv ShowBlockerGraph <$ onClick] [text "Update"]
+              [ renderBlockerDetailLevel (ss ^. serverTiming)
+              , button [TimingEv ShowBlockerGraph <$ onClick] [text "Update"]
               , buttonShowBlocker (model ^. modelTiming)
               ]
           ]

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -57,7 +57,7 @@ import GHCSpecter.Data.GHC.Hie (ModuleHieInfo)
 import GHCSpecter.Data.Map (BiKeyMap, KeyMap, emptyBiKeyMap, emptyKeyMap)
 import GHCSpecter.Data.Timing.Types (TimingTable, emptyTimingTable)
 import GHCSpecter.GraphLayout.Types (GraphVisInfo)
-import GHCSpecter.UI.Types.Event (DetailLevel)
+import GHCSpecter.UI.Types.Event (BlockerDetailLevel (..), DetailLevel)
 
 type ChanModule = (Channel, Text)
 
@@ -71,6 +71,7 @@ data TimingState = TimingState
     _tsTimingTable :: TimingTable
   , _tsBlockerGraph :: IntMap [Int]
   , _tsBlockerGraphViz :: Maybe GraphVisInfo
+  , _tsBlockerDetailLevel :: BlockerDetailLevel
   }
   deriving (Show, Generic)
 
@@ -87,6 +88,7 @@ emptyTimingState =
     , _tsTimingTable = emptyTimingTable
     , _tsBlockerGraph = IM.empty
     , _tsBlockerGraphViz = Nothing
+    , _tsBlockerDetailLevel = Blocking5
     }
 
 data ModuleGraphState = ModuleGraphState
@@ -162,7 +164,6 @@ data ServerState = ServerState
   , _serverModuleBreakpoints :: [ModuleName]
   -- TODO: These numbers from configuration should be separated to an env in ReaderT.
   , _serverModuleClusterSize :: Int
-  , _serverModuleBlockerThreshold :: Int
   }
   deriving (Show, Generic)
 
@@ -172,8 +173,8 @@ instance FromJSON ServerState
 
 instance ToJSON ServerState
 
-initServerState :: Int -> Int -> ServerState
-initServerState nodeSizeLimit blockerThreshold =
+initServerState :: Int -> ServerState
+initServerState nodeSizeLimit =
   ServerState
     { _serverMessageSN = 0
     , _serverShouldUpdate = True
@@ -188,7 +189,6 @@ initServerState nodeSizeLimit blockerThreshold =
     , _serverHieState = emptyHieState
     , _serverModuleBreakpoints = []
     , _serverModuleClusterSize = nodeSizeLimit
-    , _serverModuleBlockerThreshold = blockerThreshold
     }
 
 incrementSN :: ServerState -> ServerState

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -162,8 +162,8 @@ data ServerState = ServerState
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   , _serverModuleBreakpoints :: [ModuleName]
-  -- TODO: These numbers from configuration should be separated to an env in ReaderT.
-  , _serverModuleClusterSize :: Int
+  , -- TODO: These numbers from configuration should be separated to an env in ReaderT.
+    _serverModuleClusterSize :: Int
   }
   deriving (Show, Generic)
 

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -160,8 +160,9 @@ data ServerState = ServerState
   , _serverModuleGraphState :: ModuleGraphState
   , _serverHieState :: HieState
   , _serverModuleBreakpoints :: [ModuleName]
-  -- TODO: This configuration should be separated to an env in ReaderT.
+  -- TODO: These numbers from configuration should be separated to an env in ReaderT.
   , _serverModuleClusterSize :: Int
+  , _serverModuleBlockerThreshold :: Int
   }
   deriving (Show, Generic)
 
@@ -171,8 +172,8 @@ instance FromJSON ServerState
 
 instance ToJSON ServerState
 
-initServerState :: Int -> ServerState
-initServerState nodeSizeLimit =
+initServerState :: Int -> Int -> ServerState
+initServerState nodeSizeLimit blockerThreshold =
   ServerState
     { _serverMessageSN = 0
     , _serverShouldUpdate = True
@@ -187,6 +188,7 @@ initServerState nodeSizeLimit =
     , _serverHieState = emptyHieState
     , _serverModuleBreakpoints = []
     , _serverModuleClusterSize = nodeSizeLimit
+    , _serverModuleBlockerThreshold = blockerThreshold
     }
 
 incrementSN :: ServerState -> ServerState

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -24,14 +24,12 @@ module GHCSpecter.UI.Types (
   UIState (..),
   HasUIState (..),
   emptyUIState,
-
 ) where
 
 import Control.Lens (makeClassy)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import GHCSpecter.Channel.Common.Types (DriverId)
-import GHCSpecter.Channel.Outbound.Types (BreakpointLoc (..))
 import GHCSpecter.Data.Assets (Assets)
 import GHCSpecter.Data.Timing.Types (TimingTable)
 import GHCSpecter.UI.Types.Event (DetailLevel (..), Tab (..))

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -2,6 +2,8 @@ module GHCSpecter.UI.Types.Event (
   -- * Enums
   Tab (..),
   DetailLevel (..),
+  BlockerDetailLevel (..),
+  blockerThreshold,
   ComponentTag (..),
 
   -- * Event types
@@ -30,6 +32,19 @@ data DetailLevel = UpTo30 | UpTo100 | UpTo300
 instance FromJSON DetailLevel
 
 instance ToJSON DetailLevel
+
+data BlockerDetailLevel = Blocking2 | Blocking3 | Blocking4 | Blocking5
+  deriving (Show, Eq, Ord, Generic)
+
+instance FromJSON BlockerDetailLevel
+
+instance ToJSON BlockerDetailLevel
+
+blockerThreshold :: BlockerDetailLevel -> Int
+blockerThreshold Blocking2 = 2
+blockerThreshold Blocking3 = 3
+blockerThreshold Blocking4 = 4
+blockerThreshold Blocking5 = 5
 
 data ComponentTag
   = TimingView

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -11,6 +11,7 @@ module GHCSpecter.UI.Types.Event (
   SubModuleEvent (..),
   ModuleGraphEvent (..),
   SessionEvent (..),
+  BlockerModuleGraphEvent (..),
   TimingEvent (..),
   MouseEvent (..),
   ConsoleEvent (..),
@@ -74,6 +75,11 @@ data SessionEvent
   | PauseSessionEv
   deriving (Show, Eq)
 
+data BlockerModuleGraphEvent
+  = BMGGraph ModuleGraphEvent
+  | BMGUpdateLevel BlockerDetailLevel
+  deriving (Show, Eq)
+
 data TimingEvent
   = ToCurrentTime
   | -- | is thawed (i.e. flowing) = True, is frozen = False
@@ -84,7 +90,7 @@ data TimingEvent
   | HoverOffModule ModuleName
   | ShowBlockerGraph
   | CloseBlockerGraph
-  | BlockerModuleGraphEv ModuleGraphEvent
+  | BlockerModuleGraphEv BlockerModuleGraphEvent
   deriving (Show, Eq)
 
 data MouseEvent

--- a/daemon/src/GHCSpecter/Worker/Timing.hs
+++ b/daemon/src/GHCSpecter/Worker/Timing.hs
@@ -26,6 +26,7 @@ import GHCSpecter.Server.Types (
   HasTimingState (..),
   ServerState,
  )
+import GHCSpecter.UI.Types.Event (blockerThreshold)
 
 timingWorker :: TVar ServerState -> IO ()
 timingWorker ssRef = do
@@ -45,10 +46,10 @@ timingBlockerGraphWorker ssRef = do
   ss' <-
     atomically $ do
       ss <- readTVar ssRef
-      let blockerThreshold = ss ^. serverModuleBlockerThreshold
+      let blThre = ss ^. serverTiming . tsBlockerDetailLevel . to blockerThreshold
           mgi = ss ^. serverSessionInfo . to sessionModuleGraph
           ttable = ss ^. serverTiming . tsTimingTable
-          blockerGraph = makeBlockerGraph blockerThreshold mgi ttable
+          blockerGraph = makeBlockerGraph blThre mgi ttable
           ss' = (serverTiming . tsBlockerGraph .~ blockerGraph) ss
       writeTVar ssRef ss'
       pure ss'

--- a/daemon/src/GHCSpecter/Worker/Timing.hs
+++ b/daemon/src/GHCSpecter/Worker/Timing.hs
@@ -45,9 +45,10 @@ timingBlockerGraphWorker ssRef = do
   ss' <-
     atomically $ do
       ss <- readTVar ssRef
-      let mgi = ss ^. serverSessionInfo . to sessionModuleGraph
+      let blockerThreshold = ss ^. serverModuleBlockerThreshold
+          mgi = ss ^. serverSessionInfo . to sessionModuleGraph
           ttable = ss ^. serverTiming . tsTimingTable
-          blockerGraph = makeBlockerGraph mgi ttable
+          blockerGraph = makeBlockerGraph blockerThreshold mgi ttable
           ss' = (serverTiming . tsBlockerGraph .~ blockerGraph) ss
       writeTVar ssRef ss'
       pure ss'

--- a/ghc-specter.yaml.sample
+++ b/ghc-specter.yaml.sample
@@ -3,4 +3,3 @@ session_file: session.json
 web_port: 7070
 start_with_breakpoint: True
 module_cluster_size: 75
-module_blocker_threshold: 5

--- a/ghc-specter.yaml.sample
+++ b/ghc-specter.yaml.sample
@@ -2,4 +2,5 @@ socket: /tmp/socket.ipc
 session_file: session.json
 web_port: 7070
 start_with_breakpoint: True
-module_cluster_size: 10
+module_cluster_size: 75
+module_blocker_threshold: 5

--- a/plugin/src/GHCSpecter/Config.hs
+++ b/plugin/src/GHCSpecter/Config.hs
@@ -25,11 +25,14 @@ data Config = Config
   , configWebPort :: Int
   , configStartWithBreakpoint :: Bool
   , configModuleClusterSize :: Int
+  , configModuleBlockerThreshold :: Int
   }
   deriving (Show, Generic)
 
+-- | default configuration
+-- NOTE: non-trivial default value: cluster size = 5, blocker threshold = 5
 emptyConfig :: Config
-emptyConfig = Config "" "" 0 False 150 -- cluster size = 150 for default value.
+emptyConfig = Config "" "" 0 False 150 5
 
 modifier :: String -> String
 modifier = camelTo2 '_' . drop 6

--- a/plugin/src/GHCSpecter/Config.hs
+++ b/plugin/src/GHCSpecter/Config.hs
@@ -25,14 +25,13 @@ data Config = Config
   , configWebPort :: Int
   , configStartWithBreakpoint :: Bool
   , configModuleClusterSize :: Int
-  , configModuleBlockerThreshold :: Int
   }
   deriving (Show, Generic)
 
 -- | default configuration
--- NOTE: non-trivial default value: cluster size = 5, blocker threshold = 5
+-- NOTE: non-trivial default value: cluster size = 150.
 emptyConfig :: Config
-emptyConfig = Config "" "" 0 False 150 5
+emptyConfig = Config "" "" 0 False 150
 
 modifier :: String -> String
 modifier = camelTo2 '_' . drop 6


### PR DESCRIPTION
Introduced BlockerDetailLevel, which dynamically filters out blocker modules by a given number of blocked modules. 
Four levels (>=2, >=3, >=4, >=5) can be selected via radio buttons.