### PR TITLE
Config module cluster size per project

### DIFF
--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -80,6 +80,10 @@ updateInbox chanMsg = incrementSN . updater
          in (serverTiming . tsTimingMap %~ alterToKeyMap f drvId)
       CMBox (CMSession s') ->
         (serverSessionInfo .~ s')
+          . ( case sessionPreferredModuleClusterSize s' of
+                Nothing -> id
+                Just size -> (serverModuleClusterSize .~ size)
+            )
       CMBox (CMModuleGraph mgi _msrcs) ->
         (serverModuleGraphState . mgsModuleGraphInfo .~ mgi)
       CMBox (CMHsHie _ _) ->

--- a/plugin/src-ghc92/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc92/Plugin/GHCSpecter/Init.hs
@@ -93,6 +93,7 @@ initGhcSession env = do
                   , sessionBackend = backend
                   , sessionStartTime = Just startTime
                   , sessionIsPaused = configStartWithBreakpoint cfg
+                  , sessionPreferredModuleClusterSize = Just (configModuleClusterSize cfg)
                   }
           modifyTVar'
             sessionRef

--- a/plugin/src-ghc94/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc94/Plugin/GHCSpecter/Init.hs
@@ -94,6 +94,7 @@ initGhcSession env = do
                   , sessionBackend = backend
                   , sessionStartTime = Just startTime
                   , sessionIsPaused = configStartWithBreakpoint cfg
+                  , sessionPreferredModuleClusterSize = Just (configModuleClusterSize cfg)
                   }
           modifyTVar'
             sessionRef

--- a/plugin/src-ghc96/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter/Init.hs
@@ -93,6 +93,7 @@ initGhcSession env = do
                   , sessionBackend = backend
                   , sessionStartTime = Just startTime
                   , sessionIsPaused = configStartWithBreakpoint cfg
+                  , sessionPreferredModuleClusterSize = Just (configModuleClusterSize cfg)
                   }
           modifyTVar'
             sessionRef

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -204,6 +204,7 @@ data SessionInfo = SessionInfo
   , sessionBackend :: Backend
   , sessionStartTime :: Maybe UTCTime
   , sessionIsPaused :: Bool
+  , sessionPreferredModuleClusterSize :: Maybe Int
   }
   deriving (Show, Generic)
 
@@ -221,6 +222,7 @@ emptySessionInfo =
     , sessionBackend = NCG
     , sessionStartTime = Nothing
     , sessionIsPaused = True
+    , sessionPreferredModuleClusterSize = Nothing
     }
 
 data ChanMessage (a :: Channel) where


### PR DESCRIPTION
And it overrides default cluster size which is specified when daemon starts.