### PR TITLE
Install read-the-docs style documentation page

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,9 @@
 name: docs_pages_workflow
 
-on: [push]
-#  push:
-#    branches:
-#      - master
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build_docs_job:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,44 @@
+name: docs_pages_workflow
+
+on: [push]
+#  push:
+#    branches:
+#      - master
+
+jobs:
+  build_docs_job:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4.4.0
+        with:
+          python-version: 3.11.0
+      - name: Install dependencies
+        run: |
+          python -m pip install -U sphinx
+          python -m pip install sphinx-rtd-theme
+          python -m pip install myst-parser
+      - name: make the sphinx docs
+        run: |
+          make -C docs clean
+          make -C docs html
+      - name: Init new repo in dist folder and commit
+        run: |
+          cd docs/_build/html/
+          git init
+          touch .nojekyll
+          git add -A
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git commit -m 'deploy'
+      - name: Force push to destination branch
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages
+          force: true
+          directory: ./docs/_build/html

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,33 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import sphinx_rtd_theme
+
+project = 'ghc-specter'
+copyright = '2022, Mercury Technologies, Inc'
+author = 'Mercury Technologies, Inc'
+release = '1.0.0.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'myst_parser',
+    'sphinx_rtd_theme'
+]
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,0 +1,24 @@
+# Getting Started
+
+## Configuration
+One can configure ghc-specter by the file `ghc-specter.yaml`.
+The file should be present in the directory where ghc-specter-daemon
+runs and where a target `ghc` runs (usually the root directory of a
+cabal project).
+A sample config YAML file can be found in `ghc-specter.yaml.sample`.
+
+## Run daemon
+```
+$ nix develop
+$ cabal run ghc-specter-daemon:ghc-specter-daemon -- online
+```
+
+## Run GHC in a project
+Run GHC with `-fplugin Plugin.GHCSpecter` and `-plugin-package ghc-specter-plugin`.
+If `ghc-specter-plugin` is already specified as the dependency of the project,
+the latter is not necessary.
+
+Example:
+```
+$ cabal build --ghc-options "-fplugin Plugin.GHCSpecter -plugin-package ghc-specter-plugin"
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,19 @@
+
+Welcome to ghc-specter's documentation
+======================================
+
+Inspecting tool for the GHC pipeline through GHC plugin
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   getting_started
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,9 @@
                 [ p.fourmolu ]
               else
                 [ p.fourmolu_0_9_0_0 ]));
-          in pkgs.mkShell { packages = [ hsenv pkgs.nixfmt ]; };
+              pyenv = pkgs.python3.withPackages
+                (p: [ p.sphinx p.sphinx_rtd_theme p.myst-parser ]);
+          in pkgs.mkShell { packages = [ hsenv pyenv pkgs.nixfmt ]; };
         mkPackagesFor = compiler: {
           inherit (hpkgsFor compiler) ghc-specter-plugin ghc-specter-daemon ghc-build-analyzer;
         };


### PR DESCRIPTION
Through CI, the generated documentation will be shown on https://https://mercurytechnologies.github.io/ghc-specter
The document generation is only on push master.

