### PR TITLE
ghcHEAD shell

### DIFF
--- a/daemon/package.yaml
+++ b/daemon/package.yaml
@@ -95,7 +95,6 @@ library:
     - free
     - ghc
     - ghc-specter-plugin
-    - hiedb
     - http-types
     - lens
     - optparse-applicative
@@ -112,6 +111,10 @@ library:
     - wai-websockets
     - warp
     - websockets
+  when:
+    - condition: impl (ghc < 9.5)
+      dependencies:
+        - hiedb
 
 executables:
   ghc-specter-daemon:

--- a/flake.lock
+++ b/flake.lock
@@ -46,6 +46,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1656928814,
@@ -59,6 +75,46 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "type": "github"
+      }
+    },
+    "ghc_nix": {
+      "inputs": {
+        "all-cabal-hashes": [
+          "hackage-index"
+        ],
+        "flake-compat": "flake-compat",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-unstable": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677005603,
+        "narHash": "sha256-0E6Cn7WZP7sCbcI6nsoEVLlWGfmLhuypHAfxioepy6Q=",
+        "owner": "wavewave",
+        "repo": "ghc.nix",
+        "rev": "9e2907537899555d6da52d6369d89f1f9fc37bd4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "wavewave",
+        "ref": "fix-hash-again",
+        "repo": "ghc.nix",
+        "type": "github"
+      }
+    },
+    "hackage-index": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-q/xdYkEwjNKOP189sETVAnnCwA7mhXUM8kXCq29eiRE=",
+        "type": "file",
+        "url": "https://api.github.com/repos/commercialhaskell/all-cabal-hashes/tarball/13a91ab76cfac2098eff2780f3d3b6224352a7a2"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://api.github.com/repos/commercialhaskell/all-cabal-hashes/tarball/13a91ab76cfac2098eff2780f3d3b6224352a7a2"
       }
     },
     "nixpkgs": {
@@ -116,6 +172,8 @@
         "concur": "concur",
         "concur-replica": "concur-replica",
         "flake-utils": "flake-utils",
+        "ghc_nix": "ghc_nix",
+        "hackage-index": "hackage-index",
         "nixpkgs": "nixpkgs",
         "nixpkgs-ogdf": "nixpkgs-ogdf",
         "replica": "replica"

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,18 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/master";
     flake-utils.url = "github:numtide/flake-utils";
+    hackage-index = {
+      type = "file";
+      flake = false;
+      url =
+        "https://api.github.com/repos/commercialhaskell/all-cabal-hashes/tarball/13a91ab76cfac2098eff2780f3d3b6224352a7a2";
+    };
+    ghc_nix = {
+      url = "github:wavewave/ghc.nix/fix-hash-again";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.nixpkgs-unstable.follows = "nixpkgs";
+      inputs.all-cabal-hashes.follows = "hackage-index";
+    };
     concur = {
       url = "github:wavewave/concur/ghc-9.2";
       flake = false;
@@ -21,7 +33,8 @@
     nixpkgs-ogdf.url = "github:wavewave/nixpkgs/wavewave/ogdf";
     # Hackage version of OGDF
     OGDF = {
-      url = "https://hackage.haskell.org/package/OGDF-1.0.0.0/OGDF-1.0.0.0.tar.gz";
+      url =
+        "https://hackage.haskell.org/package/OGDF-1.0.0.0/OGDF-1.0.0.0.tar.gz";
       flake = false;
     };
   };
@@ -37,7 +50,8 @@
         haskellOverlay = final: hself: hsuper: {
           "criterion" = final.haskell.lib.dontCheck hsuper.criterion;
           "concur-core" =
-            hself.callCabal2nix "concur-core" "${inputs.concur}/concur-core" { };
+            hself.callCabal2nix "concur-core" "${inputs.concur}/concur-core"
+            { };
           "concur-replica" =
             hself.callCabal2nix "concur-replica" inputs.concur-replica { };
           "discrimination" = hself.callHackage "discrimination" "0.5" { };
@@ -48,21 +62,19 @@
           "retry" = final.haskell.lib.dontCheck hsuper.retry;
 
           # fficxx-related
-          "fficxx" =
-            hself.callHackage "fficxx" "0.7.0.0" { };
-          "fficxx-runtime" =
-            hself.callHackage "fficxx-runtime" "0.7.0.0" { };
-          "stdcxx" =
-            hself.callHackage "stdcxx" "0.7.0.0" { };
+          "fficxx" = hself.callHackage "fficxx" "0.7.0.0" { };
+          "fficxx-runtime" = hself.callHackage "fficxx-runtime" "0.7.0.0" { };
+          "stdcxx" = hself.callHackage "stdcxx" "0.7.0.0" { };
           # libOGDF is bundled with libCOIN, so remove COIN dependency.
-          "OGDF" = hself.callCabal2nix "OGDF" inputs.OGDF { COIN = null; OGDF = ogdfLib; };
-          "template" =
-            final.haskell.lib.doJailbreak hsuper.template;
+          "OGDF" = hself.callCabal2nix "OGDF" inputs.OGDF {
+            COIN = null;
+            OGDF = ogdfLib;
+          };
+          "template" = final.haskell.lib.doJailbreak hsuper.template;
 
           # TODO: check whether this will be fixed in GHC 9.4.3.
           "conduit-extra" = final.haskell.lib.dontCheck hsuper.conduit-extra;
-          "file-embed" =
-            hself.callHackage "file-embed" "0.0.15.0" { };
+          "file-embed" = hself.callHackage "file-embed" "0.0.15.0" { };
           # fixity-th is disabled to avoid segfault during compilation.
           "fourmolu" = final.haskell.lib.dontCheck
             (final.haskell.lib.overrideCabal
@@ -83,15 +95,13 @@
           # ghc-debug related deps
           "bitwise" = final.haskell.lib.doJailbreak hsuper.bitwise;
           "brick" = hsuper.brick_1_3;
-          "eventlog2html" =
-            final.haskell.lib.doJailbreak (hself.callHackage "eventlog2html" "0.9.2" { });
+          "eventlog2html" = final.haskell.lib.doJailbreak
+            (hself.callHackage "eventlog2html" "0.9.2" { });
           "ghc-events" = final.haskell.lib.doJailbreak hsuper.ghc-events;
           "monoidal-containers" =
             final.haskell.lib.doJailbreak hsuper.monoidal-containers;
-          "microlens" =
-            hself.callHackage "microlens" "0.4.13.1" { };
-          "microlens-ghc" =
-            hself.callHackage "microlens-ghc" "0.4.14.1" { };
+          "microlens" = hself.callHackage "microlens" "0.4.13.1" { };
+          "microlens-ghc" = hself.callHackage "microlens-ghc" "0.4.14.1" { };
           "microlens-platform" =
             hself.callHackage "microlens-platform" "0.4.3.3" { };
           "string-qq" = final.haskell.lib.doJailbreak hsuper.string-qq;
@@ -100,12 +110,11 @@
           # ghc-debug-*
           "ghc-debug-common" =
             hself.callHackage "ghc-debug-common" "0.4.0.0" { };
-          "ghc-debug-stub" =
-            final.haskell.lib.doJailbreak (hself.callHackage "ghc-debug-stub" "0.4.0.0" { });
-          "ghc-debug-client" =
-            final.haskell.lib.doJailbreak (hself.callHackage "ghc-debug-client" "0.4.0.0" { });
-          "ghc-debug-brick" =
-            hself.callHackage "ghc-debug-brick" "0.4.0.0" { };
+          "ghc-debug-stub" = final.haskell.lib.doJailbreak
+            (hself.callHackage "ghc-debug-stub" "0.4.0.0" { });
+          "ghc-debug-client" = final.haskell.lib.doJailbreak
+            (hself.callHackage "ghc-debug-client" "0.4.0.0" { });
+          "ghc-debug-brick" = hself.callHackage "ghc-debug-brick" "0.4.0.0" { };
           "ghc-debug-convention" =
             hself.callHackage "ghc-debug-convention" "0.4.0.0" { };
 
@@ -119,7 +128,8 @@
         };
 
         hpkgsFor = compiler:
-          pkgs.haskell.packages.${compiler}.extend (hself: hsuper: haskellOverlay pkgs hself hsuper);
+          pkgs.haskell.packages.${compiler}.extend
+          (hself: hsuper: haskellOverlay pkgs hself hsuper);
 
         mkShellFor = compiler:
           let
@@ -152,17 +162,26 @@
                 [ p.fourmolu ]
               else
                 [ p.fourmolu_0_9_0_0 ]));
-              pyenv = pkgs.python3.withPackages
-                (p: [ p.sphinx p.sphinx_rtd_theme p.myst-parser ]);
+            pyenv = pkgs.python3.withPackages
+              (p: [ p.sphinx p.sphinx_rtd_theme p.myst-parser ]);
           in pkgs.mkShell { packages = [ hsenv pyenv pkgs.nixfmt ]; };
         mkPackagesFor = compiler: {
-          inherit (hpkgsFor compiler) ghc-specter-plugin ghc-specter-daemon ghc-build-analyzer;
+          inherit (hpkgsFor compiler)
+            ghc-specter-plugin ghc-specter-daemon ghc-build-analyzer;
         };
         supportedCompilers = [ "ghc924" "ghc942" ];
 
+        shellGHCHEAD = {
+          "ghcHEAD" = (import ./nix/ghcHEAD/shell.nix {
+            inherit (inputs) ghc_nix;
+            inherit system pkgs;
+          }).ghcNixShell;
+        };
+
       in {
         inherit haskellOverlay;
-        devShells = pkgs.lib.genAttrs supportedCompilers mkShellFor;
+        devShells = (pkgs.lib.genAttrs supportedCompilers mkShellFor)
+          // shellGHCHEAD;
         packages = pkgs.lib.genAttrs supportedCompilers mkPackagesFor;
       });
 

--- a/flake.nix
+++ b/flake.nix
@@ -174,7 +174,7 @@
         shellGHCHEAD = {
           "ghcHEAD" = (import ./nix/ghcHEAD/shell.nix {
             inherit (inputs) ghc_nix;
-            inherit system pkgs;
+            inherit system pkgs ogdfLib;
           }).ghcNixShell;
         };
 

--- a/nix/ghcHEAD/ghcHEAD-cabal.project
+++ b/nix/ghcHEAD/ghcHEAD-cabal.project
@@ -35,6 +35,10 @@ package OGDF
   -- by default, ghc finds g++ and that is linked to /usr/bin/g++ on macos.
   ghc-options: -pgmcxx c++
 
+package ghc-specter-daemon
+  -- by default, ghc finds g++ and that is linked to /usr/bin/g++ on macos.
+  ghc-options: -pgmcxx c++
+
 allow-newer:
   Cabal,
   base,

--- a/nix/ghcHEAD/ghcHEAD-cabal.project
+++ b/nix/ghcHEAD/ghcHEAD-cabal.project
@@ -1,5 +1,5 @@
 packages:
-  -- ./daemon
+  ./daemon
   ./plugin
   ./ghc-build-analyzer
 
@@ -12,6 +12,29 @@ repository head.hackage.ghc.haskell.org
        7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
 
+-- concur-core branch:ghc-9.2
+source-repository-package
+        type: git
+        location: https://github.com/wavewave/concur.git
+        tag: 7718678e6e4907fb53bfd9248eda8fc175626f05
+        subdir: concur-core
+
+-- concur-replica branch:ghc-9.2
+source-repository-package
+        type: git
+        location: https://github.com/wavewave/concur-replica.git
+        tag: e15785b3b09e97790ae23c8ae8671c191d039a2c
+
+-- replica branch:ghc-9.2
+source-repository-package
+        type: git
+        location: https://github.com/wavewave/replica.git
+        tag: 30e41c7982047d782db5080c17b76d4756291e0c
+
+package OGDF
+  -- by default, ghc finds g++ and that is linked to /usr/bin/g++ on macos.
+  ghc-options: -pgmcxx c++
+
 allow-newer:
   Cabal,
   base,
@@ -21,6 +44,7 @@ allow-newer:
   ghc-bignum,
   ghc-prim,
   integer-gmp,
+  mtl,
   primitive,
   template-haskell,
   text,
@@ -94,6 +118,7 @@ constraints:
   singletons-th ==3.1,
   siphash ==1.0.3,
   streaming ==0.2.3.1,
+  template ==0.2.0.10,
   true-name ==0.1.0.3,
   typelits-printf ==0.2.0.0,
   unix-compat ==0.6,

--- a/nix/ghcHEAD/ghcHEAD-cabal.project
+++ b/nix/ghcHEAD/ghcHEAD-cabal.project
@@ -1,0 +1,107 @@
+packages:
+  -- ./daemon
+  ./plugin
+  ./ghc-build-analyzer
+
+repository head.hackage.ghc.haskell.org
+   url: https://ghc.gitlab.haskell.org/head.hackage/
+   secure: True
+   key-threshold: 3
+   root-keys:
+       26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+       7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+       f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+
+allow-newer:
+  Cabal,
+  base,
+  binary,
+  bytestring,
+  ghc,
+  ghc-bignum,
+  ghc-prim,
+  integer-gmp,
+  primitive,
+  template-haskell,
+  text,
+  time,
+  transformers
+
+constraints:
+  base installed,
+  ghc installed,
+  ghc-bignum installed,
+  ghc-prim installed,
+  integer-gmp installed,
+  template-haskell installed
+
+constraints:
+  -- Cabal ==2.4.1.0 || ==3.0.2.0 || ==3.2.1.0,
+  FPretty ==1.1,
+  ForestStructures ==0.0.1.0,
+  acid-state ==0.16.1.1,
+  ansi-pretty ==0.1.2.2,
+  arith-encode ==1.0.2,
+  async-pool ==0.9.1,
+  aura ==3.2.9,
+  box-tuples ==0.2.0.4,
+  cabal-doctest ==1.0.9,
+  charsetdetect ==1.1.0.2,
+  charsetdetect-ae ==1.1.0.4,
+  chaselev-deque ==0.5.0.5,
+  critbit ==0.2.0.0,
+  crypto-random ==0.0.9,
+  cryptol ==2.13.0,
+  data-default-instances-new-base ==0.0.2,
+  data-r-tree ==0.6.0,
+  datetime ==0.3.1,
+  doctest ==0.21.0,
+  drinkery ==0.4,
+  endo ==0.3.0.1,
+  enumeration ==0.2.0,
+  exception-mtl ==0.4.0.1,
+  extra ==1.7.12,
+  foundation ==0.0.29,
+  free-functors ==1.2.1,
+  freer-simple ==1.2.1.2,
+  futhark ==0.22.7,
+  futhark-data ==1.1.0.0,
+  futhark-server ==1.2.1.0,
+  haskeline ==0.7.5.0,
+  haxl ==2.4.0.0,
+  hgeometry ==0.14,
+  hgeometry-combinatorial ==0.14,
+  hgeometry-ipe ==0.13,
+  hiedb >=0.4.1.0,
+  inj-base ==0.2.0.0,
+  inline-c-cpp ==0.5.0.0,
+  io-choice ==0.0.7,
+  language-c-quote ==0.13,
+  language-haskell-extract ==0.2.4,
+  mainland-pretty ==0.7.1,
+  packman ==0.5.0,
+  parameterized-utils ==2.1.6.0,
+  partial-isomorphisms ==0.2.3.0,
+  pgp-wordlist ==0.1.0.3,
+  posix-api ==0.4.0.0,
+  row-types ==1.0.1.2,
+  salak ==0.3.6,
+  sbv ==9.0,
+  servant ==0.19.1,
+  servant-conduit ==0.15.1,
+  servant-machines ==0.15.1,
+  singletons-base ==3.1,
+  singletons-th ==3.1,
+  siphash ==1.0.3,
+  streaming ==0.2.3.1,
+  true-name ==0.1.0.3,
+  typelits-printf ==0.2.0.0,
+  unix-compat ==0.6,
+  vector-th-unbox ==0.2.2,
+  warp ==3.3.24,
+  what4 ==1.3,
+  winery ==1.4
+
+constraints:
+  optparse-applicative -process,
+  tasty -unix

--- a/nix/ghcHEAD/shell.nix
+++ b/nix/ghcHEAD/shell.nix
@@ -1,24 +1,17 @@
-{ ghc_nix, system, pkgs, }: {
+{ ghc_nix, system, pkgs, ogdfLib }: {
   # ghc.nix shell
   ghcNixShell = ghc_nix.outputs.devShells.${system}.default.overrideAttrs
     (attrs: {
       buildInputs = attrs.buildInputs ++ [
-        #pkgs.bzip2
-        #pkgs.expat
-        #pkgs.geos
-        #pkgs.gpgme
-        #pkgs.icu
-        #pkgs.libical
-        #pkgs.libmcrypt
-        #pkgs.libssh2
-        #pkgs.openssl
-        #pkgs.pcre
+        ogdfLib
         pkgs.pkgconfig
       ];
+      OGDF=ogdfLib;
       shellHook = ''
         echo "ghc.nix shell hook"
         ${attrs.shellHook}
         echo "now entering into ghcHEAD shell. Please set PATH to have your target GHC bin directory."
+        echo ${ogdfLib}
       '';
     });
 }

--- a/nix/ghcHEAD/shell.nix
+++ b/nix/ghcHEAD/shell.nix
@@ -1,0 +1,24 @@
+{ ghc_nix, system, pkgs, }: {
+  # ghc.nix shell
+  ghcNixShell = ghc_nix.outputs.devShells.${system}.default.overrideAttrs
+    (attrs: {
+      buildInputs = attrs.buildInputs ++ [
+        #pkgs.bzip2
+        #pkgs.expat
+        #pkgs.geos
+        #pkgs.gpgme
+        #pkgs.icu
+        #pkgs.libical
+        #pkgs.libmcrypt
+        #pkgs.libssh2
+        #pkgs.openssl
+        #pkgs.pcre
+        pkgs.pkgconfig
+      ];
+      shellHook = ''
+        echo "ghc.nix shell hook"
+        ${attrs.shellHook}
+        echo "now entering into ghcHEAD shell. Please set PATH to have your target GHC bin directory."
+      '';
+    });
+}

--- a/plugin/package.yaml
+++ b/plugin/package.yaml
@@ -87,7 +87,6 @@ library:
     - errors
     - extra
     - ghc-debug-stub
-    - hiedb
     - network
     - process
     - safe
@@ -96,6 +95,9 @@ library:
     - transformers
     - yaml
   when:
+    - condition: impl (ghc >= 9.5)
+      dependencies:
+        - ghc
     - condition: impl (ghc >= 9.4) && impl (ghc < 9.5)
       dependencies:
         - ghc == 9.4.*

--- a/plugin/src/GHCSpecter/Util/GHC.hs
+++ b/plugin/src/GHCSpecter/Util/GHC.hs
@@ -53,7 +53,11 @@ import GHC.Unit.Module.Graph (
  )
 import GHC.Unit.Module.Location (ModLocation (..))
 import GHC.Unit.Module.ModSummary (ModSummary (..))
+#if MIN_VERSION_ghc(9, 6, 0)
+import Language.Haskell.Syntax.Module.Name (moduleNameString)
+#else
 import GHC.Unit.Module.Name (moduleNameString)
+#endif
 import GHC.Unit.Types (GenModule (moduleName))
 import GHC.Utils.Outputable (Outputable (ppr))
 import GHCSpecter.Channel.Common.Types (type ModuleName)

--- a/plugin/src/Plugin/GHCSpecter/Tasks.hs
+++ b/plugin/src/Plugin/GHCSpecter/Tasks.hs
@@ -34,7 +34,11 @@ import GHC.Unit.Module.ModGuts (ModGuts (..))
 import GHC.Utils.Outputable (Outputable (..))
 import GHCSpecter.Channel.Outbound.Types (ConsoleReply (..))
 import Language.Haskell.Syntax.Decls (HsGroup)
+#if MIN_VERSION_ghc(9, 6, 0)
+import Language.Haskell.Syntax.Expr (HsUntypedSplice, LHsExpr)
+#else
 import Language.Haskell.Syntax.Expr (HsSplice, LHsExpr)
+#endif
 import Plugin.GHCSpecter.Tasks.Core2Core (listCore, printCore)
 import Plugin.GHCSpecter.Tasks.Typecheck (
   fetchUnqualifiedImports,
@@ -66,7 +70,11 @@ renamedResultActionCommands :: HsGroup GhcRn -> CommandSet TcM
 renamedResultActionCommands grp =
   CommandSet [(":show-renamed", \_ -> showRenamed grp)]
 
+#if MIN_VERSION_ghc(9, 6, 0)
+rnSpliceCommands :: HsUntypedSplice GhcRn -> CommandSet RnM
+#else
 rnSpliceCommands :: HsSplice GhcRn -> CommandSet RnM
+#endif
 rnSpliceCommands splice =
   CommandSet [(":show-splice", \_ -> showRnSplice splice)]
 

--- a/plugin/src/Plugin/GHCSpecter/Tasks/Core2Core.hs
+++ b/plugin/src/Plugin/GHCSpecter/Tasks/Core2Core.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Plugin.GHCSpecter.Tasks.Core2Core (
   listCore,
   printCore,
@@ -30,7 +32,11 @@ import GHC.Types.Name.Occurrence (occNameString)
 import GHC.Types.SrcLoc (RealSrcSpan, SrcSpan)
 import GHC.Types.Var (Var)
 import GHC.Unit.Module.ModGuts (ModGuts (..))
+#if MIN_VERSION_ghc(9, 6, 0)
+import Language.Haskell.Syntax.Module.Name (ModuleName, moduleNameString)
+#else
 import GHC.Unit.Module.Name (ModuleName, moduleNameString)
+#endif
 import GHC.Unit.Types (Unit, toUnitId, unitString)
 import GHCSpecter.Channel.Outbound.Types (ConsoleReply (..))
 import GHCSpecter.Util.GHC (printPpr, showPpr)

--- a/plugin/src/Plugin/GHCSpecter/Tasks/Typecheck.hs
+++ b/plugin/src/Plugin/GHCSpecter/Tasks/Typecheck.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Plugin.GHCSpecter.Tasks.Typecheck (
   fetchUnqualifiedImports,
   showRenamed,
@@ -15,6 +17,10 @@ import Data.Set (Set)
 import Data.Set qualified as S
 import Data.Text qualified as T
 import GHC.Driver.Session (DynFlags, getDynFlags)
+#if MIN_VERSION_ghc(9, 6, 0)
+import GHC.Driver.Ppr (showSDoc)
+import GHC.Hs.Expr (pprUntypedSplice)
+#endif
 import GHC.Hs.Extension (GhcRn, GhcTc)
 import GHC.Plugins (Name)
 import GHC.Tc.Types (RnM, TcGblEnv (..), TcM)
@@ -31,7 +37,11 @@ import GHCSpecter.Util.GHC (
   showPpr,
  )
 import Language.Haskell.Syntax.Decls (HsGroup)
+#if MIN_VERSION_ghc(9, 6, 0)
+import Language.Haskell.Syntax.Expr (HsUntypedSplice, LHsExpr)
+#else
 import Language.Haskell.Syntax.Expr (HsSplice, LHsExpr)
+#endif
 
 fetchUnqualifiedImports :: TcGblEnv -> TcM ConsoleReply
 fetchUnqualifiedImports tc = do
@@ -54,10 +64,18 @@ showRenamed grp = do
   let txt = T.pack (showPpr dflags grp)
   pure (ConsoleReplyText (Just "renamed") txt)
 
+#if MIN_VERSION_ghc(9, 6, 0)
+showRnSplice :: HsUntypedSplice GhcRn -> RnM ConsoleReply
+#else
 showRnSplice :: HsSplice GhcRn -> RnM ConsoleReply
+#endif
 showRnSplice splice = do
   dflags <- getDynFlags
+#if MIN_VERSION_ghc(9, 6, 0)
+  let txt = T.pack (showSDoc dflags (pprUntypedSplice True Nothing splice))
+#else
   let txt = T.pack (showPpr dflags splice)
+#endif
   pure (ConsoleReplyText (Just "splice") txt)
 
 showSpliceExpr :: LHsExpr GhcTc -> TcM ConsoleReply

--- a/plugin/src/Plugin/GHCSpecter/Tasks/Typecheck.hs
+++ b/plugin/src/Plugin/GHCSpecter/Tasks/Typecheck.hs
@@ -1,3 +1,4 @@
+{- FOURMOLU_DISABLE -}
 {-# LANGUAGE CPP #-}
 
 module Plugin.GHCSpecter.Tasks.Typecheck (


### PR DESCRIPTION
based on the ghc.nix shell and head.hackage, locally built GHC can be used for building ghc-specter packages.
Nix provides haskell env only for building GHC (based on ghc 9.2.4) and C++ deps for ghc-specter, but the Haskell deps for ghc-specter are compiled via cabal.project specification.
Note that this shell is for testing this project with up-to-date GHC, and not intended for reproducible packaging.