### PR TITLE
[WIP] Eventlog logcat utility

### DIFF
--- a/logcat/app/logcat/Main.hs
+++ b/logcat/app/logcat/Main.hs
@@ -1,0 +1,186 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Control.Concurrent (forkIO, threadDelay)
+import Control.Concurrent.STM (TVar, atomically, modifyTVar', newTVarIO, readTVar)
+import qualified Control.Exception as E
+import Control.Lens ((%~), (.~), (^.))
+import Control.Monad (forever)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BL
+import Data.Fixed (Fixed (MkFixed))
+import Data.Foldable (toList)
+import Data.GI.Base (AttrOp ((:=)), new, on)
+import Data.GI.Gtk.Threading (postGUIASync)
+import qualified Data.List as L (foldl')
+import Data.Maybe (fromMaybe)
+import Data.Sequence ((|>))
+import qualified Data.Sequence as Seq (empty)
+import GHC.RTS.Events (Event (..))
+import GHC.RTS.Events.Incremental
+  ( Decoder (..),
+    decodeEvents,
+    readHeader,
+  )
+import qualified GI.Cairo.Render as R
+import GI.Cairo.Render.Connector (renderWithContext)
+import qualified GI.Gtk as Gtk
+import Network.Socket
+  ( Family (AF_UNIX),
+    SockAddr (SockAddrUnix),
+    Socket,
+    SocketType (Stream),
+    close,
+    connect,
+    socket,
+    withSocketsDo,
+  )
+import Network.Socket.ByteString (recv)
+import Render
+  ( canvasHeight,
+    canvasWidth,
+    drawLogcatState,
+    flushDoubleBuffer,
+    pixelToSec,
+    secToPixel,
+    timelineMargin,
+  )
+import System.IO (hFlush, stdout)
+import Text.Pretty.Simple (pPrint)
+import Types
+  ( HasLogcatState (..),
+    HasViewState (..),
+    LogcatState,
+    emptyLogcatState,
+  )
+import Util.Event (eventInfoToString)
+import Util.Histo (aggregateCount, histoAdd)
+
+recordEvent :: TVar LogcatState -> Event -> IO ()
+recordEvent sref ev =
+  atomically $ do
+    ltime <- (^. logcatLastEventTime) <$> readTVar sref
+    let sec = MkFixed (fromIntegral (evTime ev))
+        updateLastEventTime =
+          if sec > ltime
+            then logcatLastEventTime .~ sec
+            else id
+    modifyTVar' sref ((logcatEventQueue %~ (|> ev)) . updateLastEventTime)
+
+-- | Adjust timeline viewport to ensure the last event is out of the right margin
+-- of the timeline. This checks if the last event falls under the margin, and if so,
+-- move the plot origin to make the last event at the center of the timeline.
+adjustTimelineOrigin :: LogcatState -> LogcatState
+adjustTimelineOrigin s
+  | ltimePos > canvasWidth - timelineMargin =
+    let currCenterTime = pixelToSec origin (canvasWidth * 0.5)
+        deltaTime = ltime - currCenterTime
+     in (logcatViewState . viewTimeOrigin %~ (\x -> x + deltaTime)) s
+  | otherwise = s
+  where
+    origin = s ^. logcatViewState . viewTimeOrigin
+    ltime = s ^. logcatLastEventTime
+    ltimePos = secToPixel origin ltime
+
+flushEventQueue :: R.Surface -> TVar LogcatState -> IO ()
+flushEventQueue sfc sref = do
+  atomically $ do
+    s <- readTVar sref
+    let queue = s ^. logcatEventQueue
+        hist = s ^. logcatEventHisto
+        diff = aggregateCount $ fmap (eventInfoToString . evSpec) $ toList queue
+        hist' = L.foldl' histoAdd hist diff
+    modifyTVar' sref $
+      (logcatEventStore %~ (<> queue))
+        . (logcatEventQueue .~ Seq.empty)
+        . (logcatEventHisto .~ hist')
+        . adjustTimelineOrigin
+  R.renderWith sfc $ do
+    drawLogcatState sref
+
+dump :: TVar LogcatState -> Socket -> IO ()
+dump sref sock = goHeader ""
+  where
+    goHeader bs0 = do
+      bs1 <- recv sock 1024
+      let bs = bs0 <> bs1
+      let lbs = BL.fromStrict bs
+      let e = readHeader lbs
+      case e of
+        Left err -> print err >> goHeader bs
+        Right (hdr, lbs') -> do
+          pPrint hdr
+          let dec0 = decodeEvents hdr
+          goEvents hdr dec0 (BL.toStrict lbs')
+
+    go :: Decoder Event -> BS.ByteString -> IO (Maybe (Decoder Event), BS.ByteString)
+    go dec !bytes = do
+      case dec of
+        Produce ev dec' -> do
+          recordEvent sref ev
+          hFlush stdout
+          go dec' bytes
+        Consume k ->
+          if BS.null bytes
+            then pure (Just dec, "")
+            else go (k bytes) ""
+        Done bytes' ->
+          pure (Nothing, bytes')
+        Error _bytes' e -> do
+          pPrint e
+          hFlush stdout
+          -- reset if error happens.
+          pure (Nothing, "")
+
+    goEvents hdr dec !bytes = do
+      (mdec', bytes') <- go dec bytes
+      let dec' = fromMaybe (decodeEvents hdr) mdec'
+      bytes'' <- recv sock 1024
+      goEvents hdr dec' (bytes' <> bytes'')
+
+tickTock :: Gtk.DrawingArea -> R.Surface -> TVar LogcatState -> IO ()
+tickTock drawingArea sfc sref = forever $ do
+  threadDelay 1_000_000
+  flushEventQueue sfc sref
+  postGUIASync $
+    #queueDraw drawingArea
+
+main :: IO ()
+main = do
+  sref <- newTVarIO emptyLogcatState
+  _ <- Gtk.init Nothing
+  -- NOTE: this should be closed with surfaceDestroy
+  sfc <- R.createImageSurface R.FormatARGB32 (floor canvasWidth) (floor canvasHeight)
+  mainWindow <- new Gtk.Window [#type := Gtk.WindowTypeToplevel]
+  drawingArea <- new Gtk.DrawingArea []
+  _ <- drawingArea `on` #draw $
+    renderWithContext $ do
+      flushDoubleBuffer sfc
+      pure True
+  layout <- do
+    vbox <- new Gtk.Box [#orientation := Gtk.OrientationVertical, #spacing := 0]
+    #packStart vbox drawingArea True True 0
+    pure vbox
+  #add mainWindow layout
+  #setDefaultSize mainWindow (floor canvasWidth) (floor canvasHeight)
+  #showAll mainWindow
+
+  _ <- forkIO $ tickTock drawingArea sfc sref
+  _ <- forkIO $ receiver sref
+  Gtk.main
+  R.surfaceFinish sfc
+
+receiver :: TVar LogcatState -> IO ()
+receiver sref =
+  withSocketsDo $ do
+    let file = "/tmp/eventlog.sock"
+        open = do
+          sock <- socket AF_UNIX Stream 0
+          connect sock (SockAddrUnix file)
+          pure sock
+    E.bracket open close (dump sref)
+    pure ()

--- a/logcat/app/logcat/Render.hs
+++ b/logcat/app/logcat/Render.hs
@@ -1,0 +1,147 @@
+module Render
+  ( -- * GUI parameters
+    canvasWidth,
+    canvasHeight,
+    timelineMargin,
+
+    -- * conversion function
+    secToPixel,
+    pixelToSec,
+
+    -- * draw functions
+    drawEventMark,
+    drawTimeGrid,
+    drawTimeline,
+    drawHistBar,
+    drawLogcatState,
+
+    -- * flush double buffer
+    flushDoubleBuffer,
+  )
+where
+
+import Control.Concurrent.STM (TVar, atomically, readTVar)
+import Control.Lens ((^.))
+import Control.Monad.IO.Class (liftIO)
+import Data.Fixed (Fixed (MkFixed), Nano)
+import Data.Foldable (for_)
+import qualified Data.List as L
+import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Data.Sequence (Seq)
+import GHC.RTS.Events (Event (..))
+import qualified GI.Cairo.Render as R
+import Types
+  ( HasLogcatState (..),
+    HasViewState (..),
+    LogcatState,
+    ViewState,
+  )
+import Util.Event (eventInfoEnumMap, eventInfoToString)
+
+canvasWidth :: Double
+canvasWidth = 1440
+
+canvasHeight :: Double
+canvasHeight = 768
+
+timelineMargin :: Double
+timelineMargin = 300
+
+timelineScale :: Double
+timelineScale = 50
+
+secToPixel :: Nano -> Nano -> Double
+secToPixel origin sec =
+  realToFrac (sec - origin) * timelineScale + 10.0
+
+pixelToSec :: Nano -> Double -> Nano
+pixelToSec origin px =
+  realToFrac ((px - 10.0) / timelineScale) + origin
+
+drawEventMark :: ViewState -> Event -> R.Render ()
+drawEventMark vs ev = do
+  let origin = vs ^. viewTimeOrigin
+      sec = MkFixed (fromIntegral (evTime ev)) :: Nano
+      x = secToPixel origin sec
+      evname = eventInfoToString (evSpec ev)
+      tag = fromMaybe 0 (L.lookup evname eventInfoEnumMap)
+      y = fromIntegral tag * 3.0
+  R.moveTo x y
+  R.lineTo x (y + 2)
+  R.stroke
+
+drawTimeGrid :: ViewState -> R.Render ()
+drawTimeGrid vs = do
+  let origin = vs ^. viewTimeOrigin
+      tmax = pixelToSec origin canvasWidth
+      ts = [0, 1 .. tmax]
+      lblTs = [0, 10 .. tmax]
+  R.setSourceRGBA 0 0 1 0.5
+  R.setLineWidth 0.1
+  R.setLineCap R.LineCapRound
+  R.setLineJoin R.LineJoinRound
+  for_ ts $ \t -> do
+    let x = secToPixel origin t
+    R.moveTo x 0
+    R.lineTo x 150
+    R.stroke
+  R.setSourceRGBA 0 0 1 0.8
+  R.setFontSize 8
+  for_ lblTs $ \t -> do
+    R.moveTo (secToPixel origin t) 10
+    R.textPath (show (floor t :: Int) <> " s")
+    R.stroke
+
+drawTimeline :: ViewState -> Seq Event -> R.Render ()
+drawTimeline vs evs = do
+  drawTimeGrid vs
+  R.setSourceRGBA 0.16 0.18 0.19 1.0
+  R.setLineWidth 0.3
+  R.setLineCap R.LineCapRound
+  R.setLineJoin R.LineJoinRound
+  for_ evs $ \ev ->
+    drawEventMark vs ev
+
+drawHistBar :: (Double, Double) -> (String, Int) -> R.Render ()
+drawHistBar (xoffset, yoffset) (ev, value) = do
+  let tag = fromMaybe 0 (L.lookup ev eventInfoEnumMap)
+  R.setSourceRGBA 0.16 0.18 0.19 1.0
+  R.setLineWidth 1.0
+  let y = yoffset + 10.0 * fromIntegral tag
+      w = fromIntegral value / 100.0
+  R.moveTo xoffset (y + 10.0)
+  R.setFontSize 8.0
+  R.textPath ev
+  R.fill
+  R.rectangle (xoffset + 100) (y + 2) w 8
+  R.fill
+  R.moveTo (xoffset + 104 + w) (y + 10.0)
+  R.textPath (show value)
+  R.fill
+
+drawLogcatState :: TVar LogcatState -> R.Render ()
+drawLogcatState sref = do
+  R.setSourceRGB 1 1 1
+  R.rectangle 0 0 canvasWidth canvasHeight
+  R.fill
+  s <- liftIO $ atomically $ readTVar sref
+  let evs = s ^. logcatEventStore
+      hist = s ^. logcatEventHisto
+      vs = s ^. logcatViewState
+  let xoffset = 10
+      yoffset = 100
+  drawTimeline vs evs
+  R.setSourceRGBA 0 0 1 0.8
+  R.setLineWidth 1
+  R.moveTo 0 150
+  R.lineTo canvasWidth 150
+  R.stroke
+  for_ (Map.toAscList hist) $ \(ev, value) ->
+    drawHistBar (xoffset, yoffset) (ev, value)
+
+flushDoubleBuffer :: R.Surface -> R.Render ()
+flushDoubleBuffer sfc = do
+  R.setSourceSurface sfc 0 0
+  R.setOperator R.OperatorSource
+  R.paint

--- a/logcat/app/logcat/Types.hs
+++ b/logcat/app/logcat/Types.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module Types
+  ( -- * view state
+    ViewState (..),
+    HasViewState (..),
+    emptyViewState,
+
+    -- * top-level logcat state
+    LogcatState (..),
+    HasLogcatState (..),
+    emptyLogcatState,
+  )
+where
+
+import Control.Lens (makeClassy)
+import Data.Fixed (Nano)
+import Data.Map (Map)
+import qualified Data.Map as Map (empty)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq (empty)
+import GHC.RTS.Events (Event (..))
+
+data ViewState = ViewState
+  { -- | start point of the timeline view
+    _viewTimeOrigin :: Nano
+  }
+
+makeClassy ''ViewState
+
+emptyViewState :: ViewState
+emptyViewState = ViewState 0
+
+data LogcatState = LogcatState
+  { _logcatEventStore :: Seq Event,
+    -- TODO: Queue should be a local state, not a global state, considering STM overhead.
+    _logcatEventQueue :: Seq Event,
+    _logcatEventHisto :: Map String Int,
+    _logcatLastEventTime :: Nano,
+    _logcatViewState :: ViewState
+  }
+
+makeClassy ''LogcatState
+
+emptyLogcatState :: LogcatState
+emptyLogcatState =
+  LogcatState
+    { _logcatEventStore = Seq.empty,
+      _logcatEventQueue = Seq.empty,
+      _logcatEventHisto = Map.empty,
+      _logcatLastEventTime = 0,
+      _logcatViewState = emptyViewState
+    }

--- a/logcat/app/logcat/Util/Event.hs
+++ b/logcat/app/logcat/Util/Event.hs
@@ -1,0 +1,230 @@
+module Util.Event
+  ( eventInfoToString,
+    eventInfoEnumMap,
+  )
+where
+
+import GHC.RTS.Events (EventInfo (..))
+
+eventInfoToString :: EventInfo -> String
+eventInfoToString info =
+  case info of
+    EventBlock {} -> "EventBlock"
+    UnknownEvent {} -> "UnknownEvent"
+    Startup {} -> "Startup"
+    Shutdown {} -> "Shutdown"
+    CreateThread {} -> "CreateThread"
+    RunThread {} -> "RunThread"
+    StopThread {} -> "StopThread"
+    ThreadRunnable {} -> "ThreadRunnable"
+    MigrateThread {} -> "MigrateThread"
+    WakeupThread {} -> "WakeupThread"
+    ThreadLabel {} -> "ThreadLabel"
+    CreateSparkThread {} -> "CreateSparkThread"
+    SparkCounters {} -> "SparkCounters"
+    SparkCreate {} -> "SparkCreate"
+    SparkDud {} -> "SparkDud"
+    SparkOverflow {} -> "SparkOverflow"
+    SparkRun {} -> "SparkRun"
+    SparkSteal {} -> "SparkSteal"
+    SparkFizzle {} -> "SparkFizzle"
+    SparkGC {} -> "SparkGC"
+    TaskCreate {} -> "TaskCreate"
+    TaskMigrate {} -> "TaskMigrate"
+    TaskDelete {} -> "TaskDelete"
+    RequestSeqGC {} -> "RequestSeqGC"
+    RequestParGC {} -> "RequestParGC"
+    StartGC {} -> "StartGC"
+    GCWork {} -> "GCWork"
+    GCIdle {} -> "GCIdle"
+    GCDone {} -> "GCDone"
+    EndGC {} -> "EndGC"
+    GlobalSyncGC {} -> "GlobalSyncGC"
+    GCStatsGHC {} -> "GCStatsGHC"
+    MemReturn {} -> "MemReturn"
+    HeapAllocated {} -> "HeapAllocated"
+    HeapSize {} -> "HeapSize"
+    BlocksSize {} -> "BlocksSize"
+    HeapLive {} -> "HeapLive"
+    HeapInfoGHC {} -> "HeapInfoGHC"
+    CapCreate {} -> "CapCreate"
+    CapDelete {} -> "CapDelete"
+    CapDisable {} -> "CapDisable"
+    CapEnable {} -> "CapEnable"
+    CapsetCreate {} -> "CapsetCreate"
+    CapsetDelete {} -> "CapsetDelete"
+    CapsetAssignCap {} -> "CapsetAssignCap"
+    CapsetRemoveCap {} -> "CapsetRemoveCap"
+    RtsIdentifier {} -> "RtsIdentifier"
+    ProgramArgs {} -> "ProgramArgs"
+    ProgramEnv {} -> "ProgramEnv"
+    OsProcessPid {} -> "OsProcessPid"
+    OsProcessParentPid {} -> "OsProcessParentPid"
+    WallClockTime {} -> "WallClockTime"
+    Message {} -> "Message"
+    UserMessage {} -> "UserMessage"
+    UserMarker {} -> "UserMarker"
+    Version {} -> "Version"
+    ProgramInvocation {} -> "ProgramInvocation"
+    CreateMachine {} -> "CreateMachine"
+    KillMachine {} -> "KillMachine"
+    CreateProcess {} -> "CreateProcess"
+    KillProcess {} -> "KillProcess"
+    AssignThreadToProcess {} -> "AssignThreadToProcess"
+    EdenStartReceive {} -> "EdenStartReceive"
+    EdenEndReceive {} -> "EdenEndReceive"
+    SendMessage {} -> "SendMessage"
+    ReceiveMessage {} -> "ReceiveMessage"
+    SendReceiveLocalMessage {} -> "SendReceiveLocalMessage"
+    InternString {} -> "InternString"
+    MerStartParConjunction {} -> "MerStartParConjunction"
+    MerEndParConjunction {} -> "MerEndParConjunction"
+    MerEndParConjunct {} -> "MerEndParConjunct"
+    MerCreateSpark {} -> "MerCreateSpark"
+    MerFutureCreate {} -> "MerFutureCreate"
+    MerFutureWaitNosuspend {} -> "MerFutureWaitNosuspend"
+    MerFutureWaitSuspended {} -> "MerFutureWaitSuspended"
+    MerFutureSignal {} -> "MerFutureSignal"
+    MerLookingForGlobalThread {} -> "MerLookingForGlobalThread"
+    MerWorkStealing {} -> "MerWorkStealing"
+    MerLookingForLocalSpark {} -> "MerLookingForLocalSpark"
+    MerReleaseThread {} -> "MerReleaseThread"
+    MerCapSleeping {} -> "MerCapSleeping"
+    MerCallingMain {} -> "MerCallingMain"
+    PerfName {} -> "PerfName"
+    PerfCounter {} -> "PerfCounter"
+    PerfTracepoint {} -> "PerfTracepoint"
+    HeapProfBegin {} -> "HeapProfBegin"
+    HeapProfCostCentre {} -> "HeapProfCostCentre"
+    InfoTableProv {} -> "InfoTableProv"
+    HeapProfSampleBegin {} -> "HeapProfSampleBegin"
+    HeapProfSampleEnd {} -> "HeapProfSampleEnd"
+    HeapBioProfSampleBegin {} -> "HeapBioProfSampleBegin"
+    HeapProfSampleCostCentre {} -> "HeapBioProfSampleCostCentre"
+    HeapProfSampleString {} -> "HeapProfSampleString"
+    ProfSampleCostCentre {} -> "ProfSampleCostCentre"
+    ProfBegin {} -> "ProfBegin"
+    UserBinaryMessage {} -> "UserBinaryMessage"
+    ConcMarkBegin {} -> "ConcMarkBegin"
+    ConcMarkEnd {} -> "ConcMarkEnd"
+    ConcSyncBegin {} -> "ConcSyncBegin"
+    ConcSyncEnd {} -> "ConcSyncEnd"
+    ConcSweepBegin {} -> "ConcSweepBegin"
+    ConcSweepEnd {} -> "ConcSweepEnd"
+    ConcUpdRemSetFlush {} -> "ConcUpdRemSetFlush"
+    NonmovingHeapCensus {} -> "NonmovingHeapCensus"
+    TickyCounterDef {} -> "TickyCounterDef"
+    TickyCounterSample {} -> "TickyCounterSample"
+    TickyBeginSample {} -> "TickyBeginSample"
+
+-- TODO: this should be read off right from RTS def.
+eventInfoEnumMap :: [(String, Int)]
+eventInfoEnumMap =
+  [ ("EventBlock", 1),
+    ("UnknownEvent", 2),
+    ("Startup", 3),
+    ("Shutdown", 4),
+    ("CreateThread", 5),
+    ("RunThread", 6),
+    ("StopThread", 7),
+    ("ThreadRunnable", 8),
+    ("MigrateThread", 9),
+    ("WakeupThread", 10),
+    ("ThreadLabel", 11),
+    ("CreateSparkThread", 12),
+    ("SparkCounters", 13),
+    ("SparkCreate", 14),
+    ("SparkDud", 15),
+    ("SparkOverflow", 16),
+    ("SparkRun", 17),
+    ("SparkSteal", 18),
+    ("SparkFizzle", 19),
+    ("SparkGC", 20),
+    ("TaskCreate", 21),
+    ("TaskMigrate", 22),
+    ("TaskDelete", 23),
+    ("RequestSeqGC", 24),
+    ("RequestParGC", 25),
+    ("StartGC", 26),
+    ("GCWork", 27),
+    ("GCIdle", 28),
+    ("GCDone", 29),
+    ("EndGC", 30),
+    ("GlobalSyncGC", 31),
+    ("GCStatsGHC", 32),
+    ("MemReturn", 33),
+    ("HeapAllocated", 34),
+    ("HeapSize", 35),
+    ("BlocksSize", 36),
+    ("HeapLive", 37),
+    ("HeapInfoGHC", 38),
+    ("CapCreate", 39),
+    ("CapDelete", 40),
+    ("CapDisable", 41),
+    ("CapEnable", 42),
+    ("CapsetCreate", 43),
+    ("CapsetDelete", 44),
+    ("CapsetAssignCap", 45),
+    ("CapsetRemoveCap", 46),
+    ("RtsIdentifier", 47),
+    ("ProgramArgs", 48),
+    ("ProgramEnv", 49),
+    ("OsProcessPid", 50),
+    ("OsProcessParentPid", 51),
+    ("WallClockTime", 52),
+    ("Message", 53),
+    ("UserMessage", 54),
+    ("UserMarker", 55),
+    ("Version", 56),
+    ("ProgramInvocation", 57),
+    ("CreateMachine", 58),
+    ("KillMachine", 59),
+    ("CreateProcess", 60),
+    ("KillProcess", 61),
+    ("AssignThreadToProcess", 62),
+    ("EdenStartReceive", 63),
+    ("EdenEndReceive", 64),
+    ("SendMessage", 65),
+    ("ReceiveMessage", 66),
+    ("SendReceiveLocalMessage", 67),
+    ("InternString", 68),
+    ("MerStartParConjunction", 69),
+    ("MerEndParConjunction", 70),
+    ("MerEndParConjunct", 71),
+    ("MerCreateSpark", 72),
+    ("MerFutureCreate", 73),
+    ("MerFutureWaitNosuspend", 74),
+    ("MerFutureWaitSuspended", 75),
+    ("MerFutureSignal", 76),
+    ("MerLookingForGlobalThread", 77),
+    ("MerWorkStealing", 78),
+    ("MerLookingForLocalSpark", 79),
+    ("MerReleaseThread", 80),
+    ("MerCapSleeping", 81),
+    ("MerCallingMain", 82),
+    ("PerfName", 83),
+    ("PerfCounter", 84),
+    ("PerfTracepoint", 85),
+    ("HeapProfBegin", 86),
+    ("HeapProfCostCentre", 87),
+    ("InfoTableProv", 88),
+    ("HeapProfSampleBegin", 89),
+    ("HeapProfSampleEnd", 90),
+    ("HeapBioProfSampleBegin", 91),
+    ("HeapProfSampleCostCentre", 92),
+    ("HeapProfSampleString", 93),
+    ("ProfSampleCostCentre", 94),
+    ("ProfBegin", 95),
+    ("UserBinaryMessage", 96),
+    ("ConcMarkBegin", 97),
+    ("ConcMarkEnd", 98),
+    ("ConcSyncBegin", 99),
+    ("ConcSyncEnd", 100),
+    ("ConcSweepBegin", 101),
+    ("ConcSweepEnd", 102),
+    ("ConcUpdRemSetFlush", 103),
+    ("NonmovingHeapCensus", 104),
+    ("TickyCounterDef", 105),
+    ("TickyCounterSample", 106),
+    ("TickyBeginSample", 107)
+  ]

--- a/logcat/app/logcat/Util/Histo.hs
+++ b/logcat/app/logcat/Util/Histo.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE BangPatterns #-}
+
+module Util.Histo
+  ( aggregateCount,
+    histoAdd,
+  )
+where
+
+import Data.List (group, sort)
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Maybe (mapMaybe)
+
+aggregateCount :: [String] -> [(String, Int)]
+aggregateCount = mapMaybe count . group . sort
+  where
+    count ys@(x : _) = Just (x, length ys)
+    count [] = Nothing
+
+histoAdd :: Map String Int -> (String, Int) -> Map String Int
+histoAdd !hist (key, value) = Map.alter upd key hist
+  where
+    upd Nothing = Just value
+    upd (Just value0) = Just (value0 + value)

--- a/logcat/ghc-specter-logcat.cabal
+++ b/logcat/ghc-specter-logcat.cabal
@@ -1,0 +1,42 @@
+Name:		ghc-specter-logcat
+Version:	1.0
+Synopsis:	logging
+Description: 	logging
+Homepage:       http://MercuryTechnologies.github.io/ghc-specter
+License: 	MIT
+License-file:	LICENSE
+Author:		Ian-Woo Kim
+Maintainer: 	Ian-Woo Kim <ianwookim@gmail.com>
+Category:       Application
+Tested-with:    GHC == 9.6
+Build-Type: 	Simple
+Cabal-Version:  2.0
+data-files:     CHANGES
+Source-repository head
+  type: git
+  location: git://github.com/MercuryTechnologies/ghc-specter.git
+
+Executable logcat
+  Main-is:        Main.hs
+  other-modules:  Render
+                  Types
+                  Util.Event
+                  Util.Histo
+  hs-source-dirs: app/logcat
+  ghc-options: -j -Wall -Werror -threaded -rtsopts
+  Build-Depends:
+                  base == 4.*,
+                  bytestring,
+                  containers,
+                  gi-cairo,
+                  gi-cairo-connector >= 0.1.1,
+                  gi-cairo-render >= 0.1.2,
+                  gi-gdk,
+                  gi-gtk,
+                  gi-gtk-hs,
+                  ghc-events,
+                  haskell-gi-base,
+                  lens > 5,
+                  network,
+                  pretty-simple,
+                  stm

--- a/nix/ghcHEAD/ghcHEAD-cabal.project
+++ b/nix/ghcHEAD/ghcHEAD-cabal.project
@@ -1,5 +1,6 @@
 packages:
   ./daemon
+  ./logcat
   ./plugin
   ./ghc-build-analyzer
 
@@ -11,6 +12,62 @@ repository head.hackage.ghc.haskell.org
        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
        7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+
+-- gtk2hs
+
+source-repository-package
+        type: git
+        location: https://github.com/gtk2hs/gtk2hs.git
+        tag: 587e7f165657e066c55a84771af32a9ef2e5428d
+        subdir: tools
+
+source-repository-package
+        type: git
+        location: https://github.com/gtk2hs/gtk2hs.git
+        tag: 587e7f165657e066c55a84771af32a9ef2e5428d
+        subdir: cairo
+
+source-repository-package
+        type: git
+        location: https://github.com/gtk2hs/gtk2hs.git
+        tag: 587e7f165657e066c55a84771af32a9ef2e5428d
+        subdir: gio
+
+source-repository-package
+        type: git
+        location: https://github.com/gtk2hs/gtk2hs.git
+        tag: 587e7f165657e066c55a84771af32a9ef2e5428d
+        subdir: glib
+
+source-repository-package
+        type: git
+        location: https://github.com/gtk2hs/gtk2hs.git
+        tag: 587e7f165657e066c55a84771af32a9ef2e5428d
+        subdir: gtk
+
+source-repository-package
+        type: git
+        location: https://github.com/gtk2hs/gtk2hs.git
+        tag: 587e7f165657e066c55a84771af32a9ef2e5428d
+        subdir: pango
+
+source-repository-package
+        type: git
+        location: https://github.com/dalpd/svgcairo.git
+        tag: d1e0d7ae04c1edca83d5b782e464524cdda6ae85
+
+-- gi-gtk
+
+source-repository-package
+        type: git
+        location: https://github.com/wavewave/haskell-gi.git
+        tag: 63e1aa2694213f77c7d1ca50af899497205905ef
+        subdir: base
+
+source-repository-package
+        type: git
+        location: https://github.com/wavewave/haskell-gi.git
+        tag: 63e1aa2694213f77c7d1ca50af899497205905ef
 
 -- concur-core branch:ghc-9.2
 source-repository-package

--- a/nix/ghcHEAD/shell.nix
+++ b/nix/ghcHEAD/shell.nix
@@ -2,16 +2,29 @@
   # ghc.nix shell
   ghcNixShell = ghc_nix.outputs.devShells.${system}.default.overrideAttrs
     (attrs: {
-      buildInputs = attrs.buildInputs ++ [
-        ogdfLib
+      buildInputs = attrs.buildInputs
+      ++ [
+        pkgs.epoxy.dev
+        pkgs.gd
+        pkgs.gobject-introspection
+        pkgs.gtk3
+        pkgs.libdatrie
+        pkgs.libdeflate
+        pkgs.librsvg.dev
+        pkgs.libthai
+        pkgs.pcre
+        pkgs.pcre2
+        pkgs.xorg.libXdmcp.dev
+        pkgs.libxkbcommon.dev
+        pkgs.xorg.libXtst
         pkgs.pkgconfig
-      ];
-      OGDF=ogdfLib;
+        ogdfLib
+      ]
+      ++ pkgs.lib.optional pkgs.stdenv.isLinux [pkgs.libselinux.dev pkgs.libsepol.dev pkgs.util-linux.dev];
       shellHook = ''
         echo "ghc.nix shell hook"
         ${attrs.shellHook}
         echo "now entering into ghcHEAD shell. Please set PATH to have your target GHC bin directory."
-        echo ${ogdfLib}
       '';
     });
 }


### PR DESCRIPTION
Being connected with target haskell binary via a socket file, eventlog can be dumped into this utility ghc-specter-logcat:logcat and shown graphically.