### PR TITLE
Proper subcomponent event coordinate transformation

### DIFF
--- a/daemon-exp/app/ghc-specter-daemon-exp/ModuleGraph.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/ModuleGraph.hs
@@ -14,6 +14,7 @@ import GHCSpecter.Channel.Outbound.Types (Timer)
 import GHCSpecter.Data.Map (BiKeyMap, KeyMap)
 import GHCSpecter.Data.Timing.Util (isModuleCompilationDone)
 import GHCSpecter.GraphLayout.Types (GraphVisInfo)
+import GHCSpecter.Graphics.DSL (ViewPort (..))
 import GHCSpecter.Render.Components.GraphView (compileModuleGraph)
 import GHCSpecter.UI.Constants (modGraphHeight, modGraphWidth)
 import GHCSpecter.UI.Types (
@@ -23,7 +24,6 @@ import GHCSpecter.UI.Types (
   HasViewPortInfo (..),
   ModuleGraphUI,
   UIState,
-  ViewPort (..),
  )
 import GI.Cairo.Render qualified as R
 import Renderer (renderPrimitive)

--- a/daemon-exp/app/ghc-specter-daemon-exp/ModuleGraph.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/ModuleGraph.hs
@@ -40,7 +40,7 @@ renderModuleGraph ::
   GraphVisInfo ->
   R.Render ()
 renderModuleGraph uiRef vb mgrui nameMap drvModMap timing clustering grVisInfo = do
-  R.liftIO $ atomically $ modifyTVar' uiRef (uiViewRaw . uiRawEventBoxMap .~ [])
+  R.liftIO $ atomically $ modifyTVar' uiRef (uiViewRaw . uiRawEventMap .~ [])
   let valueFor name =
         fromMaybe 0 $ do
           cluster <- L.lookup name clustering

--- a/daemon-exp/app/ghc-specter-daemon-exp/ModuleGraph.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/ModuleGraph.hs
@@ -62,5 +62,5 @@ renderModuleGraph uiRef vb mgrui nameMap drvModMap timing clustering grVisInfo =
       scaleY = modGraphHeight / (vy1 - vy0)
   R.scale scaleX scaleY
   R.translate (-vx0) (-vy0)
-  traverse_ (renderPrimitive uiRef vb) rexp
+  traverse_ (renderPrimitive vb) rexp
   R.restore

--- a/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
@@ -62,12 +62,12 @@ setColor ColorRedLevel4 = R.setSourceRGBA 0.945 0.580 0.541 1 -- F1948A
 setColor ColorRedLevel5 = R.setSourceRGBA 0.925 0.439 0.388 1 -- EC7063
 
 renderPrimitive :: TVar UIState -> ViewBackend -> Primitive -> R.Render ()
-renderPrimitive uiRef vb (Rectangle (x, y) w h mline mbkg mlwidth mname) = do
+renderPrimitive uiRef _ (Rectangle (x, y) w h mline mbkg mlwidth mname) = do
   for_ mname $ \name ->
     R.liftIO $
       atomically $
         modifyTVar' uiRef $
-          uiViewRaw . uiRawEventBoxMap %~ (\es -> let e = (name, ((x, y), (x + w, y + h))) in e : es)
+          uiViewRaw . uiRawEventMap %~ (\es -> let e = (name, ((x, y), (x + w, y + h))) in e : es)
   for_ mbkg $ \bkg -> do
     setColor bkg
     R.rectangle x y w h

--- a/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
@@ -15,7 +15,12 @@ import Control.Lens ((%~))
 import Data.Foldable (for_, traverse_)
 import Data.Int (Int32)
 import Data.Text (Text)
-import GHCSpecter.Graphics.DSL (Color (..), Primitive (..), TextPosition (..))
+import GHCSpecter.Graphics.DSL (
+  Color (..),
+  Primitive (..),
+  TextPosition (..),
+  ViewPort (..),
+ )
 import GHCSpecter.UI.Types (
   HasUIState (..),
   HasUIViewRaw (..),
@@ -67,7 +72,7 @@ renderPrimitive uiRef _ (Rectangle (x, y) w h mline mbkg mlwidth mname) = do
     R.liftIO $
       atomically $
         modifyTVar' uiRef $
-          uiViewRaw . uiRawEventMap %~ (\es -> let e = (name, ((x, y), (x + w, y + h))) in e : es)
+          uiViewRaw . uiRawEventMap %~ (\es -> let e = (name, ViewPort (x, y) (x + w, y + h)) in e : es)
   for_ mbkg $ \bkg -> do
     setColor bkg
     R.rectangle x y w h

--- a/daemon-exp/app/ghc-specter-daemon-exp/Timing.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Timing.hs
@@ -44,7 +44,7 @@ renderTiming ::
   TimingTable ->
   R.Render ()
 renderTiming uiRef vb drvModMap tui ttable = do
-  R.liftIO $ atomically $ modifyTVar' uiRef (uiViewRaw . uiRawEventBoxMap .~ [])
+  R.liftIO $ atomically $ modifyTVar' uiRef (uiViewRaw . uiRawEventMap .~ [])
   let rexpTimingChart :: [Primitive]
       rexpTimingChart = compileTimingChart drvModMap tui ttable
       rexpMemChart :: [Primitive]

--- a/daemon-exp/app/ghc-specter-daemon-exp/Timing.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Timing.hs
@@ -11,7 +11,10 @@ import Data.Maybe (fromMaybe)
 import GHCSpecter.Channel.Common.Types (DriverId, ModuleName)
 import GHCSpecter.Data.Map (BiKeyMap)
 import GHCSpecter.Data.Timing.Types (TimingTable)
-import GHCSpecter.Graphics.DSL (Primitive (..))
+import GHCSpecter.Graphics.DSL (
+  Primitive (..),
+  ViewPort (..),
+ )
 import GHCSpecter.Render.Components.TimingView (
   compileBlockers,
   compileMemChart,
@@ -30,7 +33,6 @@ import GHCSpecter.UI.Types (
   HasViewPortInfo (..),
   TimingUI,
   UIState,
-  ViewPort (..),
  )
 import GI.Cairo.Render qualified as R
 import Renderer (renderPrimitive)

--- a/daemon-exp/app/ghc-specter-daemon-exp/Timing.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Timing.hs
@@ -13,6 +13,7 @@ import GHCSpecter.Data.Map (BiKeyMap)
 import GHCSpecter.Data.Timing.Types (TimingTable)
 import GHCSpecter.Graphics.DSL (
   Primitive (..),
+  Scene (..),
   ViewPort (..),
  )
 import GHCSpecter.Render.Components.TimingView (
@@ -35,7 +36,10 @@ import GHCSpecter.UI.Types (
   UIState,
  )
 import GI.Cairo.Render qualified as R
-import Renderer (renderPrimitive)
+import Renderer (
+  renderPrimitive,
+  renderScene,
+ )
 import Types (ViewBackend)
 
 renderTiming ::
@@ -47,46 +51,45 @@ renderTiming ::
   R.Render ()
 renderTiming uiRef vb drvModMap tui ttable = do
   R.liftIO $ atomically $ modifyTVar' uiRef (uiViewRaw . uiRawEventMap .~ [])
-  let rexpTimingChart :: [Primitive]
-      rexpTimingChart = compileTimingChart drvModMap tui ttable
-      rexpMemChart :: [Primitive]
-      rexpMemChart = compileMemChart drvModMap tui ttable
-      rexpTimingBar :: [Primitive]
-      rexpTimingBar = compileTimingRange tui ttable
-  -- timing chart
-  R.save
-  R.rectangle 0 0 (timingWidth * 0.8) timingHeight
-  R.clip
-  -- TODO: refactor this out
   let vpi = tui ^. timingUIViewPort
-      ViewPort (vx0, vy0) (vx1, vy1) = fromMaybe (vpi ^. vpViewPort) (vpi ^. vpTempViewPort)
-      scaleX = timingWidth / (vx1 - vx0)
-      scaleY = timingHeight / (vy1 - vy0)
-  R.scale scaleX scaleY
-  R.translate (-vx0) (-vy0)
-  traverse_ (renderPrimitive uiRef vb) rexpTimingChart
-  R.restore
+      vp@(ViewPort (vx0, vy0) (vx1, vy1)) = fromMaybe (vpi ^. vpViewPort) (vpi ^. vpTempViewPort)
+      sceneTimingChart = compileTimingChart drvModMap tui ttable
+      sceneMemChart = compileMemChart drvModMap tui ttable
+      sceneTimingRange = compileTimingRange tui ttable
+  -- timing chart
+  let sceneTimingChart' =
+        sceneTimingChart
+          { sceneGlobalViewPort = ViewPort (0, 0) (timingWidth * 0.8, timingHeight)
+          , sceneLocalViewPort = vp
+          }
+  renderScene uiRef vb sceneTimingChart'
   -- mem chart
-  R.save
-  R.rectangle (timingWidth * 0.8) 0 timingWidth timingHeight
-  R.clip
-  R.translate (timingWidth * 0.8) 0
-  R.scale 1.0 scaleY
-  R.translate 0 (-vy0)
-  traverse_ (renderPrimitive uiRef vb) rexpMemChart
-  R.restore
-  -- timing range
-  R.save
-  R.translate 0 timingHeight
-  traverse_ (renderPrimitive uiRef vb) rexpTimingBar
-  R.restore
-  -- blocker
-  R.save
-  R.translate 0 (timingHeight + timingRangeHeight)
-  -- R.setSourceRGBA 0.5 0.5 0.5 1
-  -- R.rectangle 0 0 100 100
-  -- R.stroke
+  let ViewPort (cx0, cy0) (cx1, cy1) = sceneGlobalViewPort sceneTimingChart'
+      ViewPort (vx0, vy0) (vx1, vy1) = sceneLocalViewPort sceneTimingChart'
+      scaleX = (cx1 - cx0) / (vx1 - vx0)
+      scaleY = (cy1 - cy0) / (vy1 - vy0)
+      sceneMemChart' =
+        sceneMemChart
+          { sceneGlobalViewPort = ViewPort (timingWidth * 0.8, 0) (timingWidth, timingHeight)
+          , sceneLocalViewPort = ViewPort (0, vy0) (300, vy1)
+          }
+  renderScene uiRef vb sceneMemChart'
+  -- timing range bar
+  let sceneTimingRange' =
+        sceneTimingRange
+          { sceneGlobalViewPort = ViewPort (0, timingHeight) (timingWidth, timingHeight + timingRangeHeight)
+          , sceneLocalViewPort = ViewPort (0, 0) (timingWidth, timingRangeHeight)
+          }
+  renderScene uiRef vb sceneTimingRange'
+  -- blocker lines
   for_ (tui ^. timingUIHoveredModule) $ \hoveredMod -> do
-    let rexpBlockers = compileBlockers hoveredMod ttable
-    traverse_ (renderPrimitive uiRef vb) rexpBlockers
-  R.restore
+    let sceneBlockers = compileBlockers hoveredMod ttable
+        ViewPort (vx0, vy0) (vx1, vy1) = sceneLocalViewPort sceneBlockers
+        w = vx1 - vx0
+        h = vy1 - vy0
+        offsetY = timingHeight + timingRangeHeight
+        sceneBlockers' =
+          sceneBlockers
+            { sceneGlobalViewPort = ViewPort (0, offsetY) (w, h + offsetY)
+            }
+    renderScene uiRef vb sceneBlockers'

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -88,7 +88,6 @@ import GHCSpecter.UI.Types.Event (
  )
 import GHCSpecter.Util.Transformation (
   hitItem,
-  isInside,
   transformScroll,
   transformZoom,
  )
@@ -291,9 +290,6 @@ goSession ev = do
 
 goModuleGraph :: Event -> Control ()
 goModuleGraph ev = do
-  -- printMsg $
-  --   "I am in goModuleGraph, " <> T.pack (show (model0 ^. modelTab)) <> ", " <> T.pack (show ev)
-
   case ev of
     MainModuleEv mev -> do
       modifyUISS $ \(ui, ss) ->
@@ -323,15 +319,9 @@ goModuleGraph ev = do
       ((ui, _), (ui', _)) <-
         modifyAndReturnBoth $ \(ui, ss) ->
           let model = ui ^. uiModel
-              -- rx = x / modGraphWidth
-              -- ry = y / modGraphHeight
-              -- ViewPort (x0, y0) (x1, y1) = ui ^. uiModel . modelMainModuleGraph . modGraphViewPort . vpViewPort
-              -- x' = x0 + (x1 - x0) * rx
-              -- y' = y0 + (y1 - y0) * ry
               emaps = ui ^. uiViewRaw . uiRawEventMap
               mprevHit = ui ^. uiModel . modelMainModuleGraph . modGraphUIHover
               mnowHit = listToMaybe $ mapMaybe (hitItem (x, y)) emaps
-              --   fst <$> L.find (\(_label, box) -> (x', y') `isInside` box) emap
               (ui', ss')
                 | mnowHit /= mprevHit =
                     let mev = HoverOnModuleEv mnowHit
@@ -503,15 +493,9 @@ goTiming ev = do
       ((ui, _), (ui', _)) <-
         modifyAndReturnBoth $ \(ui, ss) ->
           let
-            -- rx = x / timingWidth
-            -- ry = y / timingHeight
-            -- ViewPort (x0, y0) (x1, y1) = ui ^. uiModel . modelTiming . timingUIViewPort . vpViewPort
-            -- x' = x0 + (x1 - x0) * rx
-            -- y' = y0 + (y1 - y0) * ry
             emaps = ui ^. uiViewRaw . uiRawEventMap
             mprevHit = ui ^. uiModel . modelTiming . timingUIHoveredModule
             mnowHit = listToMaybe $ mapMaybe (hitItem (x, y)) emaps
-            --   fst <$> L.find (\(_label, box) -> (x', y') `isInside` box) emap
             ui'
               | mnowHit /= mprevHit =
                   (uiModel . modelTiming . timingUIHoveredModule .~ mnowHit) ui

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -327,7 +327,7 @@ goModuleGraph ev = do
               ViewPort (x0, y0) (x1, y1) = ui ^. uiModel . modelMainModuleGraph . modGraphViewPort . vpViewPort
               x' = x0 + (x1 - x0) * rx
               y' = y0 + (y1 - y0) * ry
-              emap = ui ^. uiViewRaw . uiRawEventBoxMap
+              emap = ui ^. uiViewRaw . uiRawEventMap
               mprevHit = ui ^. uiModel . modelMainModuleGraph . modGraphUIHover
               mnowHit = fst <$> L.find (\(_label, box) -> (x', y') `isInside` box) emap
               (ui', ss')
@@ -505,7 +505,7 @@ goTiming ev = do
               ViewPort (x0, y0) (x1, y1) = ui ^. uiModel . modelTiming . timingUIViewPort . vpViewPort
               x' = x0 + (x1 - x0) * rx
               y' = y0 + (y1 - y0) * ry
-              emap = ui ^. uiViewRaw . uiRawEventBoxMap
+              emap = ui ^. uiViewRaw . uiRawEventMap
               mprevHit = ui ^. uiModel . modelTiming . timingUIHoveredModule
               mnowHit = fst <$> L.find (\(_label, box) -> (x', y') `isInside` box) emap
               ui'

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -45,6 +45,7 @@ import GHCSpecter.Control.Types (
  )
 import GHCSpecter.Data.Map (alterToKeyMap, emptyKeyMap, forwardLookup)
 import GHCSpecter.Data.Timing.Types (HasTimingTable (..))
+import GHCSpecter.Graphics.DSL (ViewPort (..))
 import GHCSpecter.Server.Types (
   ConsoleItem (..),
   HasServerState (..),
@@ -70,7 +71,6 @@ import GHCSpecter.UI.Types (
   HasViewPortInfo (..),
   ModuleGraphUI (..),
   UIModel,
-  ViewPort (..),
   ViewPortInfo (..),
  )
 import GHCSpecter.UI.Types.Event (

--- a/daemon/src/GHCSpecter/Render/Components/TimingView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TimingView.hs
@@ -48,7 +48,12 @@ import GHCSpecter.Data.Timing.Types (
   TimingTable,
  )
 import GHCSpecter.Data.Timing.Util (isTimeInTimerRange)
-import GHCSpecter.Graphics.DSL (Color (..), Primitive (..), TextPosition (..))
+import GHCSpecter.Graphics.DSL (
+  Color (..),
+  Primitive (..),
+  TextPosition (..),
+  ViewPort (..),
+ )
 import GHCSpecter.Render.ConcurReplicaSVG (renderPrimitive)
 import GHCSpecter.Render.Util (divClass, xmlns)
 import GHCSpecter.UI.ConcurReplica.DOM (
@@ -74,7 +79,6 @@ import GHCSpecter.UI.Types (
   HasTimingUI (..),
   HasViewPortInfo (..),
   TimingUI,
-  ViewPort (..),
  )
 import GHCSpecter.UI.Types.Event (
   BackgroundEvent (RefreshUI),

--- a/daemon/src/GHCSpecter/Render/Components/TimingView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TimingView.hs
@@ -36,7 +36,6 @@ import Data.Time.Clock (
   nominalDiffTimeToSeconds,
   secondsToNominalDiffTime,
  )
-import Debug.Trace (trace)
 import GHCSpecter.Channel.Common.Types (DriverId, ModuleName)
 import GHCSpecter.Channel.Outbound.Types (MemInfo (..))
 import GHCSpecter.Data.Map (

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.UI.Types (
-  ViewPort (..),
   ModuleGraphUI (..),
   HasModuleGraphUI (..),
   emptyModuleGraphUI,
@@ -33,6 +32,7 @@ import Data.Time.Clock (UTCTime)
 import GHCSpecter.Channel.Common.Types (DriverId)
 import GHCSpecter.Data.Assets (Assets)
 import GHCSpecter.Data.Timing.Types (TimingTable)
+import GHCSpecter.Graphics.DSL (ViewPort (..))
 import GHCSpecter.UI.Constants (
   modGraphHeight,
   modGraphWidth,
@@ -40,12 +40,6 @@ import GHCSpecter.UI.Constants (
   timingWidth,
  )
 import GHCSpecter.UI.Types.Event (DetailLevel (..), Tab (..))
-
-data ViewPort = ViewPort
-  { topLeft :: (Double, Double)
-  , bottomRight :: (Double, Double)
-  }
-  deriving (Show)
 
 data ViewPortInfo = ViewPortInfo
   { _vpViewPort :: ViewPort
@@ -157,7 +151,7 @@ data UIViewRaw = UIViewRaw
   { _uiTransientBanner :: Maybe Double
   -- ^ progress bar status.
   -- TODO: This will be handled more properly with typed transition.
-  , _uiRawEventMap :: [(Text, ((Double, Double), (Double, Double)))]
+  , _uiRawEventMap :: [(Text, ViewPort)]
   -- ^ event name -> bounding box map
   }
 

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -157,7 +157,7 @@ data UIViewRaw = UIViewRaw
   { _uiTransientBanner :: Maybe Double
   -- ^ progress bar status.
   -- TODO: This will be handled more properly with typed transition.
-  , _uiRawEventBoxMap :: [(Text, ((Double, Double), (Double, Double)))]
+  , _uiRawEventMap :: [(Text, ((Double, Double), (Double, Double)))]
   -- ^ event name -> bounding box map
   }
 

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -32,7 +32,7 @@ import Data.Time.Clock (UTCTime)
 import GHCSpecter.Channel.Common.Types (DriverId)
 import GHCSpecter.Data.Assets (Assets)
 import GHCSpecter.Data.Timing.Types (TimingTable)
-import GHCSpecter.Graphics.DSL (ViewPort (..))
+import GHCSpecter.Graphics.DSL (EventMap (..), ViewPort (..))
 import GHCSpecter.UI.Constants (
   modGraphHeight,
   modGraphWidth,
@@ -151,7 +151,7 @@ data UIViewRaw = UIViewRaw
   { _uiTransientBanner :: Maybe Double
   -- ^ progress bar status.
   -- TODO: This will be handled more properly with typed transition.
-  , _uiRawEventMap :: [(Text, ViewPort)]
+  , _uiRawEventMap :: [EventMap]
   -- ^ event name -> bounding box map
   }
 

--- a/daemon/src/GHCSpecter/Util/Transformation.hs
+++ b/daemon/src/GHCSpecter/Util/Transformation.hs
@@ -7,7 +7,7 @@ module GHCSpecter.Util.Transformation (
   isInside,
 ) where
 
-import GHCSpecter.UI.Types (ViewPort (..))
+import GHCSpecter.Graphics.DSL (ViewPort (..))
 import GHCSpecter.UI.Types.Event (ScrollDirection (..))
 
 -- | scroll
@@ -41,6 +41,6 @@ transformZoom (rx, ry) scale (ViewPort (x0, y0) (x1, y1)) = ViewPort (x0', y0') 
     x1' = x + (x1 - x) / scale
     y1' = y + (y1 - y) / scale
 
-isInside :: (Double, Double) -> ((Double, Double), (Double, Double)) -> Bool
-isInside (x, y) ((x0, y0), (x1, y1)) =
+isInside :: (Double, Double) -> ViewPort -> Bool
+isInside (x, y) (ViewPort (x0, y0) (x1, y1)) =
   x >= x0 && x <= x1 && y >= y0 && y <= y1

--- a/daemon/src/GHCSpecter/Util/Transformation.hs
+++ b/daemon/src/GHCSpecter/Util/Transformation.hs
@@ -58,9 +58,7 @@ hitItem (x, y) emap
   where
     cvp@(ViewPort (cx0, cy0) (cx1, cy1)) = eventMapGlobalViewPort emap
     ViewPort (vx0, vy0) (vx1, vy1) = eventMapLocalViewPort emap
-    -- scaleX = (cx1 - cx0) / (vx1 - vx0)
-    -- scaleY = (cy1 - cy0) / (vy1 - vy0)
     rx = (x - cx0) / (cx1 - cx0)
-    ry = (y - cy0) / (cy1 - cy1)
+    ry = (y - cy0) / (cy1 - cy0)
     vx = vx0 + rx * (vx1 - vx0)
     vy = vy0 + ry * (vy1 - vy0)

--- a/render/src/GHCSpecter/Graphics/DSL.hs
+++ b/render/src/GHCSpecter/Graphics/DSL.hs
@@ -3,10 +3,10 @@ module GHCSpecter.Graphics.DSL (
   Color (..),
   TextPosition (..),
 
-  -- * graphics primitive and group elements
+  -- * graphics primitives
   Primitive (..),
-  Group (..),
   ViewPort (..),
+  Scene (..),
 ) where
 
 import Data.Text (Text)
@@ -46,15 +46,15 @@ data Primitive
     DrawText (Double, Double) TextPosition Color Int Text
   deriving (Show)
 
--- canvas coordinate to the scene
-data Group = Group
-  { groupFromCanvasCoordinate :: (Double, Double) -> (Double, Double)
-  , groupToCanvasCoordinate :: (Double, Double) -> (Double, Double)
-  , groupElements :: [Primitive]
-  }
-
 data ViewPort = ViewPort
   { topLeft :: (Double, Double)
   , bottomRight :: (Double, Double)
   }
   deriving (Show)
+
+-- scene has local view port matched with global canvas
+data Scene = Scene
+  { sceneGlobalViewPort :: ViewPort
+  , sceneLocalViewPort :: ViewPort
+  , sceneElements :: [Primitive]
+  }

--- a/render/src/GHCSpecter/Graphics/DSL.hs
+++ b/render/src/GHCSpecter/Graphics/DSL.hs
@@ -6,6 +6,7 @@ module GHCSpecter.Graphics.DSL (
   -- * graphics primitive and group elements
   Primitive (..),
   Group (..),
+  ViewPort (..),
 ) where
 
 import Data.Text (Text)
@@ -51,3 +52,9 @@ data Group = Group
   , groupToCanvasCoordinate :: (Double, Double) -> (Double, Double)
   , groupElements :: [Primitive]
   }
+
+data ViewPort = ViewPort
+  { topLeft :: (Double, Double)
+  , bottomRight :: (Double, Double)
+  }
+  deriving (Show)

--- a/render/src/GHCSpecter/Graphics/DSL.hs
+++ b/render/src/GHCSpecter/Graphics/DSL.hs
@@ -7,6 +7,9 @@ module GHCSpecter.Graphics.DSL (
   Primitive (..),
   ViewPort (..),
   Scene (..),
+
+  -- * event primitives
+  EventMap (..),
 ) where
 
 import Data.Text (Text)
@@ -57,4 +60,10 @@ data Scene = Scene
   { sceneGlobalViewPort :: ViewPort
   , sceneLocalViewPort :: ViewPort
   , sceneElements :: [Primitive]
+  }
+
+data EventMap = EventMap
+  { eventMapGlobalViewPort :: ViewPort
+  , eventMapLocalViewPort :: ViewPort
+  , eventMapElements :: [(Text, ViewPort)]
   }

--- a/render/src/GHCSpecter/Graphics/DSL.hs
+++ b/render/src/GHCSpecter/Graphics/DSL.hs
@@ -61,9 +61,11 @@ data Scene = Scene
   , sceneLocalViewPort :: ViewPort
   , sceneElements :: [Primitive]
   }
+  deriving (Show)
 
 data EventMap = EventMap
   { eventMapGlobalViewPort :: ViewPort
   , eventMapLocalViewPort :: ViewPort
   , eventMapElements :: [(Text, ViewPort)]
   }
+  deriving (Show)


### PR DESCRIPTION
By introducing Scene with local and global view port information, the corresponding coordinate transformations needed for event to hit items are done properly. 