### PR TITLE
Fix module graph on ghc 9.6

### DIFF
--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -80,7 +80,7 @@ updateInbox chanMsg = incrementSN . updater
          in (serverTiming . tsTimingMap %~ alterToKeyMap f drvId)
       CMBox (CMSession s') ->
         (serverSessionInfo .~ s')
-      CMBox (CMModuleGraph mgi) ->
+      CMBox (CMModuleGraph mgi _msrcs) ->
         (serverModuleGraphState . mgsModuleGraphInfo .~ mgi)
       CMBox (CMHsHie _ _) ->
         id
@@ -122,10 +122,9 @@ invokeWorker ssRef workQ (CMBox o) =
     CMCheckImports {} -> pure ()
     CMModuleInfo {} -> pure ()
     CMTiming {} -> pure ()
-    CMSession s' -> do
-      let modSrcs = sessionModuleSources s'
+    CMSession {} -> pure ()
+    CMModuleGraph mgi modSrcs -> do
       void $ forkIO (moduleSourceWorker ssRef modSrcs)
-    CMModuleGraph mgi ->
       void $ forkIO (moduleGraphWorker ssRef mgi)
     CMHsHie _drvId hiefile ->
       void $ forkIO (hieWorker ssRef workQ hiefile)

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -46,6 +46,7 @@ import GHCSpecter.Driver.Session.Types (
  )
 import GHCSpecter.Server.Types (
   ConsoleItem (..),
+  HasModuleGraphState (..),
   HasServerState (..),
   HasTimingState (..),
   ServerState (..),
@@ -79,6 +80,8 @@ updateInbox chanMsg = incrementSN . updater
          in (serverTiming . tsTimingMap %~ alterToKeyMap f drvId)
       CMBox (CMSession s') ->
         (serverSessionInfo .~ s')
+      CMBox (CMModuleGraph mgi) ->
+        (serverModuleGraphState . mgsModuleGraphInfo .~ mgi)
       CMBox (CMHsHie _ _) ->
         id
       CMBox (CMPaused drvId loc) ->
@@ -121,8 +124,8 @@ invokeWorker ssRef workQ (CMBox o) =
     CMTiming {} -> pure ()
     CMSession s' -> do
       let modSrcs = sessionModuleSources s'
-          mgi = sessionModuleGraph s'
       void $ forkIO (moduleSourceWorker ssRef modSrcs)
+    CMModuleGraph mgi ->
       void $ forkIO (moduleGraphWorker ssRef mgi)
     CMHsHie _drvId hiefile ->
       void $ forkIO (hieWorker ssRef workQ hiefile)

--- a/daemon/src/GHCSpecter/Render/ModuleGraph.hs
+++ b/daemon/src/GHCSpecter/Render/ModuleGraph.hs
@@ -209,7 +209,7 @@ render model ss =
         )
   where
     sessionInfo = ss ^. serverSessionInfo
-    nameMap = mginfoModuleNameMap $ sessionModuleGraph sessionInfo
+    nameMap = ss ^. serverModuleGraphState . mgsModuleGraphInfo . to mginfoModuleNameMap
     drvModMap = ss ^. serverDriverModuleMap
     timing = ss ^. serverTiming . tsTimingMap
     mgs = ss ^. serverModuleGraphState

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -39,6 +39,7 @@ import GHCSpecter.Data.Map (
  )
 import GHCSpecter.Render.Util (divClass, spanClass)
 import GHCSpecter.Server.Types (
+  HasModuleGraphState (..),
   HasServerState (..),
   HasTimingState (..),
   ServerState (..),
@@ -217,7 +218,7 @@ render ss =
             (topPart ++ statusPart ++ infoPart)
   where
     sessionInfo = ss ^. serverSessionInfo
-    mgi = sessionModuleGraph sessionInfo
+    mgi = ss ^. serverModuleGraphState . mgsModuleGraphInfo
     timing = ss ^. serverTiming . tsTimingMap
     drvModMap = ss ^. serverDriverModuleMap
     pausedMap = ss ^. serverPaused

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -169,7 +169,6 @@ renderBlockerGraph ss =
     ]
     contents
   where
-    sessionInfo = ss ^. serverSessionInfo
     drvModMap = ss ^. serverDriverModuleMap
     nameMap = ss ^. serverModuleGraphState . mgsModuleGraphInfo . to mginfoModuleNameMap
     ttable = ss ^. serverTiming . tsTimingTable

--- a/daemon/src/GHCSpecter/Render/Timing.hs
+++ b/daemon/src/GHCSpecter/Render/Timing.hs
@@ -35,6 +35,7 @@ import GHCSpecter.Render.Components.GraphView qualified as GraphView
 import GHCSpecter.Render.Components.TimingView qualified as TimingView
 import GHCSpecter.Render.Util (divClass)
 import GHCSpecter.Server.Types (
+  HasModuleGraphState (..),
   HasServerState (..),
   HasTimingState (..),
   ServerState (..),
@@ -170,7 +171,7 @@ renderBlockerGraph ss =
   where
     sessionInfo = ss ^. serverSessionInfo
     drvModMap = ss ^. serverDriverModuleMap
-    nameMap = mginfoModuleNameMap $ sessionModuleGraph sessionInfo
+    nameMap = ss ^. serverModuleGraphState . mgsModuleGraphInfo . to mginfoModuleNameMap
     ttable = ss ^. serverTiming . tsTimingTable
     maxTime =
       case ttable ^. ttableTimingInfos of

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -48,8 +48,10 @@ import GHCSpecter.Channel.Common.Types (
 import GHCSpecter.Channel.Outbound.Types (
   BreakpointLoc,
   Channel,
+  ModuleGraphInfo (..),
   SessionInfo (..),
   Timer,
+  emptyModuleGraphInfo,
   emptySessionInfo,
  )
 import GHCSpecter.Data.GHC.Hie (ModuleHieInfo)
@@ -91,7 +93,8 @@ emptyTimingState =
     }
 
 data ModuleGraphState = ModuleGraphState
-  { _mgsModuleForest :: Forest ModuleName
+  { _mgsModuleGraphInfo :: ModuleGraphInfo
+  , _mgsModuleForest :: Forest ModuleName
   , _mgsClusterGraph :: Maybe GraphVisInfo
   , _mgsClustering :: [(ModuleName, [ModuleName])]
   , _mgsSubgraph :: [(DetailLevel, [(ModuleName, GraphVisInfo)])]
@@ -105,7 +108,14 @@ instance FromJSON ModuleGraphState
 instance ToJSON ModuleGraphState
 
 emptyModuleGraphState :: ModuleGraphState
-emptyModuleGraphState = ModuleGraphState [] Nothing [] []
+emptyModuleGraphState =
+  ModuleGraphState
+    { _mgsModuleGraphInfo = emptyModuleGraphInfo
+    , _mgsModuleForest = []
+    , _mgsClusterGraph = Nothing
+    , _mgsClustering = []
+    , _mgsSubgraph = []
+    }
 
 newtype HieState = HieState
   { _hieModuleMap :: Map ModuleName ModuleHieInfo

--- a/nix/ghcHEAD/ghcHEAD-cabal.project
+++ b/nix/ghcHEAD/ghcHEAD-cabal.project
@@ -51,14 +51,6 @@ source-repository-package
         location: https://github.com/wavewave/replica.git
         tag: 30e41c7982047d782db5080c17b76d4756291e0c
 
-package OGDF
-  -- by default, ghc finds g++ and that is linked to /usr/bin/g++ on macos.
-  ghc-options: -pgmcxx c++
-
-package ghc-specter-daemon
-  -- by default, ghc finds g++ and that is linked to /usr/bin/g++ on macos.
-  ghc-options: -pgmcxx c++
-
 allow-newer:
   Cabal,
   base,

--- a/nix/ghcHEAD/shell.nix
+++ b/nix/ghcHEAD/shell.nix
@@ -30,6 +30,7 @@ in {
       shellHook = ''
         echo "ghc.nix shell hook"
         ${attrs.shellHook}
+        export CXX=${pkgs.stdenv.cc}/bin/c++
         echo "now entering into ghcHEAD shell. Please set PATH to have your target GHC bin directory."
         export FONTCONFIG_FILE="${fontconf}"
         export PANGOCAIRO_BACKEND=fc

--- a/plugin/ghc-specter-plugin.cabal
+++ b/plugin/ghc-specter-plugin.cabal
@@ -38,6 +38,7 @@ library
       Plugin.GHCSpecter.Comm
       Plugin.GHCSpecter.Console
       Plugin.GHCSpecter.Hooks
+      Plugin.GHCSpecter.Init
       Plugin.GHCSpecter.Tasks
       Plugin.GHCSpecter.Tasks.Core2Core
       Plugin.GHCSpecter.Tasks.Typecheck

--- a/plugin/src-ghc92/Plugin/GHCSpecter.hs
+++ b/plugin/src-ghc92/Plugin/GHCSpecter.hs
@@ -9,22 +9,18 @@ module Plugin.GHCSpecter (
   plugin,
 ) where
 
-import Control.Concurrent (forkOS)
 import Control.Concurrent.STM (
   atomically,
   modifyTVar',
   readTVar,
-  stateTVar,
  )
-import Control.Monad (void, when)
+import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (for_)
 import Data.Functor ((<&>))
-import Data.Map.Strict qualified as M
 import Data.Text qualified as T
 import Data.Time.Clock (getCurrentTime)
 import GHC.Core.Opt.Monad (CoreM, CoreToDo (..), getDynFlags)
-import GHC.Driver.Backend qualified as GHC (Backend (..))
 import GHC.Driver.Env (Hsc, HscEnv (..))
 import GHC.Driver.Flags (GeneralFlag (Opt_WriteHie))
 import GHC.Driver.Hooks (Hooks (..))
@@ -36,32 +32,20 @@ import GHC.Driver.Plugins (
   type CommandLineOption,
  )
 import GHC.Driver.Session (gopt)
-import GHC.Driver.Session qualified as GHC (DynFlags (..), GhcMode (..))
 import GHC.Hs (HsParsedModule)
 import GHC.Hs.Extension (GhcRn, GhcTc)
-import GHC.RTS.Flags (getRTSFlags)
 import GHC.Tc.Types (TcGblEnv (..), TcM, TcPlugin (..), TcPluginResult (TcPluginOk), unsafeTcPluginTcM)
 import GHC.Unit.Module.Location (ModLocation (..))
 import GHC.Unit.Module.ModSummary (ModSummary (..))
 import GHCSpecter.Channel.Common.Types (DriverId (..))
 import GHCSpecter.Channel.Outbound.Types (
-  Backend (..),
   BreakpointLoc (..),
   ChanMessage (..),
-  GhcMode (..),
-  ProcessInfo (..),
-  SessionInfo (..),
  )
-import GHCSpecter.Config (
-  Config (..),
-  defaultGhcSpecterConfigFile,
-  emptyConfig,
-  loadConfig,
- )
-import GHCSpecter.Util.GHC (extractModuleGraphInfo, extractModuleSources, getModuleName, showPpr)
+import GHCSpecter.Util.GHC (getModuleName, showPpr)
 import Language.Haskell.Syntax.Decls (HsGroup)
 import Language.Haskell.Syntax.Expr (LHsExpr)
-import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
+import Plugin.GHCSpecter.Comm (queueMessage)
 import Plugin.GHCSpecter.Console (breakPoint)
 import Plugin.GHCSpecter.Hooks (
   getMemInfo,
@@ -71,99 +55,17 @@ import Plugin.GHCSpecter.Hooks (
   sendModuleName,
   sendModuleStart,
  )
+import Plugin.GHCSpecter.Init (initGhcSession)
 import Plugin.GHCSpecter.Tasks (core2coreCommands, driverCommands, emptyCommandSet, parsedResultActionCommands, renamedResultActionCommands, spliceRunActionCommands, typecheckResultActionCommands)
 import Plugin.GHCSpecter.Types (
   PluginSession (..),
   assignModuleFileToDriverId,
   assignModuleToDriverId,
-  initMsgQueue,
   sessionRef,
  )
 import Safe (headMay, readMay)
-import System.Directory (canonicalizePath, getCurrentDirectory)
-import System.Environment (getArgs, getExecutablePath)
+import System.Directory (canonicalizePath)
 import System.Mem (setAllocationCounter)
-import System.Process (getCurrentPid)
-
--- TODO: Make the initialization work with GHCi.
-
--- | GHC session-wide initialization
-initGhcSession :: HscEnv -> IO ()
-initGhcSession env = do
-  -- NOTE: Read session and overwrite on the session should be done in a single
-  -- atomic STM operation. As a consequence, unfortunately, the necessary IO
-  -- action should be done outside STM beforehand, which implies the action will
-  -- be done multiple times per every driver start.
-  -- This is because we do not have a plugin insertion at real GHC initialization.
-  startTime <- getCurrentTime
-  pid <- fromInteger . toInteger <$> getCurrentPid
-  execPath <- getExecutablePath
-  cwd <- canonicalizePath =<< getCurrentDirectory
-  args <- getArgs
-  rtsflags <- getRTSFlags
-  -- print rtsflags
-  queue_ <- initMsgQueue
-  ecfg <- loadConfig defaultGhcSpecterConfigFile
-  let cfg = either (const emptyConfig) id ecfg
-  -- read/write should be atomic inside a single STM. i.e. no interleaving
-  -- IO actions are allowed.
-  (isNewStart, queue) <-
-    atomically $ do
-      ps <- readTVar sessionRef
-      let ghcSessionInfo = psSessionInfo ps
-          mtimeQueue =
-            (,) <$> sessionStartTime ghcSessionInfo <*> psMessageQueue ps
-      case mtimeQueue of
-        -- session has started already.
-        Just (_, queue) -> pure (False, queue)
-        -- session start
-        Nothing -> do
-          let ghcMode =
-                case (GHC.ghcMode (hsc_dflags env)) of
-                  GHC.CompManager -> CompManager
-                  GHC.OneShot -> OneShot
-                  GHC.MkDepend -> MkDepend
-              backend =
-                case (GHC.backend (hsc_dflags env)) of
-                  GHC.NCG -> NCG
-                  GHC.LLVM -> LLVM
-                  GHC.ViaC -> ViaC
-                  GHC.Interpreter -> Interpreter
-                  GHC.NoBackend -> NoBackend
-              modGraph = hsc_mod_graph env
-              modGraphInfo = extractModuleGraphInfo modGraph
-              newGhcSessionInfo =
-                SessionInfo
-                  { sessionProcess = Just (ProcessInfo pid execPath cwd args rtsflags)
-                  , sessionGhcMode = ghcMode
-                  , sessionBackend = backend
-                  , sessionStartTime = Just startTime
-                  , sessionModuleGraph = modGraphInfo
-                  , sessionModuleSources = M.empty
-                  , sessionIsPaused = configStartWithBreakpoint cfg
-                  }
-          modifyTVar'
-            sessionRef
-            ( \s ->
-                s
-                  { psSessionConfig = cfg
-                  , psSessionInfo = newGhcSessionInfo
-                  , psMessageQueue = Just queue_
-                  }
-            )
-          pure (True, queue_)
-  when isNewStart $ do
-    void $ forkOS $ runMessageQueue cfg queue
-    let modGraph = hsc_mod_graph env
-    modSources <- extractModuleSources modGraph
-    sinfo <-
-      atomically $
-        stateTVar sessionRef $ \ps ->
-          let sinfo0 = psSessionInfo ps
-              sinfo = sinfo0 {sessionModuleSources = modSources}
-              ps' = ps {psSessionInfo = sinfo}
-           in (sinfo, ps')
-    queueMessage (CMSession sinfo)
 
 -- | Driver session-wide initialization
 initDriverSession :: IO DriverId

--- a/plugin/src-ghc92/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc92/Plugin/GHCSpecter/Init.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE MultiWayIf #-}
+
+module Plugin.GHCSpecter.Init (
+  -- * init ghc session and send the info
+  initGhcSession,
+) where
+
+import Control.Concurrent (forkOS)
+import Control.Concurrent.STM (
+  atomically,
+  modifyTVar',
+  readTVar,
+  stateTVar,
+ )
+import Control.Monad (void, when)
+import Data.Map.Strict qualified as M
+import Data.Time.Clock (getCurrentTime)
+import GHC.Driver.Backend qualified as GHC (Backend (..))
+import GHC.Driver.Env (HscEnv (..))
+import GHC.Driver.Session qualified as GHC (DynFlags (..), GhcMode (..))
+import GHC.RTS.Flags (getRTSFlags)
+import GHCSpecter.Channel.Outbound.Types (
+  Backend (..),
+  ChanMessage (..),
+  GhcMode (..),
+  ProcessInfo (..),
+  SessionInfo (..),
+ )
+import GHCSpecter.Config (
+  Config (..),
+  defaultGhcSpecterConfigFile,
+  emptyConfig,
+  loadConfig,
+ )
+import GHCSpecter.Util.GHC (extractModuleGraphInfo, extractModuleSources)
+import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
+import Plugin.GHCSpecter.Types (
+  PluginSession (..),
+  initMsgQueue,
+  sessionRef,
+ )
+import System.Directory (canonicalizePath, getCurrentDirectory)
+import System.Environment (getArgs, getExecutablePath)
+import System.Process (getCurrentPid)
+
+-- TODO: Make the initialization work with GHCi.
+
+-- | GHC session-wide initialization
+initGhcSession :: HscEnv -> IO ()
+initGhcSession env = do
+  -- NOTE: Read session and overwrite on the session should be done in a single
+  -- atomic STM operation. As a consequence, unfortunately, the necessary IO
+  -- action should be done outside STM beforehand, which implies the action will
+  -- be done multiple times per every driver start.
+  -- This is because we do not have a plugin insertion at real GHC initialization.
+  startTime <- getCurrentTime
+  pid <- fromInteger . toInteger <$> getCurrentPid
+  execPath <- getExecutablePath
+  cwd <- canonicalizePath =<< getCurrentDirectory
+  args <- getArgs
+  rtsflags <- getRTSFlags
+  queue_ <- initMsgQueue
+  ecfg <- loadConfig defaultGhcSpecterConfigFile
+  let cfg = either (const emptyConfig) id ecfg
+  -- read/write should be atomic inside a single STM. i.e. no interleaving
+  -- IO actions are allowed.
+  (isNewStart, queue) <-
+    atomically $ do
+      ps <- readTVar sessionRef
+      let ghcSessionInfo = psSessionInfo ps
+          mtimeQueue =
+            (,) <$> sessionStartTime ghcSessionInfo <*> psMessageQueue ps
+      case mtimeQueue of
+        -- session has started already.
+        Just (_, queue) -> pure (False, queue)
+        -- session start
+        Nothing -> do
+          let ghcMode =
+                case (GHC.ghcMode (hsc_dflags env)) of
+                  GHC.CompManager -> CompManager
+                  GHC.OneShot -> OneShot
+                  GHC.MkDepend -> MkDepend
+              backend =
+                case (GHC.backend (hsc_dflags env)) of
+                  GHC.NCG -> NCG
+                  GHC.LLVM -> LLVM
+                  GHC.ViaC -> ViaC
+                  GHC.Interpreter -> Interpreter
+                  GHC.NoBackend -> NoBackend
+              modGraph = hsc_mod_graph env
+              modGraphInfo = extractModuleGraphInfo modGraph
+              newGhcSessionInfo =
+                SessionInfo
+                  { sessionProcess = Just (ProcessInfo pid execPath cwd args rtsflags)
+                  , sessionGhcMode = ghcMode
+                  , sessionBackend = backend
+                  , sessionStartTime = Just startTime
+                  , sessionModuleGraph = modGraphInfo
+                  , sessionModuleSources = M.empty
+                  , sessionIsPaused = configStartWithBreakpoint cfg
+                  }
+          modifyTVar'
+            sessionRef
+            ( \s ->
+                s
+                  { psSessionConfig = cfg
+                  , psSessionInfo = newGhcSessionInfo
+                  , psMessageQueue = Just queue_
+                  }
+            )
+          pure (True, queue_)
+  when isNewStart $ do
+    void $ forkOS $ runMessageQueue cfg queue
+    let modGraph = hsc_mod_graph env
+    modSources <- extractModuleSources modGraph
+    sinfo <-
+      atomically $
+        stateTVar sessionRef $ \ps ->
+          let sinfo0 = psSessionInfo ps
+              sinfo = sinfo0 {sessionModuleSources = modSources}
+              ps' = ps {psSessionInfo = sinfo}
+           in (sinfo, ps')
+    queueMessage (CMSession sinfo)

--- a/plugin/src-ghc94/Plugin/GHCSpecter.hs
+++ b/plugin/src-ghc94/Plugin/GHCSpecter.hs
@@ -9,65 +9,49 @@ module Plugin.GHCSpecter (
   plugin,
 ) where
 
-import Control.Concurrent (forkOS)
 import Control.Concurrent.STM (
   atomically,
   modifyTVar',
   readTVar,
-  stateTVar,
  )
-import Control.Monad (void, when)
+import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (for_)
 import Data.Functor ((<&>))
 import Data.IntMap qualified as IM
-import Data.Map.Strict qualified as M
 import Data.Text qualified as T
-import Data.Time.Clock (getCurrentTime)
 import GHC.Core.Opt.Monad (CoreM, CoreToDo (..), getDynFlags)
-import GHC.Driver.Backend qualified as GHC (Backend (..))
 import GHC.Driver.Env (Hsc, HscEnv (..))
 import GHC.Driver.Flags (GeneralFlag (Opt_WriteHie))
 import GHC.Driver.Hooks (Hooks (..))
 import GHC.Driver.Plugins (ParsedResult, Plugin (..), PluginWithArgs (..), StaticPlugin (..), defaultPlugin, staticPlugins, type CommandLineOption)
 import GHC.Driver.Session (gopt)
-import GHC.Driver.Session qualified as GHC (DynFlags (..), GhcMode (..))
 import GHC.Hs.Extension (GhcRn, GhcTc)
-import GHC.RTS.Flags (getRTSFlags)
 import GHC.Tc.Types (TcGblEnv (..), TcM, TcPlugin (..), TcPluginSolveResult (TcPluginOk), unsafeTcPluginTcM)
 import GHC.Types.Unique.FM (emptyUFM)
 import GHC.Unit.Module.Location (ModLocation (..))
 import GHC.Unit.Module.ModSummary (ModSummary (..))
 import GHCSpecter.Channel.Common.Types (DriverId (..))
 import GHCSpecter.Channel.Outbound.Types (
-  Backend (..),
   BreakpointLoc (..),
   ChanMessage (..),
-  GhcMode (..),
   ModuleGraphInfo (..),
-  ProcessInfo (..),
   SessionInfo (..),
- )
-import GHCSpecter.Config (
-  Config (..),
-  defaultGhcSpecterConfigFile,
-  emptyConfig,
-  loadConfig,
  )
 import GHCSpecter.Util.GHC (
   extractModuleGraphInfo,
-  extractModuleSources,
   showPpr,
  )
 import Language.Haskell.Syntax.Decls (HsGroup)
 import Language.Haskell.Syntax.Expr (LHsExpr)
-import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
+import Plugin.GHCSpecter.Comm (queueMessage)
 import Plugin.GHCSpecter.Console (breakPoint)
 import Plugin.GHCSpecter.Hooks (
   runMetaHook',
   runPhaseHook',
   runRnSpliceHook',
  )
+import Plugin.GHCSpecter.Init (initGhcSession)
 import Plugin.GHCSpecter.Tasks (
   core2coreCommands,
   emptyCommandSet,
@@ -78,93 +62,10 @@ import Plugin.GHCSpecter.Tasks (
  )
 import Plugin.GHCSpecter.Types (
   PluginSession (..),
-  initMsgQueue,
   sessionRef,
  )
 import Safe (headMay, readMay)
-import System.Directory (canonicalizePath, getCurrentDirectory)
-import System.Environment (getArgs, getExecutablePath)
-import System.Process (getCurrentPid)
-
--- TODO: Make the initialization work with GHCi.
-
--- | GHC session-wide initialization
-initGhcSession :: HscEnv -> IO ()
-initGhcSession env = do
-  -- NOTE: Read session and overwrite on the session should be done in a single
-  -- atomic STM operation. As a consequence, unfortunately, the necessary IO
-  -- action should be done outside STM beforehand, which implies the action will
-  -- be done multiple times per every driver start.
-  -- This is because we do not have a plugin insertion at real GHC initialization.
-  startTime <- getCurrentTime
-  pid <- fromInteger . toInteger <$> getCurrentPid
-  execPath <- getExecutablePath
-  cwd <- canonicalizePath =<< getCurrentDirectory
-  args <- getArgs
-  rtsflags <- getRTSFlags
-  -- print rtsflags
-  queue_ <- initMsgQueue
-  ecfg <- loadConfig defaultGhcSpecterConfigFile
-  let cfg = either (const emptyConfig) id ecfg
-  -- read/write should be atomic inside a single STM. i.e. no interleaving
-  -- IO actions are allowed.
-  (isNewStart, queue) <-
-    atomically $ do
-      ps <- readTVar sessionRef
-      let ghcSessionInfo = psSessionInfo ps
-          mtimeQueue =
-            (,) <$> sessionStartTime ghcSessionInfo <*> psMessageQueue ps
-      case mtimeQueue of
-        -- session has started already.
-        Just (_, queue) -> pure (False, queue)
-        -- session start
-        Nothing -> do
-          let ghcMode =
-                case (GHC.ghcMode (hsc_dflags env)) of
-                  GHC.CompManager -> CompManager
-                  GHC.OneShot -> OneShot
-                  GHC.MkDepend -> MkDepend
-              backend =
-                case (GHC.backend (hsc_dflags env)) of
-                  GHC.NCG -> NCG
-                  GHC.LLVM -> LLVM
-                  GHC.ViaC -> ViaC
-                  GHC.Interpreter -> Interpreter
-                  GHC.NoBackend -> NoBackend
-              modGraph = hsc_mod_graph env
-              modGraphInfo = extractModuleGraphInfo modGraph
-              newGhcSessionInfo =
-                SessionInfo
-                  { sessionProcess = Just (ProcessInfo pid execPath cwd args rtsflags)
-                  , sessionGhcMode = ghcMode
-                  , sessionBackend = backend
-                  , sessionStartTime = Just startTime
-                  , sessionModuleGraph = modGraphInfo
-                  , sessionModuleSources = M.empty
-                  , sessionIsPaused = configStartWithBreakpoint cfg
-                  }
-          modifyTVar'
-            sessionRef
-            ( \s ->
-                s
-                  { psSessionConfig = cfg
-                  , psSessionInfo = newGhcSessionInfo
-                  , psMessageQueue = Just queue_
-                  }
-            )
-          pure (True, queue_)
-  when isNewStart $ do
-    void $ forkOS $ runMessageQueue cfg queue
-    let modGraph = hsc_mod_graph env
-    modSources <- extractModuleSources modGraph
-    sinfo <-
-      atomically $
-        stateTVar sessionRef $ \ps ->
-          let sinfo0 = psSessionInfo ps
-              sinfo = sinfo0 {sessionModuleSources = modSources}
-              ps' = ps {psSessionInfo = sinfo}
-           in (sinfo, ps')
-    queueMessage (CMSession sinfo)
+import System.Directory (canonicalizePath)
 
 --
 -- parsedResultAction plugin

--- a/plugin/src-ghc94/Plugin/GHCSpecter.hs
+++ b/plugin/src-ghc94/Plugin/GHCSpecter.hs
@@ -215,18 +215,6 @@ driver opts env0 = do
   -- NOTE2: this will wipe out all other plugins and fix opts
   -- TODO: if other plugins exist, throw exception.
   -- TODO: intefaceLoadAction plugin (interfere with driverPlugin due to withPlugin)
-  {- sinfo0 <-
-    atomically $
-      psSessionInfo <$> readTVar sessionRef
-  let modGraphInfo0 = sessionModuleGraph sinfo0
-      modGraph1 = hsc_mod_graph env0
-      modGraphInfo1 = extractModuleGraphInfo modGraph1
-  when (IM.size (mginfoModuleNameMap modGraphInfo0) < IM.size (mginfoModuleNameMap modGraphInfo1)) $ do
-    let sinfo1 = sinfo0 {sessionModuleGraph = modGraphInfo1}
-    atomically $
-      modifyTVar'
-        sessionRef
-        (\s -> s {psSessionInfo = sinfo1}) -}
   let modGraph = hsc_mod_graph env0
       modGraphInfo = extractModuleGraphInfo modGraph
   modSources <- extractModuleSources modGraph

--- a/plugin/src-ghc94/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src-ghc94/Plugin/GHCSpecter/Hooks.hs
@@ -18,9 +18,11 @@ module Plugin.GHCSpecter.Hooks (
 ) where
 
 import Control.Applicative ((<|>))
-import Control.Concurrent.STM (atomically, readTVar, writeTVar)
+import Control.Concurrent.STM (atomically, modifyTVar', readTVar, writeTVar)
+import Control.Monad (when)
 import Control.Monad.Extra (ifM)
 import Data.Foldable (for_)
+import Data.IntMap qualified as IM
 import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
@@ -54,11 +56,16 @@ import GHCSpecter.Channel.Outbound.Types (
   BreakpointLoc (..),
   ChanMessage (..),
   MemInfo (..),
+  ModuleGraphInfo (..),
   Timer (..),
   TimerTag (..),
  )
 import GHCSpecter.Data.Map (backwardLookup, insertToBiKeyMap)
-import GHCSpecter.Util.GHC (getModuleName)
+import GHCSpecter.Util.GHC (
+  extractModuleGraphInfo,
+  extractModuleSources,
+  getModuleName,
+ )
 import Language.Haskell.Syntax.Expr (HsSplice)
 import Plugin.GHCSpecter.Comm (queueMessage)
 import Plugin.GHCSpecter.Console (breakPoint)
@@ -263,9 +270,29 @@ sendCompStateOnPhase drvId phase pt = do
     T_Cpp {} -> pure ()
     T_HsPp {} -> pure ()
     T_HscRecomp {} -> pure ()
-    T_Hsc {} ->
+    T_Hsc env _ ->
       case pt of
         PhaseStart -> do
+          -- NOTE: Unfortunately, from GHC 9.6, the driver plugin is loaded before
+          -- the module graph is computed. Therefore, the Hsc phase start point of
+          -- the first module is where we can get module graph information reliably.
+          -- So we put the initialization here.
+          let modGraph1 = hsc_mod_graph env
+              modGraphInfo1 = extractModuleGraphInfo modGraph1
+          modSources1 <- extractModuleSources modGraph1
+          shouldUpdate <-
+            atomically $ do
+              (modGraphInfo0, _) <- psModuleGraph <$> readTVar sessionRef
+              let
+                -- TODO: this check is incorrect. need a better method for detecting changes.
+                shouldUpdate =
+                  IM.size (mginfoModuleNameMap modGraphInfo0) < IM.size (mginfoModuleNameMap modGraphInfo1)
+              when shouldUpdate $
+                modifyTVar' sessionRef (\ps -> ps {psModuleGraph = (modGraphInfo1, modSources1)})
+              pure shouldUpdate
+          when shouldUpdate $ do
+            queueMessage (CMModuleGraph modGraphInfo1 modSources1)
+
           -- send timing information
           startTime <- getCurrentTime
           setAllocationCounter 0

--- a/plugin/src-ghc94/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc94/Plugin/GHCSpecter/Init.hs
@@ -11,7 +11,6 @@ import Control.Concurrent.STM (
   stateTVar,
  )
 import Control.Monad (void, when)
-import Data.Map.Strict qualified as M
 import Data.Time.Clock (getCurrentTime)
 import GHC.Driver.Backend qualified as GHC (Backend (..))
 import GHC.Driver.Env (HscEnv (..))
@@ -88,16 +87,12 @@ initGhcSession env = do
                   GHC.ViaC -> ViaC
                   GHC.Interpreter -> Interpreter
                   GHC.NoBackend -> NoBackend
-              modGraph = hsc_mod_graph env
-              modGraphInfo = extractModuleGraphInfo modGraph
               newGhcSessionInfo =
                 SessionInfo
                   { sessionProcess = Just (ProcessInfo pid execPath cwd args rtsflags)
                   , sessionGhcMode = ghcMode
                   , sessionBackend = backend
                   , sessionStartTime = Just startTime
-                  , sessionModuleGraph = modGraphInfo
-                  , sessionModuleSources = M.empty
                   , sessionIsPaused = configStartWithBreakpoint cfg
                   }
           modifyTVar'
@@ -113,12 +108,12 @@ initGhcSession env = do
   when isNewStart $ do
     void $ forkOS $ runMessageQueue cfg queue
     let modGraph = hsc_mod_graph env
+        modGraphInfo = extractModuleGraphInfo modGraph
     modSources <- extractModuleSources modGraph
-    sinfo <-
-      atomically $
-        stateTVar sessionRef $ \ps ->
-          let sinfo0 = psSessionInfo ps
-              sinfo = sinfo0 {sessionModuleSources = modSources}
-              ps' = ps {psSessionInfo = sinfo}
-           in (sinfo, ps')
+    sinfo <- atomically $
+      stateTVar sessionRef $ \ps ->
+        let sinfo = psSessionInfo ps
+            ps' = ps {psModuleGraph = (modGraphInfo, modSources)}
+         in (sinfo, ps')
     queueMessage (CMSession sinfo)
+    queueMessage (CMModuleGraph modGraphInfo modSources)

--- a/plugin/src-ghc94/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc94/Plugin/GHCSpecter/Init.hs
@@ -1,0 +1,124 @@
+module Plugin.GHCSpecter.Init (
+  -- * init ghc session and send the info
+  initGhcSession,
+) where
+
+import Control.Concurrent (forkOS)
+import Control.Concurrent.STM (
+  atomically,
+  modifyTVar',
+  readTVar,
+  stateTVar,
+ )
+import Control.Monad (void, when)
+import Data.Map.Strict qualified as M
+import Data.Time.Clock (getCurrentTime)
+import GHC.Driver.Backend qualified as GHC (Backend (..))
+import GHC.Driver.Env (HscEnv (..))
+import GHC.Driver.Session qualified as GHC (DynFlags (..), GhcMode (..))
+import GHC.RTS.Flags (getRTSFlags)
+import GHCSpecter.Channel.Outbound.Types (
+  Backend (..),
+  ChanMessage (..),
+  GhcMode (..),
+  ProcessInfo (..),
+  SessionInfo (..),
+ )
+import GHCSpecter.Config (
+  Config (..),
+  defaultGhcSpecterConfigFile,
+  emptyConfig,
+  loadConfig,
+ )
+import GHCSpecter.Util.GHC (
+  extractModuleGraphInfo,
+  extractModuleSources,
+ )
+import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
+import Plugin.GHCSpecter.Types (
+  PluginSession (..),
+  initMsgQueue,
+  sessionRef,
+ )
+import System.Directory (canonicalizePath, getCurrentDirectory)
+import System.Environment (getArgs, getExecutablePath)
+import System.Process (getCurrentPid)
+
+-- TODO: Make the initialization work with GHCi.
+
+-- | GHC session-wide initialization
+initGhcSession :: HscEnv -> IO ()
+initGhcSession env = do
+  -- NOTE: Read session and overwrite on the session should be done in a single
+  -- atomic STM operation. As a consequence, unfortunately, the necessary IO
+  -- action should be done outside STM beforehand, which implies the action will
+  -- be done multiple times per every driver start.
+  -- This is because we do not have a plugin insertion at real GHC initialization.
+  startTime <- getCurrentTime
+  pid <- fromInteger . toInteger <$> getCurrentPid
+  execPath <- getExecutablePath
+  cwd <- canonicalizePath =<< getCurrentDirectory
+  args <- getArgs
+  rtsflags <- getRTSFlags
+  queue_ <- initMsgQueue
+  ecfg <- loadConfig defaultGhcSpecterConfigFile
+  let cfg = either (const emptyConfig) id ecfg
+  -- read/write should be atomic inside a single STM. i.e. no interleaving
+  -- IO actions are allowed.
+  (isNewStart, queue) <-
+    atomically $ do
+      ps <- readTVar sessionRef
+      let ghcSessionInfo = psSessionInfo ps
+          mtimeQueue =
+            (,) <$> sessionStartTime ghcSessionInfo <*> psMessageQueue ps
+      case mtimeQueue of
+        -- session has started already.
+        Just (_, queue) -> pure (False, queue)
+        -- session start
+        Nothing -> do
+          let ghcMode =
+                case (GHC.ghcMode (hsc_dflags env)) of
+                  GHC.CompManager -> CompManager
+                  GHC.OneShot -> OneShot
+                  GHC.MkDepend -> MkDepend
+              backend =
+                case (GHC.backend (hsc_dflags env)) of
+                  GHC.NCG -> NCG
+                  GHC.LLVM -> LLVM
+                  GHC.ViaC -> ViaC
+                  GHC.Interpreter -> Interpreter
+                  GHC.NoBackend -> NoBackend
+              modGraph = hsc_mod_graph env
+              modGraphInfo = extractModuleGraphInfo modGraph
+              newGhcSessionInfo =
+                SessionInfo
+                  { sessionProcess = Just (ProcessInfo pid execPath cwd args rtsflags)
+                  , sessionGhcMode = ghcMode
+                  , sessionBackend = backend
+                  , sessionStartTime = Just startTime
+                  , sessionModuleGraph = modGraphInfo
+                  , sessionModuleSources = M.empty
+                  , sessionIsPaused = configStartWithBreakpoint cfg
+                  }
+          modifyTVar'
+            sessionRef
+            ( \s ->
+                s
+                  { psSessionConfig = cfg
+                  , psSessionInfo = newGhcSessionInfo
+                  , psMessageQueue = Just queue_
+                  }
+            )
+          pure (True, queue_)
+  when isNewStart $ do
+    void $ forkOS $ runMessageQueue cfg queue
+    let modGraph = hsc_mod_graph env
+    modSources <- extractModuleSources modGraph
+    sinfo <-
+      atomically $
+        stateTVar sessionRef $ \ps ->
+          let sinfo0 = psSessionInfo ps
+              sinfo = sinfo0 {sessionModuleSources = modSources}
+              ps' = ps {psSessionInfo = sinfo}
+           in (sinfo, ps')
+    queueMessage (CMSession sinfo)

--- a/plugin/src-ghc94/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc94/Plugin/GHCSpecter/Init.hs
@@ -107,13 +107,6 @@ initGhcSession env = do
           pure (True, queue_)
   when isNewStart $ do
     void $ forkOS $ runMessageQueue cfg queue
-    let modGraph = hsc_mod_graph env
-        modGraphInfo = extractModuleGraphInfo modGraph
-    modSources <- extractModuleSources modGraph
-    sinfo <- atomically $
-      stateTVar sessionRef $ \ps ->
-        let sinfo = psSessionInfo ps
-            ps' = ps {psModuleGraph = (modGraphInfo, modSources)}
-         in (sinfo, ps')
+    sinfo <-
+      atomically $ psSessionInfo <$> readTVar sessionRef
     queueMessage (CMSession sinfo)
-    queueMessage (CMModuleGraph modGraphInfo modSources)

--- a/plugin/src-ghc96/Plugin/GHCSpecter.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter.hs
@@ -28,13 +28,13 @@ import GHC.Driver.Hooks (Hooks (..))
 import GHC.Driver.Plugins (ParsedResult, Plugin (..), PluginWithArgs (..), StaticPlugin (..), defaultPlugin, staticPlugins, type CommandLineOption)
 import GHC.Driver.Session (gopt)
 import GHC.Hs.Extension (GhcRn, GhcTc)
-import GHC.Tc.Types
-  ( TcGblEnv (..),
-    TcM,
-    TcPlugin (..),
-    TcPluginSolveResult (TcPluginOk),
-    unsafeTcPluginTcM
-  )
+import GHC.Tc.Types (
+  TcGblEnv (..),
+  TcM,
+  TcPlugin (..),
+  TcPluginSolveResult (TcPluginOk),
+  unsafeTcPluginTcM,
+ )
 import GHC.Types.Unique.FM (emptyUFM)
 import GHC.Unit.Module.Location (ModLocation (..))
 import GHC.Unit.Module.ModSummary (ModSummary (..))
@@ -58,7 +58,7 @@ import Plugin.GHCSpecter.Hooks (
   runPhaseHook',
   runRnSpliceHook',
  )
-import Plugin.GHCSpecter.Init (initGhcSession)
+-- import Plugin.GHCSpecter.Init (initGhcSession)
 import Plugin.GHCSpecter.Tasks (
   core2coreCommands,
   emptyCommandSet,
@@ -214,7 +214,7 @@ corePlugin opts todos = do
 --   If nothing, do not try to communicate with web frontend.
 driver :: [CommandLineOption] -> HscEnv -> IO HscEnv
 driver opts env0 = do
-  initGhcSession env0
+  -- initGhcSession env0
   -- Note: Here we try to detect the start of the compilation of each module
   -- and assign driver id per the instance.
   -- From GHC 9.4, the start point can be consistenly detected by runPhaseHook.

--- a/plugin/src-ghc96/Plugin/GHCSpecter.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter.hs
@@ -9,66 +9,56 @@ module Plugin.GHCSpecter (
   plugin,
 ) where
 
-import Control.Concurrent (forkOS)
 import Control.Concurrent.STM (
   atomically,
   modifyTVar',
   readTVar,
-  stateTVar,
  )
-import Control.Monad (void, when)
+import Control.Monad (when)
 import Control.Monad.IO.Class (liftIO)
 import Data.Foldable (for_)
 import Data.Functor ((<&>))
 import Data.IntMap qualified as IM
-import Data.Map.Strict qualified as M
 import Data.Text qualified as T
-import Data.Time.Clock (getCurrentTime)
 import GHC.Core.Opt.Monad (CoreM, getDynFlags)
 import GHC.Core.Opt.Pipeline.Types (CoreToDo (..))
-import GHC.Driver.Backend (backendDescription)
 import GHC.Driver.Env (Hsc, HscEnv (..))
 import GHC.Driver.Flags (GeneralFlag (Opt_WriteHie))
 import GHC.Driver.Hooks (Hooks (..))
 import GHC.Driver.Plugins (ParsedResult, Plugin (..), PluginWithArgs (..), StaticPlugin (..), defaultPlugin, staticPlugins, type CommandLineOption)
 import GHC.Driver.Session (gopt)
-import GHC.Driver.Session qualified as GHC (DynFlags (..), GhcMode (..))
 import GHC.Hs.Extension (GhcRn, GhcTc)
-import GHC.RTS.Flags (getRTSFlags)
-import GHC.Tc.Types (TcGblEnv (..), TcM, TcPlugin (..), TcPluginSolveResult (TcPluginOk), unsafeTcPluginTcM)
+import GHC.Tc.Types
+  ( TcGblEnv (..),
+    TcM,
+    TcPlugin (..),
+    TcPluginSolveResult (TcPluginOk),
+    unsafeTcPluginTcM
+  )
 import GHC.Types.Unique.FM (emptyUFM)
 import GHC.Unit.Module.Location (ModLocation (..))
 import GHC.Unit.Module.ModSummary (ModSummary (..))
 import GHCSpecter.Channel.Common.Types (DriverId (..))
 import GHCSpecter.Channel.Outbound.Types (
-  Backend (..),
   BreakpointLoc (..),
   ChanMessage (..),
-  GhcMode (..),
   ModuleGraphInfo (..),
-  ProcessInfo (..),
   SessionInfo (..),
- )
-import GHCSpecter.Config (
-  Config (..),
-  defaultGhcSpecterConfigFile,
-  emptyConfig,
-  loadConfig,
  )
 import GHCSpecter.Util.GHC (
   extractModuleGraphInfo,
-  extractModuleSources,
   showPpr,
  )
 import Language.Haskell.Syntax.Decls (HsGroup)
 import Language.Haskell.Syntax.Expr (LHsExpr)
-import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
+import Plugin.GHCSpecter.Comm (queueMessage)
 import Plugin.GHCSpecter.Console (breakPoint)
 import Plugin.GHCSpecter.Hooks (
   runMetaHook',
   runPhaseHook',
   runRnSpliceHook',
  )
+import Plugin.GHCSpecter.Init (initGhcSession)
 import Plugin.GHCSpecter.Tasks (
   core2coreCommands,
   emptyCommandSet,
@@ -79,95 +69,10 @@ import Plugin.GHCSpecter.Tasks (
  )
 import Plugin.GHCSpecter.Types (
   PluginSession (..),
-  initMsgQueue,
   sessionRef,
  )
 import Safe (headMay, readMay)
-import System.Directory (canonicalizePath, getCurrentDirectory)
-import System.Environment (getArgs, getExecutablePath)
-import System.Process (getCurrentPid)
-
--- TODO: Make the initialization work with GHCi.
-
--- | GHC session-wide initialization
-initGhcSession :: HscEnv -> IO ()
-initGhcSession env = do
-  -- NOTE: Read session and overwrite on the session should be done in a single
-  -- atomic STM operation. As a consequence, unfortunately, the necessary IO
-  -- action should be done outside STM beforehand, which implies the action will
-  -- be done multiple times per every driver start.
-  -- This is because we do not have a plugin insertion at real GHC initialization.
-  startTime <- getCurrentTime
-  pid <- fromInteger . toInteger <$> getCurrentPid
-  execPath <- getExecutablePath
-  cwd <- canonicalizePath =<< getCurrentDirectory
-  args <- getArgs
-  rtsflags <- getRTSFlags
-  -- print rtsflags
-  queue_ <- initMsgQueue
-  ecfg <- loadConfig defaultGhcSpecterConfigFile
-  let cfg = either (const emptyConfig) id ecfg
-  -- read/write should be atomic inside a single STM. i.e. no interleaving
-  -- IO actions are allowed.
-  (isNewStart, queue) <-
-    atomically $ do
-      ps <- readTVar sessionRef
-      let ghcSessionInfo = psSessionInfo ps
-          mtimeQueue =
-            (,) <$> sessionStartTime ghcSessionInfo <*> psMessageQueue ps
-      case mtimeQueue of
-        -- session has started already.
-        Just (_, queue) -> pure (False, queue)
-        -- session start
-        Nothing -> do
-          let ghcMode =
-                case (GHC.ghcMode (hsc_dflags env)) of
-                  GHC.CompManager -> CompManager
-                  GHC.OneShot -> OneShot
-                  GHC.MkDepend -> MkDepend
-              backend =
-                let desc = backendDescription (GHC.backend (hsc_dflags env))
-                 in if
-                        | desc == "native code generator" -> NCG
-                        | desc == "LLVM" -> LLVM
-                        | desc == "compiling via C" -> ViaC
-                        --  | desc == "compiling to JavaScript" -> Javascript
-                        | desc == "byte-code interpreter" -> Interpreter
-                        | otherwise -> NoBackend
-              modGraph = hsc_mod_graph env
-              modGraphInfo = extractModuleGraphInfo modGraph
-              newGhcSessionInfo =
-                SessionInfo
-                  { sessionProcess = Just (ProcessInfo pid execPath cwd args rtsflags)
-                  , sessionGhcMode = ghcMode
-                  , sessionBackend = backend
-                  , sessionStartTime = Just startTime
-                  , sessionModuleGraph = modGraphInfo
-                  , sessionModuleSources = M.empty
-                  , sessionIsPaused = configStartWithBreakpoint cfg
-                  }
-          modifyTVar'
-            sessionRef
-            ( \s ->
-                s
-                  { psSessionConfig = cfg
-                  , psSessionInfo = newGhcSessionInfo
-                  , psMessageQueue = Just queue_
-                  }
-            )
-          pure (True, queue_)
-  when isNewStart $ do
-    void $ forkOS $ runMessageQueue cfg queue
-    let modGraph = hsc_mod_graph env
-    modSources <- extractModuleSources modGraph
-    sinfo <-
-      atomically $
-        stateTVar sessionRef $ \ps ->
-          let sinfo0 = psSessionInfo ps
-              sinfo = sinfo0 {sessionModuleSources = modSources}
-              ps' = ps {psSessionInfo = sinfo}
-           in (sinfo, ps')
-    queueMessage (CMSession sinfo)
+import System.Directory (canonicalizePath)
 
 --
 -- parsedResultAction plugin

--- a/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
@@ -346,9 +346,9 @@ runPhaseHook' = PhaseHook $ \phase -> do
       phaseTxt = tphase2Text phase
   mdrvId <-
     case phase of
-      T_Hsc _ modSummary ->
-        -- T_Hsc is a point where the module name is first identified in the plugin though
-        -- GHC knows the module index when planning the build.
+      T_Hsc _ _ ->
+        -- Since GHC 9.4, T_Hsc is a point where the module name is first identified
+        -- in the plugin though GHC knows the module index when planning the build.
         -- Therefore, we are only able to issue a new ID associated with a given module
         -- at this point.
         -- TODO: Work on the upstream GHC to provide the index as a part of API.

--- a/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
@@ -57,7 +57,7 @@ import GHCSpecter.Channel.Outbound.Types (
   TimerTag (..),
  )
 import GHCSpecter.Data.Map (backwardLookup, insertToBiKeyMap)
-import GHCSpecter.Util.GHC (getModuleName)
+import GHCSpecter.Util.GHC (extractModuleGraphInfo, getModuleName)
 import Language.Haskell.Syntax.Expr (HsUntypedSplice)
 import Language.Haskell.Syntax.Module.Name (moduleNameString)
 import Plugin.GHCSpecter.Comm (queueMessage)
@@ -263,9 +263,13 @@ sendCompStateOnPhase drvId phase pt = do
     T_Cpp {} -> pure ()
     T_HsPp {} -> pure ()
     T_HscRecomp {} -> pure ()
-    T_Hsc {} ->
+    T_Hsc env _ ->
       case pt of
         PhaseStart -> do
+          let modGraph = hsc_mod_graph env
+              modGraphInfo = extractModuleGraphInfo modGraph
+          putStrLn "Hsc Phase start"
+          print modGraphInfo
           -- send timing information
           startTime <- getCurrentTime
           setAllocationCounter 0

--- a/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
@@ -62,6 +62,7 @@ import Language.Haskell.Syntax.Expr (HsUntypedSplice)
 import Language.Haskell.Syntax.Module.Name (moduleNameString)
 import Plugin.GHCSpecter.Comm (queueMessage)
 import Plugin.GHCSpecter.Console (breakPoint)
+import Plugin.GHCSpecter.Init (initGhcSession)
 import Plugin.GHCSpecter.Tasks (
   postMetaCommands,
   postPhaseCommands,
@@ -270,6 +271,11 @@ sendCompStateOnPhase drvId phase pt = do
               modGraphInfo = extractModuleGraphInfo modGraph
           putStrLn "Hsc Phase start"
           print modGraphInfo
+          -- NOTE: Unfortunately, from GHC 9.6, the driver plugin is loaded before
+          -- the module graph is computed. Therefore, the Hsc phase start point of
+          -- the first module is where we can get module graph information reliably.
+          -- So we put the initialization here.
+          initGhcSession env
           -- send timing information
           startTime <- getCurrentTime
           setAllocationCounter 0

--- a/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
@@ -346,7 +346,7 @@ runPhaseHook' = PhaseHook $ \phase -> do
       phaseTxt = tphase2Text phase
   mdrvId <-
     case phase of
-      T_Hsc _ _ ->
+      T_Hsc _ modSummary ->
         -- Since GHC 9.4, T_Hsc is a point where the module name is first identified
         -- in the plugin though GHC knows the module index when planning the build.
         -- Therefore, we are only able to issue a new ID associated with a given module

--- a/plugin/src-ghc96/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter/Init.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE MultiWayIf #-}
+
+module Plugin.GHCSpecter.Init (
+  -- * init ghc session and send the info
+  initGhcSession,
+) where
+
+import Control.Concurrent (forkOS)
+import Control.Concurrent.STM (
+  atomically,
+  modifyTVar',
+  readTVar,
+  stateTVar,
+ )
+import Control.Monad (void, when)
+import Data.Map.Strict qualified as M
+import Data.Time.Clock (getCurrentTime)
+import GHC.Driver.Backend (backendDescription)
+import GHC.Driver.Env (HscEnv (..))
+import GHC.Driver.Session qualified as GHC (DynFlags (..), GhcMode (..))
+import GHC.RTS.Flags (getRTSFlags)
+import GHCSpecter.Channel.Outbound.Types (
+  Backend (..),
+  ChanMessage (..),
+  GhcMode (..),
+  ProcessInfo (..),
+  SessionInfo (..),
+  emptyModuleGraphInfo,
+ )
+import GHCSpecter.Config (
+  Config (..),
+  defaultGhcSpecterConfigFile,
+  emptyConfig,
+  loadConfig,
+ )
+import GHCSpecter.Util.GHC (
+  extractModuleGraphInfo,
+  extractModuleSources,
+ )
+import Plugin.GHCSpecter.Comm (queueMessage, runMessageQueue)
+import Plugin.GHCSpecter.Types (
+  PluginSession (..),
+  initMsgQueue,
+  sessionRef,
+ )
+import System.Directory (canonicalizePath, getCurrentDirectory)
+import System.Environment (getArgs, getExecutablePath)
+import System.Process (getCurrentPid)
+
+-- TODO: Make the initialization work with GHCi.
+
+-- | GHC session-wide initialization
+initGhcSession :: HscEnv -> IO ()
+initGhcSession env = do
+  -- NOTE: Read session and overwrite on the session should be done in a single
+  -- atomic STM operation. As a consequence, unfortunately, the necessary IO
+  -- action should be done outside STM beforehand, which implies the action will
+  -- be done multiple times per every driver start.
+  -- This is because we do not have a plugin insertion at real GHC initialization.
+  startTime <- getCurrentTime
+  pid <- fromInteger . toInteger <$> getCurrentPid
+  execPath <- getExecutablePath
+  cwd <- canonicalizePath =<< getCurrentDirectory
+  args <- getArgs
+  rtsflags <- getRTSFlags
+  queue_ <- initMsgQueue
+  ecfg <- loadConfig defaultGhcSpecterConfigFile
+  let cfg = either (const emptyConfig) id ecfg
+  -- read/write should be atomic inside a single STM. i.e. no interleaving
+  -- IO actions are allowed.
+  (isNewStart, queue, mgi) <-
+    atomically $ do
+      ps <- readTVar sessionRef
+      let ghcSessionInfo = psSessionInfo ps
+          mtimeQueue =
+            (,) <$> sessionStartTime ghcSessionInfo <*> psMessageQueue ps
+      case mtimeQueue of
+        -- session has started already.
+        Just (_, queue) -> pure (False, queue, emptyModuleGraphInfo)
+        -- session start
+        Nothing -> do
+          let ghcMode =
+                case (GHC.ghcMode (hsc_dflags env)) of
+                  GHC.CompManager -> CompManager
+                  GHC.OneShot -> OneShot
+                  GHC.MkDepend -> MkDepend
+              backend =
+                let desc = backendDescription (GHC.backend (hsc_dflags env))
+                 in if
+                        | desc == "native code generator" -> NCG
+                        | desc == "LLVM" -> LLVM
+                        | desc == "compiling via C" -> ViaC
+                        --  | desc == "compiling to JavaScript" -> Javascript
+                        | desc == "byte-code interpreter" -> Interpreter
+                        | otherwise -> NoBackend
+              modGraph = hsc_mod_graph env
+              modGraphInfo = extractModuleGraphInfo modGraph
+              newGhcSessionInfo =
+                SessionInfo
+                  { sessionProcess = Just (ProcessInfo pid execPath cwd args rtsflags)
+                  , sessionGhcMode = ghcMode
+                  , sessionBackend = backend
+                  , sessionStartTime = Just startTime
+                  , sessionModuleGraph = modGraphInfo
+                  , sessionModuleSources = M.empty
+                  , sessionIsPaused = configStartWithBreakpoint cfg
+                  }
+          modifyTVar'
+            sessionRef
+            ( \s ->
+                s
+                  { psSessionConfig = cfg
+                  , psSessionInfo = newGhcSessionInfo
+                  , psMessageQueue = Just queue_
+                  }
+            )
+          pure (True, queue_, modGraphInfo)
+  print mgi
+  when isNewStart $ do
+    void $ forkOS $ runMessageQueue cfg queue
+    let modGraph = hsc_mod_graph env
+    modSources <- extractModuleSources modGraph
+    sinfo <-
+      atomically $
+        stateTVar sessionRef $ \ps ->
+          let sinfo0 = psSessionInfo ps
+              sinfo = sinfo0 {sessionModuleSources = modSources}
+              ps' = ps {psSessionInfo = sinfo}
+           in (sinfo, ps')
+    queueMessage (CMSession sinfo)

--- a/plugin/src/Plugin/GHCSpecter/Comm.hs
+++ b/plugin/src/Plugin/GHCSpecter/Comm.hs
@@ -3,7 +3,7 @@ module Plugin.GHCSpecter.Comm (
   queueMessage,
 ) where
 
-import Control.Concurrent (forkIO, forkOS)
+import Control.Concurrent (forkOS)
 import Control.Concurrent.STM (
   atomically,
   modifyTVar',
@@ -16,7 +16,6 @@ import Data.Foldable (for_)
 import Data.Foldable qualified as F
 import Data.Sequence ((|>))
 import Data.Sequence qualified as Seq
-import GHC.Debug.Stub qualified as Debug
 import GHCSpecter.Channel.Inbound.Types (
   Request (..),
   SessionRequest (..),

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -40,7 +40,9 @@ import GHCSpecter.Channel.Common.Types (
 import GHCSpecter.Channel.Inbound.Types (ConsoleRequest (..))
 import GHCSpecter.Channel.Outbound.Types (
   ChanMessageBox (..),
+  ModuleGraphInfo (..),
   SessionInfo (..),
+  emptyModuleGraphInfo,
   emptySessionInfo,
  )
 import GHCSpecter.Config (Config, emptyConfig)
@@ -74,6 +76,7 @@ emptyConsoleState = ConsoleState Nothing
 data PluginSession = PluginSession
   { psSessionConfig :: Config
   , psSessionInfo :: SessionInfo
+  , psModuleGraphInfo :: ModuleGraphInfo
   , psMessageQueue :: Maybe MsgQueue
   , psDrvIdModuleMap :: BiKeyMap DriverId ModuleName
   , psDrvIdModuleFileMap :: BiKeyMap DriverId FilePath
@@ -88,6 +91,7 @@ emptyPluginSession =
   PluginSession
     { psSessionConfig = emptyConfig
     , psSessionInfo = emptySessionInfo
+    , psModuleGraphInfo = emptyModuleGraphInfo
     , psMessageQueue = Nothing
     , psDrvIdModuleMap = emptyBiKeyMap
     , psDrvIdModuleFileMap = emptyBiKeyMap

--- a/plugin/src/Plugin/GHCSpecter/Types.hs
+++ b/plugin/src/Plugin/GHCSpecter/Types.hs
@@ -31,6 +31,8 @@ import Control.Concurrent.STM (
   newTVarIO,
   readTVar,
  )
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import GHCSpecter.Channel.Common.Types (
@@ -76,7 +78,7 @@ emptyConsoleState = ConsoleState Nothing
 data PluginSession = PluginSession
   { psSessionConfig :: Config
   , psSessionInfo :: SessionInfo
-  , psModuleGraphInfo :: ModuleGraphInfo
+  , psModuleGraph :: (ModuleGraphInfo, Map ModuleName FilePath)
   , psMessageQueue :: Maybe MsgQueue
   , psDrvIdModuleMap :: BiKeyMap DriverId ModuleName
   , psDrvIdModuleFileMap :: BiKeyMap DriverId FilePath
@@ -91,7 +93,7 @@ emptyPluginSession =
   PluginSession
     { psSessionConfig = emptyConfig
     , psSessionInfo = emptySessionInfo
-    , psModuleGraphInfo = emptyModuleGraphInfo
+    , psModuleGraph = (emptyModuleGraphInfo, Map.empty)
     , psMessageQueue = Nothing
     , psDrvIdModuleMap = emptyBiKeyMap
     , psDrvIdModuleFileMap = emptyBiKeyMap


### PR DESCRIPTION
Since GHC 9.6, the driver plugin is initialized before analyzing ModuleGraph (see [1]), and therefore, in the previous implementation, ghc-specter could not get the module graph information correctly. 
Now, I split ModuleGraphInfo out from SessionInfo so that the module graph information can be sent later when available (currently, the earliest time one can get is when Hsc phase started for the first module afaict).
Subsequent changes for GHC 9.4 and 9.6. Tested with Agda repo.

 [1] https://github.com/ghc/ghc/blob/ghc-9.6.1-release/compiler/GHC/Driver/Make.hs#L668