### PR TITLE
Install CI and clean up dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,4 +53,4 @@ jobs:
       # fourmolu-0.10.1.0
       - uses: fourmolu/fourmolu-action@v6
         with:
-          extra-args: "-o GHC2021"
+          extra-args: "-o -XGHC2021"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,14 @@ on: [pull_request, push]
 jobs:
   Build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - compilerName: ghc942
+            required: required
+          - compilerName: ghc924
+            required: required
+      fail-fast: false
     steps:
     - name: Checkout repository code
       uses: actions/checkout@v3
@@ -10,12 +18,12 @@ jobs:
       run: |
         ls ${{ github.workspace }}
     - name: Install nix
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - name: enter-shell (GHC 9.4.2)
       run: |
-        nix develop .#ghc942
+        nix develop .#${{ matrix.compilerName }}
 #  format:
 #    runs-on: ubuntu-20.04
 #    steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: "Build"
 on: [pull_request, push]
 jobs:
-  Develop:
+  dev-shell:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,7 +24,7 @@ jobs:
     - name: enter-shell
       run: |
         nix develop .#${{ matrix.compilerName }}
-  Build:
+  build-ghc-specter:
     runs-on: ubuntu-latest
     needs: [Develop]
     strategy:
@@ -45,7 +45,7 @@ jobs:
     - name: build ghc-build-analyzer
       run: |
         nix build .#${{ matrix.compilerName }}.ghc-build-analyzer
-  Format:
+  check-format:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: "Build"
+on: [pull_request, push]
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository code
+      uses: actions/checkout@v3
+    - name: List files in the repository
+      run: |
+        ls ${{ github.workspace }}
+    - name: Install nix
+      uses: cachix/install-nix-action@v16
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - name: enter-shell (GHC 9.4.2)
+      run: |
+        nix develop .#ghc942
+#  format:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/checkout@v2
+#      # ormolu 0.3.0.1
+#      - uses: mrkkrp/ormolu-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,4 +53,4 @@ jobs:
       # fourmolu-0.10.1.0
       - uses: fourmolu/fourmolu-action@v6
         with:
-          extra-args: "-o -XGHC2021"
+          extra-args: "--no-cabal -o -XGHC2021"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,11 +46,8 @@ jobs:
       run: |
         nix build .#${{ matrix.compilerName }}.ghc-build-analyzer
   Format:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ "ubuntu-latest" ]
+    runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       # fourmolu-0.10.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,9 @@ jobs:
       matrix:
         include:
           - compilerName: ghc942
-            required: required
+            required: true
           - compilerName: ghc924
-            required: required
+            required: true
       fail-fast: false
     steps:
     - name: Checkout repository code
@@ -47,6 +47,7 @@ jobs:
         nix build .#${{ matrix.compilerName }}.ghc-build-analyzer
   Format:
     runs-on: ubuntu-latest
+    required: false
     steps:
       - uses: actions/checkout@v3
       # fourmolu-0.10.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,11 @@ jobs:
       run: |
         nix build .#${{ matrix.compilerName }}.ghc-build-analyzer
   Format:
-    runs-on: ubuntu-latest
-    required: false
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ "ubuntu-latest" ]
     steps:
       - uses: actions/checkout@v3
       # fourmolu-0.10.1.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         nix develop .#${{ matrix.compilerName }}
   build-ghc-specter:
     runs-on: ubuntu-latest
-    needs: [Develop]
+    needs: [dev-shell]
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,15 @@ jobs:
       uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - name: enter-shell (GHC 9.4.2)
+    - name: enter-shell
       run: |
         nix develop .#${{ matrix.compilerName }}
-#  format:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - uses: actions/checkout@v2
-#      # ormolu 0.3.0.1
-#      - uses: mrkkrp/ormolu-action@v4
+    - name: build ghc-specter-plugin
+      run: |
+        nix build .#${{ matrix.compilerName }}.ghc-specter-plugin
+    - name: build ghc-specter-daemon
+      run: |
+        nix build .#${{ matrix.compilerName }}.ghc-specter-daemon
+    - name: build ghc-build-analyzer
+      run: |
+        nix build .#${{ matrix.compilerName }}.ghc-build-analyzer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,5 @@ jobs:
       - uses: actions/checkout@v3
       # fourmolu-0.10.1.0
       - uses: fourmolu/fourmolu-action@v6
+        with:
+          extra-args: "-o GHC2021"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: "Build"
 on: [pull_request, push]
 jobs:
-  dev-shell:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,18 +24,6 @@ jobs:
     - name: enter-shell
       run: |
         nix develop .#${{ matrix.compilerName }}
-  build-ghc-specter:
-    runs-on: ubuntu-latest
-    needs: [dev-shell]
-    strategy:
-      matrix:
-        include:
-          - compilerName: ghc942
-            required: required
-          - compilerName: ghc924
-            required: required
-      fail-fast: false
-    steps:
     - name: build ghc-specter-plugin
       run: |
         nix build .#${{ matrix.compilerName }}.ghc-specter-plugin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: "Build"
 on: [pull_request, push]
 jobs:
-  Build:
+  Develop:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,6 +24,18 @@ jobs:
     - name: enter-shell
       run: |
         nix develop .#${{ matrix.compilerName }}
+  Build:
+    runs-on: ubuntu-latest
+    needs: [Develop]
+    strategy:
+      matrix:
+        include:
+          - compilerName: ghc942
+            required: required
+          - compilerName: ghc924
+            required: required
+      fail-fast: false
+    steps:
     - name: build ghc-specter-plugin
       run: |
         nix build .#${{ matrix.compilerName }}.ghc-specter-plugin
@@ -33,3 +45,9 @@ jobs:
     - name: build ghc-build-analyzer
       run: |
         nix build .#${{ matrix.compilerName }}.ghc-build-analyzer
+  Format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # fourmolu-0.10.1.0
+      - uses: fourmolu/fourmolu-action@v6

--- a/daemon/src/GHCSpecter/Data/GHC/Core.hs
+++ b/daemon/src/GHCSpecter/Data/GHC/Core.hs
@@ -1,3 +1,4 @@
+{- FOURMOLU_DISABLE -}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MultiWayIf #-}
 

--- a/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
+++ b/daemon/src/GHCSpecter/UI/ConcurReplica/WaiHandler.hs
@@ -56,14 +56,20 @@ instance A.FromJSON Event where
     case (t :: T.Text) of
       "event" ->
         Event
-          <$> o .: "eventType"
-          <*> o .: "event"
-          <*> o .: "path"
-          <*> o .: "clientFrame"
+          <$> o
+          .: "eventType"
+          <*> o
+          .: "event"
+          <*> o
+          .: "path"
+          <*> o
+          .: "clientFrame"
       "call" ->
         CallCallback
-          <$> o .: "arg"
-          <*> o .: "id"
+          <$> o
+          .: "arg"
+          <*> o
+          .: "id"
       _ -> fail "Expected \"type\" == \"event\" | \"call\""
   parseJSON _ = fail "Expected object"
 

--- a/daemon/src/GHCSpecter/Worker/Hie.hs
+++ b/daemon/src/GHCSpecter/Worker/Hie.hs
@@ -115,9 +115,7 @@ hieWorker ssRef workQ hiefile = do
           . (modHieDefs .~ fmap convertDefRow defs)
           . (modHieSource .~ src)
           $ emptyModuleHieInfo
-
-  let callGraphWork = CallGraph.worker ssRef modName modHie
-
+      callGraphWork = CallGraph.worker ssRef modName modHie
   atomically $ do
     modifyTVar' ssRef $
       serverHieState . hieModuleMap

--- a/daemon/src/GHCSpecter/Worker/Hie.hs
+++ b/daemon/src/GHCSpecter/Worker/Hie.hs
@@ -1,3 +1,4 @@
+{- FOURMOLU_DISABLE -}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 

--- a/daemon/test/GHCSpecter/GraphLayout/Algorithm/ClusterSpec.hs
+++ b/daemon/test/GHCSpecter/GraphLayout/Algorithm/ClusterSpec.hs
@@ -54,6 +54,9 @@ testGraphInfo =
     , mginfoModuleTopSorted = []
     }
 
+nodeSizeLimit :: Int
+nodeSizeLimit = 150
+
 spec :: Spec
 spec =
   describe "GHCSpecter.Util.Graph greedy downward clustering" $ do
@@ -61,7 +64,7 @@ spec =
         bgr = makeBiDep modDep
         allNodes = IM.keys $ mginfoModuleNameMap testGraphInfo
         nNodes = length allNodes
-        largeNodes = filterOutSmallNodes modDep
+        largeNodes = filterOutSmallNodes nodeSizeLimit modDep
         smallNodes = allNodes L.\\ largeNodes
         seeds =
           ClusterState

--- a/flake.lock
+++ b/flake.lock
@@ -100,23 +100,6 @@
         "type": "github"
       }
     },
-    "microlens": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1660843290,
-        "narHash": "sha256-3MmkZKNFDRlL63GDE2EObCzzL4UfEn5hx+2aQqiylp8=",
-        "owner": "stevenfontanella",
-        "repo": "microlens",
-        "rev": "e117e429bcfca033527c4393ebb522364a83e3c7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stevenfontanella",
-        "ref": "master",
-        "repo": "microlens",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1672195622,
@@ -157,7 +140,6 @@
         "fficxx": "fficxx",
         "flake-utils": "flake-utils",
         "hs-ogdf": "hs-ogdf",
-        "microlens": "microlens",
         "nixpkgs": "nixpkgs",
         "replica": "replica",
         "vty": "vty"

--- a/flake.lock
+++ b/flake.lock
@@ -140,25 +140,7 @@
         "flake-utils": "flake-utils",
         "hs-ogdf": "hs-ogdf",
         "nixpkgs": "nixpkgs",
-        "replica": "replica",
-        "vty": "vty"
-      }
-    },
-    "vty": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1663380348,
-        "narHash": "sha256-lrqlKS+8EeImX73A9KHzkTph/o9vzQ2yHi5xfbHVZfs=",
-        "owner": "jtdaugherty",
-        "repo": "vty",
-        "rev": "db5f55caf3321d9e015fa99cc41908c12ef172a5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jtdaugherty",
-        "ref": "5.37",
-        "repo": "vty",
-        "type": "github"
+        "replica": "replica"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -58,23 +58,6 @@
         "type": "github"
       }
     },
-    "file-embed": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1630235415,
-        "narHash": "sha256-TKXWIzOPleEWSHzfWWMuF5nBc8nPJIVYZrOc0PE+Sqk=",
-        "owner": "snoyberg",
-        "repo": "file-embed",
-        "rev": "548430d2a79bb6f4cb4256768761071f59909aa5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "snoyberg",
-        "ref": "file-embed-0.0.15.0",
-        "repo": "file-embed",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1656928814,
@@ -87,23 +70,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "fourmolu": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1668486098,
-        "narHash": "sha256-MPFWDMc9nSpTtCjAIHmjLyENkektm72tCWaKnkAQfuk=",
-        "owner": "fourmolu",
-        "repo": "fourmolu",
-        "rev": "47017e0f7c333676f3fd588695c1b3d16f2075cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "fourmolu",
-        "ref": "main",
-        "repo": "fourmolu",
         "type": "github"
       }
     },
@@ -189,9 +155,7 @@
         "concur": "concur",
         "concur-replica": "concur-replica",
         "fficxx": "fficxx",
-        "file-embed": "file-embed",
         "flake-utils": "flake-utils",
-        "fourmolu": "fourmolu",
         "hs-ogdf": "hs-ogdf",
         "microlens": "microlens",
         "nixpkgs": "nixpkgs",

--- a/flake.lock
+++ b/flake.lock
@@ -107,23 +107,6 @@
         "type": "github"
       }
     },
-    "ghc-debug": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1668721384,
-        "narHash": "sha256-lVp2XCjAc9mpOdCOExVGhSOk16XXf6YgdwOCgr4GyWA=",
-        "ref": "wavewave/ghc94",
-        "rev": "8800c82dd6ef60e117751d196b9cc49aa56494db",
-        "revCount": 493,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/wavewave/ghc-debug.git"
-      },
-      "original": {
-        "ref": "wavewave/ghc94",
-        "type": "git",
-        "url": "https://gitlab.haskell.org/wavewave/ghc-debug.git"
-      }
-    },
     "hs-ogdf": {
       "inputs": {
         "fficxx": [
@@ -170,11 +153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666371646,
-        "narHash": "sha256-gLaVWLbbig3MjLbb2NzVzWe4XK8w/Qw7iJdD0u1dzDY=",
+        "lastModified": 1672195622,
+        "narHash": "sha256-Z03+maRn7EC6XzCV1+gf9JuuvSnNduy0v5RJngf+4FA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "71c5816834f93840dd301ec384c9d7947e97c27d",
+        "rev": "9a2e72335c6651d5fb16e6901aa4b5c790c243db",
         "type": "github"
       },
       "original": {
@@ -209,7 +192,6 @@
         "file-embed": "file-embed",
         "flake-utils": "flake-utils",
         "fourmolu": "fourmolu",
-        "ghc-debug": "ghc-debug",
         "hs-ogdf": "hs-ogdf",
         "microlens": "microlens",
         "nixpkgs": "nixpkgs",

--- a/flake.lock
+++ b/flake.lock
@@ -37,18 +37,20 @@
     "fficxx": {
       "inputs": {
         "flake-utils": [
+          "hs-ogdf",
           "flake-utils"
         ],
         "nixpkgs": [
+          "hs-ogdf",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1666386261,
-        "narHash": "sha256-OAbetFHl6z4XKjdLWjSULbGVZsQ8xtKp/2ThVzFwVeE=",
+        "lastModified": 1671238981,
+        "narHash": "sha256-GcXhLFDw+KLMcirtpEyap9BjbXqbl5KgPChglq+zobs=",
         "owner": "wavewave",
         "repo": "fficxx",
-        "rev": "df56f97154703504f9cf6cc97cf633b18d28b189",
+        "rev": "e926340dbffdd2271fecb6003a43c54f34adf8e9",
         "type": "github"
       },
       "original": {
@@ -75,9 +77,7 @@
     },
     "hs-ogdf": {
       "inputs": {
-        "fficxx": [
-          "fficxx"
-        ],
+        "fficxx": "fficxx",
         "flake-utils": [
           "flake-utils"
         ],
@@ -137,7 +137,6 @@
       "inputs": {
         "concur": "concur",
         "concur-replica": "concur-replica",
-        "fficxx": "fficxx",
         "flake-utils": "flake-utils",
         "hs-ogdf": "hs-ogdf",
         "nixpkgs": "nixpkgs",

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,8 @@
           # ghc-debug related deps
           "bitwise" = final.haskell.lib.doJailbreak hsuper.bitwise;
           "brick" = hsuper.brick_1_3;
-          "eventlog2html" = final.haskell.lib.doJailbreak hsuper.eventlog2html;
+          "eventlog2html" =
+            final.haskell.lib.doJailbreak (hself.callHackage "eventlog2html" "0.9.2" { });
           "ghc-events" = final.haskell.lib.doJailbreak hsuper.ghc-events;
           "monoidal-containers" =
             final.haskell.lib.doJailbreak hsuper.monoidal-containers;

--- a/flake.nix
+++ b/flake.nix
@@ -26,14 +26,6 @@
       inputs.flake-utils.follows = "flake-utils";
       inputs.fficxx.follows = "fficxx";
     };
-    file-embed = {
-      url = "github:snoyberg/file-embed/file-embed-0.0.15.0";
-      flake = false;
-    };
-    fourmolu = {
-      url = "github:fourmolu/fourmolu/main";
-      flake = false;
-    };
     microlens = {
       url = "github:stevenfontanella/microlens/master";
       flake = false;
@@ -45,7 +37,7 @@
 
   };
   outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica
-    , fficxx, hs-ogdf, file-embed, fourmolu, microlens, vty }:
+    , fficxx, hs-ogdf, microlens, vty }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -68,11 +60,12 @@
 
           # TODO: check whether this will be fixed in GHC 9.4.3.
           "conduit-extra" = final.haskell.lib.dontCheck hsuper.conduit-extra;
-          "file-embed" = hself.callCabal2nix "file-embed" file-embed { };
+          "file-embed" =
+            hself.callHackage "file-embed" "0.0.15.0" { };
           # fixity-th is disabled to avoid segfault during compilation.
-          "fourmolu_0_9_0_0" = final.haskell.lib.dontCheck
+          "fourmolu" = final.haskell.lib.dontCheck
             (final.haskell.lib.overrideCabal
-              (hself.callCabal2nix "fourmolu" fourmolu { }) (drv: {
+              (hself.callHackage "fourmolu" "0.10.1.0" { }) (drv: {
                 configureFlags = [ "-f-fixity-th" ];
                 libraryHaskellDepends = drv.libraryHaskellDepends
                   ++ [ hself.file-embed ];
@@ -129,10 +122,7 @@
                 p.extra
                 p.ghc-debug-common
                 p.ghc-debug-stub
-                #p.ghc-debug-client
-                # this seems outdated.
-                # p.ghc-debugger
-                #p.dyepack-test
+                p.ghc-debug-client
                 p.ghc-debug-brick
                 p.ghc-debug-convention
                 p.hiedb
@@ -146,10 +136,8 @@
                 p.socket
                 p.text
                 p.time
-              ] ++ (if compiler == "ghc942" then
-                [ p.fourmolu_0_9_0_0 ]
-              else
-                [ p.fourmolu ]));
+                p.fourmolu
+              ]);
           in pkgs.mkShell { packages = [ hsenv pkgs.nixfmt ]; };
 
         supportedCompilers = [ "ghc924" "ghc942" ];

--- a/flake.nix
+++ b/flake.nix
@@ -20,13 +20,8 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };
-    vty = {
-      url = "github:jtdaugherty/vty/5.37";
-      flake = false;
-    };
-
   };
-  outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica, hs-ogdf, vty }:
+  outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica, hs-ogdf }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -85,8 +80,7 @@
           "microlens-platform" =
             hself.callHackage "microlens-platform" "0.4.3.3" { };
           "string-qq" = final.haskell.lib.doJailbreak hsuper.string-qq;
-          "vty" =
-            final.haskell.lib.dontCheck (hself.callCabal2nix "vty" vty { });
+          "vty" = hself.callHackage "vty" "5.37" { };
 
           # ghc-debug-*
           "ghc-debug-common" =

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,14 @@
             hself.callHackage "ghc-debug-brick" "0.4.0.0" { };
           "ghc-debug-convention" =
             hself.callHackage "ghc-debug-convention" "0.4.0.0" { };
+
+          # ghc-specter-*
+          "ghc-specter-plugin" =
+            hself.callCabal2nix "ghc-specter-plugin" ./plugin { };
+          "ghc-specter-daemon" =
+            hself.callCabal2nix "ghc-specter-daemon" ./daemon { };
+          "ghc-build-analyzer" =
+            hself.callCabal2nix "ghc-build-analyzer" ./ghc-build-analyzer { };
         };
 
         hpkgsFor = compiler:
@@ -130,10 +138,13 @@
                 p.fourmolu
               ]);
           in pkgs.mkShell { packages = [ hsenv pkgs.nixfmt ]; };
-
+        mkPackagesFor = compiler: {
+          inherit (hpkgsFor compiler) ghc-specter-plugin ghc-specter-daemon ghc-build-analyzer;
+        };
         supportedCompilers = [ "ghc924" "ghc942" ];
       in {
         inherit haskellOverlay;
         devShells = pkgs.lib.genAttrs supportedCompilers mkShellFor;
+        packages = pkgs.lib.genAttrs supportedCompilers mkPackagesFor;
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,15 @@
                 libraryHaskellDepends = drv.libraryHaskellDepends
                   ++ [ hself.file-embed ];
               }));
+          # fixity-th is disabled to avoid segfault during compilation.
+          "fourmolu_0_9_0_0" = final.haskell.lib.dontCheck
+            (final.haskell.lib.overrideCabal
+              (hself.callHackage "fourmolu" "0.9.0.0" { }) (drv: {
+                configureFlags = [ "-f-fixity-th" ];
+                libraryHaskellDepends = drv.libraryHaskellDepends
+                  ++ [ hself.file-embed ];
+              }));
+
 
           # ghc-debug related deps
           "bitwise" = final.haskell.lib.doJailbreak hsuper.bitwise;
@@ -136,7 +145,10 @@
                 p.text
                 p.time
                 p.fourmolu
-              ]);
+              ] ++ (if compiler == "ghc942" then
+                [ p.fourmolu ]
+              else
+                [ p.fourmolu_0_9_0_0 ]));
           in pkgs.mkShell { packages = [ hsenv pkgs.nixfmt ]; };
         mkPackagesFor = compiler: {
           inherit (hpkgsFor compiler) ghc-specter-plugin ghc-specter-daemon ghc-build-analyzer;

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,6 @@
       inputs.flake-utils.follows = "flake-utils";
       inputs.fficxx.follows = "fficxx";
     };
-    microlens = {
-      url = "github:stevenfontanella/microlens/master";
-      flake = false;
-    };
     vty = {
       url = "github:jtdaugherty/vty/5.37";
       flake = false;
@@ -37,7 +33,7 @@
 
   };
   outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica
-    , fficxx, hs-ogdf, microlens, vty }:
+    , fficxx, hs-ogdf, vty }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -80,12 +76,11 @@
           "monoidal-containers" =
             final.haskell.lib.doJailbreak hsuper.monoidal-containers;
           "microlens" =
-            hself.callCabal2nix "microlens" "${microlens}/microlens" { };
+            hself.callHackage "microlens" "0.4.13.1" { };
           "microlens-ghc" =
-            hself.callCabal2nix "microlens-ghc" "${microlens}/microlens-ghc"
-            { };
-          "microlens-platform" = hself.callCabal2nix "microlens-platform"
-            "${microlens}/microlens-platform" { };
+            hself.callHackage "microlens-ghc" "0.4.14.1" { };
+          "microlens-platform" =
+            hself.callHackage "microlens-platform" "0.4.3.3" { };
           "string-qq" = final.haskell.lib.doJailbreak hsuper.string-qq;
           "vty" =
             final.haskell.lib.dontCheck (hself.callCabal2nix "vty" vty { });

--- a/flake.nix
+++ b/flake.nix
@@ -144,7 +144,6 @@
                 p.socket
                 p.text
                 p.time
-                p.fourmolu
               ] ++ (if compiler == "ghc942" then
                 [ p.fourmolu ]
               else

--- a/flake.nix
+++ b/flake.nix
@@ -34,10 +34,6 @@
       url = "github:fourmolu/fourmolu/main";
       flake = false;
     };
-    ghc-debug = {
-      url = "git+https://gitlab.haskell.org/wavewave/ghc-debug.git?ref=wavewave/ghc94";
-      flake = false;
-    };
     microlens = {
       url = "github:stevenfontanella/microlens/master";
       flake = false;
@@ -49,7 +45,7 @@
 
   };
   outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica
-    , fficxx, hs-ogdf, file-embed, fourmolu, ghc-debug, microlens, vty }:
+    , fficxx, hs-ogdf, file-embed, fourmolu, microlens, vty }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -83,7 +79,6 @@
               }));
 
           # ghc-debug related deps
-          "bimap" = hsuper.bimap_0_5_0;
           "bitwise" = final.haskell.lib.doJailbreak hsuper.bitwise;
           "brick" = hsuper.brick_1_3;
           "eventlog2html" = final.haskell.lib.doJailbreak hsuper.eventlog2html;
@@ -98,32 +93,20 @@
           "microlens-platform" = hself.callCabal2nix "microlens-platform"
             "${microlens}/microlens-platform" { };
           "string-qq" = final.haskell.lib.doJailbreak hsuper.string-qq;
-          "text-zipper" = hsuper.text-zipper_0_12;
           "vty" =
             final.haskell.lib.dontCheck (hself.callCabal2nix "vty" vty { });
 
           # ghc-debug-*
           "ghc-debug-common" =
-            hself.callCabal2nix "ghc-debug-common" "${ghc-debug}/common" { };
+            hself.callHackage "ghc-debug-common" "0.4.0.0" { };
           "ghc-debug-stub" =
-            final.haskell.lib.overrideCabal
-              (hself.callCabal2nix "ghc-debug-stub" "${ghc-debug}/stub" { }) (drv: {
-                jailbreak = true;
-                librarySystemDepends = [ ];
-              });
-          "ghc-debug-client" = final.haskell.lib.doJailbreak
-            (hself.callCabal2nix "ghc-debug-client" "${ghc-debug}/client" { });
-          # ghc-debugger seems outdated.
-          #"ghc-debugger" =
-          #  hself.callCabal2nix "ghc-debugger" "${ghc-debug}/test" { };
-          "dyepack-test" =
-            hself.callCabal2nix "dyepack-test" "${ghc-debug}/dyepack-test" { };
+            final.haskell.lib.doJailbreak (hself.callHackage "ghc-debug-stub" "0.4.0.0" { });
+          "ghc-debug-client" =
+            final.haskell.lib.doJailbreak (hself.callHackage "ghc-debug-client" "0.4.0.0" { });
           "ghc-debug-brick" =
-            hself.callCabal2nix "ghc-debug-brick" "${ghc-debug}/ghc-debug-brick"
-            { };
+            hself.callHackage "ghc-debug-brick" "0.4.0.0" { };
           "ghc-debug-convention" =
-            hself.callCabal2nix "ghc-debug-convention" "${ghc-debug}/convention"
-            { };
+            hself.callHackage "ghc-debug-convention" "0.4.0.0" { };
         };
 
         hpkgsFor = compiler:
@@ -145,10 +128,10 @@
                 p.extra
                 p.ghc-debug-common
                 p.ghc-debug-stub
-                p.ghc-debug-client
+                #p.ghc-debug-client
                 # this seems outdated.
                 # p.ghc-debugger
-                p.dyepack-test
+                #p.dyepack-test
                 p.ghc-debug-brick
                 p.ghc-debug-convention
                 p.hiedb

--- a/flake.nix
+++ b/flake.nix
@@ -15,16 +15,10 @@
       url = "github:wavewave/replica/ghc-9.2";
       flake = false;
     };
-    fficxx = {
-      url = "github:wavewave/fficxx/master";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
     hs-ogdf = {
       url = "github:wavewave/hs-ogdf/master";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
-      inputs.fficxx.follows = "fficxx";
     };
     vty = {
       url = "github:jtdaugherty/vty/5.37";
@@ -32,8 +26,7 @@
     };
 
   };
-  outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica
-    , fficxx, hs-ogdf, vty }:
+  outputs = { self, nixpkgs, flake-utils, concur, concur-replica, replica, hs-ogdf, vty }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
@@ -53,6 +46,16 @@
             final.haskell.lib.doJailbreak hsuper.newtype-generics;
           "replica" = hself.callCabal2nix "replica" replica { };
           "retry" = final.haskell.lib.dontCheck hsuper.retry;
+
+          # fficxx-related
+          "fficxx" =
+            hself.callHackage "fficxx" "0.7.0.0" { };
+          "fficxx-runtime" =
+            hself.callHackage "fficxx-runtime" "0.7.0.0" { };
+          "stdcxx" =
+            hself.callHackage "stdcxx" "0.7.0.0" { };
+          "template" =
+            final.haskell.lib.doJailbreak hsuper.template;
 
           # TODO: check whether this will be fixed in GHC 9.4.3.
           "conduit-extra" = final.haskell.lib.dontCheck hsuper.conduit-extra;
@@ -100,8 +103,7 @@
 
         hpkgsFor = compiler:
           pkgs.haskell.packages.${compiler}.extend (hself: hsuper:
-            (fficxx.haskellOverlay.${system} pkgs hself hsuper)
-            // (hs-ogdf.haskellOverlay.${system} pkgs hself hsuper)
+            (hs-ogdf.haskellOverlay.${system} pkgs hself hsuper)
             // (haskellOverlay pkgs hself hsuper));
 
         mkShellFor = compiler:

--- a/plugin/src/Plugin/GHCSpecter.hs
+++ b/plugin/src/Plugin/GHCSpecter.hs
@@ -1,3 +1,4 @@
+{- FOURMOLU_DISABLE -}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
 


### PR DESCRIPTION
This PR introduces Github action CI for ghc-specter project with nix-based build targets.
I also cleaned up dependencies, using hackage versions for them as far as we can.
