### PR TITLE
Wrap Render monad and low-level event

### DIFF
--- a/daemon-exp/app/ghc-specter-daemon-exp/Render/Common.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Render/Common.hs
@@ -1,23 +1,34 @@
 module Render.Common (
+  hruleTop,
   vruleLeft,
   boxRules,
 ) where
 
+import Control.Monad.Trans.Class (lift)
 import GHCSpecter.Graphics.DSL (
   ViewPort (..),
  )
 import GI.Cairo.Render qualified as R
+import Types (GtkRender)
 
-vruleLeft :: ViewPort -> R.Render ()
-vruleLeft (ViewPort (cx0, cy0) (_cx1, cy1)) = do
+hruleTop :: ViewPort -> GtkRender ()
+hruleTop (ViewPort (cx0, cy0) (cx1, _)) = lift $ do
+  R.setSourceRGBA 0 0 0 1
+  R.setLineWidth 1.0
+  R.moveTo cx0 cy0
+  R.lineTo cx1 cy0
+  R.stroke
+
+vruleLeft :: ViewPort -> GtkRender ()
+vruleLeft (ViewPort (cx0, cy0) (_cx1, cy1)) = lift $ do
   R.setSourceRGBA 0 0 0 1
   R.setLineWidth 1.0
   R.moveTo cx0 cy0
   R.lineTo cx0 cy1
   R.stroke
 
-boxRules :: ViewPort -> R.Render ()
-boxRules (ViewPort (cx0, cy0) (cx1, cy1)) = do
+boxRules :: ViewPort -> GtkRender ()
+boxRules (ViewPort (cx0, cy0) (cx1, cy1)) = lift $ do
   R.setSourceRGBA 0 0 0 1
   R.setLineWidth 1.0
   R.rectangle cx0 cy0 (cx1 - cx0) (cy1 - cy0)

--- a/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
@@ -89,7 +89,7 @@ setColor ColorRedLevel3 = lift $ R.setSourceRGBA 0.961 0.718 0.694 1 -- F5B7B1
 setColor ColorRedLevel4 = lift $ R.setSourceRGBA 0.945 0.580 0.541 1 -- F1948A
 setColor ColorRedLevel5 = lift $ R.setSourceRGBA 0.925 0.439 0.388 1 -- EC7063
 
-renderPrimitive :: Primitive -> GtkRender ()
+renderPrimitive :: Primitive e -> GtkRender ()
 renderPrimitive (Rectangle (x, y) w h mline mbkg mlwidth _mname) = do
   for_ mbkg $ \bkg -> do
     setColor bkg
@@ -117,7 +117,7 @@ renderPrimitive (DrawText (x, y) pos fontFace color fontSize msg) = do
   setColor color
   drawText fontFace (fromIntegral fontSize) (x, y') msg
 
-renderScene :: Scene -> GtkRender ()
+renderScene :: Scene Text -> GtkRender ()
 renderScene scene = do
   let ViewPort (cx0, cy0) (cx1, cy1) = sceneGlobalViewPort scene
       ViewPort (vx0, vy0) (vx1, vy1) = sceneLocalViewPort scene
@@ -145,7 +145,7 @@ resetWidget = do
       TabSourceView -> pure (model ^. modelWidgetConfig . wcfgSourceView)
       TabTiming -> pure (model ^. modelWidgetConfig . wcfgTiming)
 
-addEventMap :: Scene -> GtkRender ()
+addEventMap :: Scene Text -> GtkRender ()
 addEventMap scene = do
   uiRef <- (^. _2) <$> ask
   let extractEvent (Rectangle (x, y) w h _ _ _ (Just hitEvent)) =

--- a/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
@@ -139,7 +139,8 @@ resetWidget uiRef = do
 
 addEventMap :: TVar UIState -> Scene -> IO ()
 addEventMap uiRef scene = do
-  let extractEvent (Rectangle (x, y) w h _ _ _ (Just name)) = Just (name, ViewPort (x, y) (x + w, y + h))
+  let extractEvent (Rectangle (x, y) w h _ _ _ (Just hitEvent)) =
+        Just (hitEvent, ViewPort (x, y) (x + w, y + h))
       extractEvent _ = Nothing
       eitms = mapMaybe extractEvent (sceneElements scene)
       emap =

--- a/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Renderer.hs
@@ -15,12 +15,14 @@ module Renderer (
 ) where
 
 import Control.Concurrent.STM (
-  TVar,
   atomically,
   modifyTVar',
   readTVar,
  )
-import Control.Lens ((%~), (.~), (^.))
+import Control.Lens ((%~), (.~), (^.), _1, _2)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Reader (ask)
 import Data.Foldable (for_, traverse_)
 import Data.Int (Int32)
 import Data.Map (Map)
@@ -40,95 +42,101 @@ import GHCSpecter.UI.Types (
   HasUIState (..),
   HasUIViewRaw (..),
   HasWidgetConfig (..),
-  UIState,
  )
 import GHCSpecter.UI.Types.Event (Tab (..))
 import GI.Cairo.Render qualified as R
 import GI.Cairo.Render.Connector qualified as RC
 import GI.Pango qualified as P
 import GI.PangoCairo qualified as PC
-import Types (ViewBackend (..))
+import Types (GtkRender, ViewBackend (..))
 
-drawText :: ViewBackend -> TextFontFace -> Int32 -> (Double, Double) -> Text -> R.Render ()
-drawText vb face sz (x, y) msg = do
+drawText :: TextFontFace -> Int32 -> (Double, Double) -> Text -> GtkRender ()
+drawText face sz (x, y) msg = do
+  vb <- (^. _1) <$> ask
   let pangoCtxt = vbPangoContext vb
       desc = case face of
         Sans -> vbFontDescSans vb
         Mono -> vbFontDescMono vb
-  layout :: P.Layout <- P.layoutNew pangoCtxt
-  #setSize desc (sz * P.SCALE)
-  #setFontDescription layout (Just desc)
-  #setText layout msg (-1)
-  R.moveTo x y
-  ctxt <- RC.getContext
-  PC.showLayout ctxt layout
+  lift $ do
+    layout :: P.Layout <- P.layoutNew pangoCtxt
+    #setSize desc (sz * P.SCALE)
+    #setFontDescription layout (Just desc)
+    #setText layout msg (-1)
+    R.moveTo x y
+    ctxt <- RC.getContext
+    PC.showLayout ctxt layout
 
-setColor :: Color -> R.Render ()
-setColor Black = R.setSourceRGBA 0 0 0 1
-setColor White = R.setSourceRGBA 1 1 1 1
-setColor Red = R.setSourceRGBA 1 0 0 1
-setColor Blue = R.setSourceRGBA 0 0 1 1
-setColor Green = R.setSourceRGBA 0 0.5 0 1
-setColor Yellow = R.setSourceRGBA 1.0 1.0 0 1
-setColor Gray = R.setSourceRGBA 0.5 0.5 0.5 1
-setColor Orange = R.setSourceRGBA 1.0 0.647 0 1 -- FFA500
-setColor HoneyDew = R.setSourceRGBA 0.941 1.0 0.941 1 -- F0FFF0
-setColor Ivory = R.setSourceRGBA 1.0 1.0 0.941 1 -- FFFFF0
-setColor DimGray = R.setSourceRGBA 0.412 0.412 0.412 1 -- 696969
-setColor LightGray = R.setSourceRGBA 0.827 0.827 0.827 1 -- D3D3D3
-setColor LightSlateGray = R.setSourceRGBA 0.467 0.533 0.6 1 -- 778899
-setColor RoyalBlue = R.setSourceRGBA 0.255 0.412 0.882 1 -- 4169E1
-setColor DeepSkyBlue = R.setSourceRGBA 0 0.749 1.0 1 -- 00BFFF
-setColor ColorRedLevel0 = R.setSourceRGBA 1 1 1 1 -- FFFFFF
-setColor ColorRedLevel1 = R.setSourceRGBA 0.992 0.929 0.925 1 -- FDEDEC
-setColor ColorRedLevel2 = R.setSourceRGBA 0.980 0.859 0.847 1 -- FADBD8
-setColor ColorRedLevel3 = R.setSourceRGBA 0.961 0.718 0.694 1 -- F5B7B1
-setColor ColorRedLevel4 = R.setSourceRGBA 0.945 0.580 0.541 1 -- F1948A
-setColor ColorRedLevel5 = R.setSourceRGBA 0.925 0.439 0.388 1 -- EC7063
+setColor :: Color -> GtkRender ()
+setColor Black = lift $ R.setSourceRGBA 0 0 0 1
+setColor White = lift $ R.setSourceRGBA 1 1 1 1
+setColor Red = lift $ R.setSourceRGBA 1 0 0 1
+setColor Blue = lift $ R.setSourceRGBA 0 0 1 1
+setColor Green = lift $ R.setSourceRGBA 0 0.5 0 1
+setColor Yellow = lift $ R.setSourceRGBA 1.0 1.0 0 1
+setColor Gray = lift $ R.setSourceRGBA 0.5 0.5 0.5 1
+setColor Orange = lift $ R.setSourceRGBA 1.0 0.647 0 1 -- FFA500
+setColor HoneyDew = lift $ R.setSourceRGBA 0.941 1.0 0.941 1 -- F0FFF0
+setColor Ivory = lift $ R.setSourceRGBA 1.0 1.0 0.941 1 -- FFFFF0
+setColor DimGray = lift $ R.setSourceRGBA 0.412 0.412 0.412 1 -- 696969
+setColor LightGray = lift $ R.setSourceRGBA 0.827 0.827 0.827 1 -- D3D3D3
+setColor LightSlateGray = lift $ R.setSourceRGBA 0.467 0.533 0.6 1 -- 778899
+setColor RoyalBlue = lift $ R.setSourceRGBA 0.255 0.412 0.882 1 -- 4169E1
+setColor DeepSkyBlue = lift $ R.setSourceRGBA 0 0.749 1.0 1 -- 00BFFF
+setColor ColorRedLevel0 = lift $ R.setSourceRGBA 1 1 1 1 -- FFFFFF
+setColor ColorRedLevel1 = lift $ R.setSourceRGBA 0.992 0.929 0.925 1 -- FDEDEC
+setColor ColorRedLevel2 = lift $ R.setSourceRGBA 0.980 0.859 0.847 1 -- FADBD8
+setColor ColorRedLevel3 = lift $ R.setSourceRGBA 0.961 0.718 0.694 1 -- F5B7B1
+setColor ColorRedLevel4 = lift $ R.setSourceRGBA 0.945 0.580 0.541 1 -- F1948A
+setColor ColorRedLevel5 = lift $ R.setSourceRGBA 0.925 0.439 0.388 1 -- EC7063
 
-renderPrimitive :: ViewBackend -> Primitive -> R.Render ()
-renderPrimitive _ (Rectangle (x, y) w h mline mbkg mlwidth _mname) = do
+renderPrimitive :: Primitive -> GtkRender ()
+renderPrimitive (Rectangle (x, y) w h mline mbkg mlwidth _mname) = do
   for_ mbkg $ \bkg -> do
     setColor bkg
-    R.rectangle x y w h
-    R.fill
+    lift $ do
+      R.rectangle x y w h
+      R.fill
   for_ ((,) <$> mline <*> mlwidth) $ \(line, lwidth) -> do
     setColor line
-    R.setLineWidth lwidth
-    R.rectangle x y w h
-    R.stroke
-renderPrimitive _ (Polyline start xys end line width) = do
+    lift $ do
+      R.setLineWidth lwidth
+      R.rectangle x y w h
+      R.stroke
+renderPrimitive (Polyline start xys end line width) = do
   setColor line
-  R.setLineWidth width
-  uncurry R.moveTo start
-  traverse_ (uncurry R.lineTo) xys
-  uncurry R.lineTo end
-  R.stroke
-renderPrimitive vb (DrawText (x, y) pos fontFace color fontSize msg) = do
+  lift $ do
+    R.setLineWidth width
+    uncurry R.moveTo start
+    traverse_ (uncurry R.lineTo) xys
+    uncurry R.lineTo end
+    R.stroke
+renderPrimitive (DrawText (x, y) pos fontFace color fontSize msg) = do
   let y' = case pos of
         UpperLeft -> y
         LowerLeft -> y - fromIntegral fontSize - 1
   setColor color
-  drawText vb fontFace (fromIntegral fontSize) (x, y') msg
+  drawText fontFace (fromIntegral fontSize) (x, y') msg
 
-renderScene :: ViewBackend -> Scene -> R.Render ()
-renderScene vb scene = do
+renderScene :: Scene -> GtkRender ()
+renderScene scene = do
   let ViewPort (cx0, cy0) (cx1, cy1) = sceneGlobalViewPort scene
       ViewPort (vx0, vy0) (vx1, vy1) = sceneLocalViewPort scene
       scaleX = (cx1 - cx0) / (vx1 - vx0)
       scaleY = (cy1 - cy0) / (vy1 - vy0)
-  R.save
-  R.rectangle cx0 cy0 (cx1 - cx0) (cy1 - cy0)
-  R.clip
-  R.translate cx0 cy0
-  R.scale scaleX scaleY
-  R.translate (-vx0) (-vy0)
-  traverse_ (renderPrimitive vb) (sceneElements scene)
-  R.restore
+  lift $ do
+    R.save
+    R.rectangle cx0 cy0 (cx1 - cx0) (cy1 - cy0)
+    R.clip
+    R.translate cx0 cy0
+    R.scale scaleX scaleY
+    R.translate (-vx0) (-vy0)
+  traverse_ renderPrimitive (sceneElements scene)
+  lift R.restore
 
-resetWidget :: TVar UIState -> IO (Map Text ViewPort)
-resetWidget uiRef = do
-  atomically $ do
+resetWidget :: GtkRender (Map Text ViewPort)
+resetWidget = do
+  uiRef <- (^. _2) <$> ask
+  liftIO $ atomically $ do
     modifyTVar' uiRef (uiViewRaw . uiRawEventMap .~ [])
     model <- (^. uiModel) <$> readTVar uiRef
     case model ^. modelTab of
@@ -137,8 +145,9 @@ resetWidget uiRef = do
       TabSourceView -> pure (model ^. modelWidgetConfig . wcfgSourceView)
       TabTiming -> pure (model ^. modelWidgetConfig . wcfgTiming)
 
-addEventMap :: TVar UIState -> Scene -> IO ()
-addEventMap uiRef scene = do
+addEventMap :: Scene -> GtkRender ()
+addEventMap scene = do
+  uiRef <- (^. _2) <$> ask
   let extractEvent (Rectangle (x, y) w h _ _ _ (Just hitEvent)) =
         Just (hitEvent, ViewPort (x, y) (x + w, y + h))
       extractEvent _ = Nothing
@@ -150,6 +159,7 @@ addEventMap uiRef scene = do
           , eventMapLocalViewPort = sceneLocalViewPort scene
           , eventMapElements = eitms
           }
-  atomically $
-    modifyTVar' uiRef $
-      uiViewRaw . uiRawEventMap %~ (\emaps -> emap : emaps)
+  liftIO $
+    atomically $
+      modifyTVar' uiRef $
+        uiViewRaw . uiRawEventMap %~ (\emaps -> emap : emaps)

--- a/daemon-exp/app/ghc-specter-daemon-exp/Types.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Types.hs
@@ -1,7 +1,12 @@
 module Types (
   ViewBackend (..),
+  GtkRender,
 ) where
 
+import Control.Concurrent.STM (TVar)
+import Control.Monad.Trans.Reader (ReaderT)
+import GHCSpecter.UI.Types (UIState)
+import GI.Cairo.Render qualified as R
 import GI.Pango qualified as P
 
 data ViewBackend = ViewBackend
@@ -9,3 +14,5 @@ data ViewBackend = ViewBackend
   , vbFontDescSans :: P.FontDescription
   , vbFontDescMono :: P.FontDescription
   }
+
+type GtkRender = ReaderT (ViewBackend, TVar UIState) R.Render

--- a/daemon-exp/ghc-specter-daemon-exp.cabal
+++ b/daemon-exp/ghc-specter-daemon-exp.cabal
@@ -52,5 +52,6 @@ executable ghc-specter-daemon-exp
                  lens,
                  stm,
                  text,
+                 transformers,
                  time
   default-language: GHC2021

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -205,7 +205,7 @@ appendNewCommand drvId newMsg = do
         ss' = ss & (serverConsole %~ alterToKeyMap append drvId)
      in ss'
 
-scroll :: EventMap -> Lens' UIModel ViewPortInfo -> (ScrollDirection, (Double, Double)) -> UIModel -> UIModel
+scroll :: EventMap Text -> Lens' UIModel ViewPortInfo -> (ScrollDirection, (Double, Double)) -> UIModel -> UIModel
 scroll emap lensViewPort (dir, (dx, dy)) model =
   let ViewPort (cx0, _) (cx1, _) = eventMapGlobalViewPort emap
       vp@(ViewPort (vx0, _) (vx1, _)) = model ^. lensViewPort ^. vpViewPort
@@ -213,7 +213,7 @@ scroll emap lensViewPort (dir, (dx, dy)) model =
       vp' = transformScroll dir scale (dx, dy) vp
    in (lensViewPort .~ ViewPortInfo vp' Nothing) model
 
-zoom :: EventMap -> Lens' UIModel ViewPortInfo -> ((Double, Double), Double) -> UIModel -> UIModel
+zoom :: EventMap Text -> Lens' UIModel ViewPortInfo -> ((Double, Double), Double) -> UIModel -> UIModel
 zoom emap lensViewPort ((x, y), scale) model =
   let ViewPort (cx0, cy0) (cx1, cy1) = eventMapGlobalViewPort emap
       -- NOTE: While zooming is in progress, the scaling is always relative to

--- a/daemon/src/GHCSpecter/Render/Components/GraphView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GraphView.hs
@@ -64,7 +64,7 @@ compileModuleGraph ::
   GraphVisInfo ->
   -- | (focused (clicked), hinted (hovered))
   (Maybe Text, Maybe Text) ->
-  Scene
+  Scene Text
 compileModuleGraph
   nameMap
   valueFor
@@ -131,7 +131,7 @@ compileModuleGraph
           }
 
 -- | compile graph more simply to graphics DSL
-compileGraph :: (Text -> Bool) -> GraphVisInfo -> [Primitive]
+compileGraph :: (Text -> Bool) -> GraphVisInfo -> [Primitive Text]
 compileGraph cond grVisInfo =
   let Dim canvasWidth canvasHeight = grVisInfo ^. gviCanvasDim
       nodeLayoutMap =

--- a/daemon/src/GHCSpecter/Render/Components/GraphView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/GraphView.hs
@@ -39,6 +39,7 @@ import GHCSpecter.GraphLayout.Types (
  )
 import GHCSpecter.Graphics.DSL (
   Color (..),
+  HitEvent (..),
   Primitive (..),
   Scene (..),
   TextFontFace (..),
@@ -109,7 +110,12 @@ compileModuleGraph
                 | Just name == mfocused = Orange
                 | Just name == mhinted = HoneyDew
                 | otherwise = Ivory
-           in [ Rectangle (x + offX, y + h * offYFactor + h - 6) (w * aFactor) 13 (Just DimGray) (Just color1) (Just 0.8) (Just name)
+              hitEvent =
+                HitEvent
+                  { hitEventHover = Just name
+                  , hitEventClick = (False, Just name)
+                  }
+           in [ Rectangle (x + offX, y + h * offYFactor + h - 6) (w * aFactor) 13 (Just DimGray) (Just color1) (Just 0.8) (Just hitEvent)
               , Rectangle (x + offX, y + h * offYFactor + h + 3) (w * aFactor) 4 (Just Black) (Just White) (Just 0.8) Nothing
               , Rectangle (x + offX, y + h * offYFactor + h + 3) (w' * aFactor) 4 Nothing (Just Blue) Nothing Nothing
               , DrawText (x + offX + 2, y + h * offYFactor + h) LowerLeft Mono Black fontSize name

--- a/daemon/src/GHCSpecter/Render/Components/ModuleTree.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ModuleTree.hs
@@ -46,7 +46,7 @@ expandableText isBordered isExpandable txt =
         | otherwise = txt
    in txt'
 
-compileModuleTree :: SourceViewUI -> ServerState -> Scene
+compileModuleTree :: SourceViewUI -> ServerState -> Scene Text
 compileModuleTree srcUI ss =
   Scene
     { sceneId = "module-tree"
@@ -81,7 +81,7 @@ compileModuleTree srcUI ss =
 
     indentLevel = flatten . foldTree annotateLevel . fmap renderNode
 
-    render :: (Int, (Int, (Bool, Color, ModuleName, Text))) -> [Primitive]
+    render :: (Int, (Int, (Bool, Color, ModuleName, Text))) -> [Primitive Text]
     render (i, (j, (matched, color, modu, txt))) =
       let x = fromIntegral j * 20
           y = fromIntegral i * 14

--- a/daemon/src/GHCSpecter/Render/Components/ModuleTree.hs
+++ b/daemon/src/GHCSpecter/Render/Components/ModuleTree.hs
@@ -15,6 +15,7 @@ import GHCSpecter.Channel.Common.Types (type ModuleName)
 import GHCSpecter.Data.Timing.Util (isModuleCompilationDone)
 import GHCSpecter.Graphics.DSL (
   Color (..),
+  HitEvent (..),
   Primitive (..),
   Scene (..),
   TextFontFace (..),
@@ -84,16 +85,21 @@ compileModuleTree srcUI ss =
     render (i, (j, (matched, color, modu, txt))) =
       let x = fromIntegral j * 20
           y = fromIntegral i * 14
-       in if matched
-            then
-              [ Rectangle (x, y) 100 10 Nothing (Just Gray) Nothing (Just ("Unsele_" <> modu))
-              , DrawText (x, y) UpperLeft Sans color 8 txt
-              ]
-            else -- TODO: we use ugly unsafe Select_ and Unsele_ prefix here. We will introduce
-            -- proper typing mechanism later on.
-
-              [ Rectangle (x, y) 100 10 Nothing (Just White) Nothing (Just ("Select_" <> modu))
-              , DrawText (x, y) UpperLeft Sans color 8 txt
-              ]
-
+          colorBox
+            | matched = Just Gray
+            | otherwise = Just White
+          hitEvent
+            | matched =
+                HitEvent
+                  { hitEventHover = Nothing
+                  , hitEventClick = (True, Just modu)
+                  }
+            | otherwise =
+                HitEvent
+                  { hitEventHover = Nothing
+                  , hitEventClick = (False, Just modu)
+                  }
+       in [ Rectangle (x, y) 100 10 Nothing colorBox Nothing (Just hitEvent)
+          , DrawText (x, y) UpperLeft Sans color 8 txt
+          ]
     contents = concatMap render $ zip [0 ..] (concatMap indentLevel displayedForest')

--- a/daemon/src/GHCSpecter/Render/Components/Tab.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Tab.hs
@@ -24,7 +24,7 @@ data TabConfig a = TabConfig
   , tabCfgItems :: [(a, Text)]
   }
 
-compileTab :: (Eq a, Show a) => TabConfig a -> Maybe a -> Scene
+compileTab :: (Eq a, Show a) => TabConfig a -> Maybe a -> Scene Text
 compileTab cfg mtab =
   Scene
     { sceneId = tabCfgId cfg

--- a/daemon/src/GHCSpecter/Render/Components/Tab.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Tab.hs
@@ -8,6 +8,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import GHCSpecter.Graphics.DSL (
   Color (..),
+  HitEvent (..),
   Primitive (..),
   Scene (..),
   TextFontFace (..),
@@ -45,7 +46,13 @@ compileTab cfg mtab =
     fontSize = 8
     mkTab (n, (t, txt)) =
       let x = tabPos n
-       in [ Rectangle (x, 2) 80 (height - 2) Nothing (Just White) Nothing (Just (T.pack (show t)))
+          hitEvent =
+            HitEvent
+              { hitEventHover = Nothing
+              , hitEventClick =
+                  (False, Just (T.pack (show t)))
+              }
+       in [ Rectangle (x, 2) 80 (height - 2) Nothing (Just White) Nothing (Just hitEvent)
           , DrawText (x, 2) UpperLeft Sans Black fontSize txt
           ]
     mkLine (Just (n, _)) =

--- a/daemon/src/GHCSpecter/Render/Components/TextView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TextView.hs
@@ -60,7 +60,7 @@ leftOfBox j = charSize * fromIntegral (j - 1)
 rightOfBox :: Int -> Double
 rightOfBox j = charSize * fromIntegral j
 
-compileTextView :: Text -> [((Int, Int), (Int, Int))] -> Scene
+compileTextView :: Text -> [((Int, Int), (Int, Int))] -> Scene Text
 compileTextView txt highlighted =
   Scene
     { sceneId = "text-view"

--- a/daemon/src/GHCSpecter/Render/Components/TimingView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TimingView.hs
@@ -50,6 +50,7 @@ import GHCSpecter.Data.Timing.Types (
 import GHCSpecter.Data.Timing.Util (isTimeInTimerRange)
 import GHCSpecter.Graphics.DSL (
   Color (..),
+  HitEvent (..),
   Primitive (..),
   Scene (..),
   TextFontFace (..),
@@ -208,6 +209,13 @@ compileTimingChart drvModMap tui ttable =
       let highlighter
             | mmodu == mhoveredMod = (Just Orange, Just 0.5)
             | otherwise = (Nothing, Nothing)
+          mhitEvent = do
+            modu <- mmodu
+            pure
+              HitEvent
+                { hitEventHover = Just modu
+                , hitEventClick = (False, Nothing)
+                }
        in Rectangle
             (leftOfBox item, module2Y i)
             (widthOfBox item)
@@ -215,7 +223,7 @@ compileTimingChart drvModMap tui ttable =
             (highlighter ^. _1)
             (Just LightSlateGray)
             (highlighter ^. _2)
-            mmodu
+            mhitEvent
     boxHscOut (i, item) =
       Rectangle
         (leftOfBox item, module2Y i)
@@ -407,9 +415,9 @@ compileBlockers hoveredMod ttable =
     --
     placing !offset item =
       case item of
-        DrawText (x, y) p ff c fs t ->
+        DrawText (x, y) p' ff c fs t ->
           let doffset = fromIntegral fs + 4
-           in (offset + doffset, DrawText (x, y + offset) p ff c fs t)
+           in (offset + doffset, DrawText (x, y + offset) p' ff c fs t)
         Polyline (x0, y0) [] (x1, y1) c w ->
           let doffset = 5
            in (offset + doffset, Polyline (x0, y0 + offset + 3) [] (x1, y1 + offset + 3) c w)

--- a/daemon/src/GHCSpecter/Render/Components/TimingView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TimingView.hs
@@ -30,6 +30,7 @@ import Control.Monad (join)
 import Data.List qualified as L
 import Data.Map.Strict qualified as M
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
+import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time.Clock (
   NominalDiffTime,
@@ -118,7 +119,7 @@ compileRules ::
   TimingTable ->
   Int ->
   NominalDiffTime ->
-  [Primitive]
+  [Primitive Text]
 compileRules showParallel table totalHeight totalTime =
   ( if showParallel
       then fmap box rangesWithCPUUsage
@@ -164,7 +165,7 @@ compileTimingChart ::
   BiKeyMap DriverId ModuleName ->
   TimingUI ->
   TimingTable ->
-  Scene
+  Scene Text
 compileTimingChart drvModMap tui ttable =
   Scene
     { sceneId = "timing-chart"
@@ -278,7 +279,7 @@ compileTimingChart drvModMap tui ttable =
           mkLine hoveredMod upMod
     linesToDownstream = maybe [] (fromMaybe [] . mkLinesToDownstream) mhoveredMod
       where
-        mkLinesToDownstream :: ModuleName -> Maybe [Primitive]
+        mkLinesToDownstream :: ModuleName -> Maybe [Primitive Text]
         mkLinesToDownstream hoveredMod = do
           downMods <-
             M.lookup hoveredMod (ttable ^. ttableBlockedDownstreamDependency)
@@ -288,7 +289,7 @@ compileMemChart ::
   BiKeyMap DriverId ModuleName ->
   TimingUI ->
   TimingTable ->
-  Scene
+  Scene Text
 compileMemChart drvModMap tui ttable =
   Scene
     { sceneId = "mem-chart"
@@ -345,7 +346,7 @@ compileMemChart drvModMap tui ttable =
 compileTimingRange ::
   TimingUI ->
   TimingTable ->
-  Scene
+  Scene Text
 compileTimingRange tui ttable =
   Scene
     { sceneId = "timing-range"
@@ -392,7 +393,7 @@ compileTimingRange tui ttable =
         (Just 1.0)
         Nothing
 
-compileBlockers :: ModuleName -> TimingTable -> Scene
+compileBlockers :: ModuleName -> TimingTable -> Scene Text
 compileBlockers hoveredMod ttable =
   Scene
     { sceneId = "blockers"

--- a/daemon/src/GHCSpecter/Render/ConcurReplicaSVG.hs
+++ b/daemon/src/GHCSpecter/Render/ConcurReplicaSVG.hs
@@ -57,7 +57,7 @@ renderColor ColorRedLevel3 = "#F5B7B1"
 renderColor ColorRedLevel4 = "#F1948A"
 renderColor ColorRedLevel5 = "#EC7063"
 
-renderPrimitive :: (Text -> [Props ev]) -> Primitive -> Widget IHTML ev
+renderPrimitive :: (Text -> [Props ev]) -> Primitive Text -> Widget IHTML ev
 renderPrimitive handlers (Rectangle (x, y) w h mline mbkg mlwidth mhitEvent) =
   S.rect
     ( maybe [] handlers (hitEventHover =<< mhitEvent)

--- a/daemon/src/GHCSpecter/Render/ConcurReplicaSVG.hs
+++ b/daemon/src/GHCSpecter/Render/ConcurReplicaSVG.hs
@@ -17,7 +17,11 @@ import Concur.Replica.SVG.Props qualified as SP
 import Data.Maybe (isJust)
 import Data.Text (Text)
 import Data.Text qualified as T
-import GHCSpecter.Graphics.DSL (Color (..), Primitive (..))
+import GHCSpecter.Graphics.DSL (
+  Color (..),
+  HitEvent (..),
+  Primitive (..),
+ )
 import GHCSpecter.UI.ConcurReplica.DOM (text)
 import GHCSpecter.UI.ConcurReplica.SVG qualified as S
 import GHCSpecter.UI.ConcurReplica.Types (IHTML)
@@ -54,16 +58,16 @@ renderColor ColorRedLevel4 = "#F1948A"
 renderColor ColorRedLevel5 = "#EC7063"
 
 renderPrimitive :: (Text -> [Props ev]) -> Primitive -> Widget IHTML ev
-renderPrimitive handlers (Rectangle (x, y) w h mline mbkg mlwidth handleHover) =
+renderPrimitive handlers (Rectangle (x, y) w h mline mbkg mlwidth mhitEvent) =
   S.rect
-    ( maybe [] (\name -> handlers name) handleHover
+    ( maybe [] handlers (hitEventHover =<< mhitEvent)
         ++ [ SP.x (T.pack $ show x)
            , SP.y (T.pack $ show y)
            , width (T.pack $ show w)
            , height (T.pack $ show h)
            , SP.stroke (maybe "none" renderColor mline)
            , SP.fill (maybe "none" renderColor mbkg)
-           , SP.pointerEvents (if isJust handleHover then "visible" else "none")
+           , SP.pointerEvents (if isJust mhitEvent then "visible" else "none")
            ]
         ++ maybe [] (pure . SP.strokeWidth . T.pack . show) mlwidth
     )

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -42,6 +42,7 @@ import GHCSpecter.Data.Map (
  )
 import GHCSpecter.Graphics.DSL (
   Color (..),
+  HitEvent (..),
   Primitive (..),
   Scene (..),
   TextFontFace (Sans),
@@ -182,11 +183,19 @@ compilePauseResume session =
     buttonTxt
       | sessionIsPaused session = "Resume Session"
       | otherwise = "Pause Session"
-    eventTxt
-      | sessionIsPaused session = "ResumeSession"
-      | otherwise = "PauseSession"
+    hitEvent
+      | sessionIsPaused session =
+          HitEvent
+            { hitEventHover = Nothing
+            , hitEventClick = (False, Just "ResumeSession")
+            }
+      | otherwise =
+          HitEvent
+            { hitEventHover = Nothing
+            , hitEventClick = (False, Just "PauseSession")
+            }
     contents =
-      [ Rectangle (0, 0) 100 15 (Just Black) (Just Ivory) (Just 1.0) (Just eventTxt)
+      [ Rectangle (0, 0) 100 15 (Just Black) (Just Ivory) (Just 1.0) (Just hitEvent)
       , DrawText (5, 0) UpperLeft Sans Black 8 buttonTxt
       ]
 

--- a/daemon/src/GHCSpecter/Render/Session.hs
+++ b/daemon/src/GHCSpecter/Render/Session.hs
@@ -18,6 +18,7 @@ import Control.Lens (to, (^.))
 import Data.IntMap qualified as IM
 import Data.List (partition)
 import Data.Maybe (fromMaybe, isJust)
+import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import GHC.RTS.Flags (RTSFlags)
@@ -77,7 +78,7 @@ compileModuleInProgress ::
   BiKeyMap DriverId ModuleName ->
   KeyMap DriverId BreakpointLoc ->
   [(DriverId, Timer)] ->
-  Scene
+  Scene Text
 compileModuleInProgress drvModMap pausedMap timingInProg =
   scene {sceneId = "module-status"}
   where
@@ -94,7 +95,7 @@ compileModuleInProgress drvModMap pausedMap timingInProg =
 
 compileSession ::
   ServerState ->
-  Scene
+  Scene Text
 compileSession ss =
   scene {sceneId = "session-main"}
   where
@@ -171,7 +172,7 @@ compileSession ss =
 
     scene = compileTextView txt []
 
-compilePauseResume :: SessionInfo -> Scene
+compilePauseResume :: SessionInfo -> Scene Text
 compilePauseResume session =
   Scene
     { sceneId = "session-button"

--- a/daemon/src/GHCSpecter/Render/SourceView.hs
+++ b/daemon/src/GHCSpecter/Render/SourceView.hs
@@ -170,7 +170,7 @@ renderModuleTree srcUI ss =
                   ]
        in modItem
 
-compileSuppView :: Maybe SupplementaryView -> Scene
+compileSuppView :: Maybe SupplementaryView -> Scene Text
 compileSuppView Nothing =
   Scene
     { sceneId = "supple-view-contents"
@@ -193,7 +193,7 @@ compileSuppView (Just (SuppViewText _)) =
     , sceneElements = []
     }
 
-compileSuppViewPanel :: ModuleName -> SourceViewUI -> ServerState -> (Scene, Scene)
+compileSuppViewPanel :: ModuleName -> SourceViewUI -> ServerState -> (Scene Text, Scene Text)
 compileSuppViewPanel modu srcUI ss =
   (Tab.compileTab tabCfg mtab, compileSuppView msuppView)
   where

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -229,7 +229,7 @@ data UIViewRaw = UIViewRaw
   { _uiTransientBanner :: Maybe Double
   -- ^ progress bar status.
   -- TODO: This will be handled more properly with typed transition.
-  , _uiRawEventMap :: [EventMap]
+  , _uiRawEventMap :: [EventMap Text]
   -- ^ event name -> bounding box map
   }
 

--- a/daemon/src/GHCSpecter/Util/Transformation.hs
+++ b/daemon/src/GHCSpecter/Util/Transformation.hs
@@ -11,7 +11,6 @@ module GHCSpecter.Util.Transformation (
 ) where
 
 import Data.List qualified as L
-import Data.Text (Text)
 import GHCSpecter.Graphics.DSL (
   EventMap (..),
   HitEvent,
@@ -57,10 +56,10 @@ isInside :: (Double, Double) -> ViewPort -> Bool
 isInside (x, y) (ViewPort (x0, y0) (x1, y1)) =
   x >= x0 && x <= x1 && y >= y0 && y <= y1
 
-hitScene :: (Double, Double) -> [EventMap] -> Maybe EventMap
+hitScene :: (Double, Double) -> [EventMap e] -> Maybe (EventMap e)
 hitScene (x, y) emaps = L.find (\emap -> (x, y) `isInside` eventMapGlobalViewPort emap) emaps
 
-hitItem :: (Double, Double) -> EventMap -> Maybe HitEvent
+hitItem :: (Double, Double) -> EventMap e -> Maybe (HitEvent e)
 hitItem (x, y) emap
   | (x, y) `isInside` cvp =
       fst

--- a/daemon/src/GHCSpecter/Util/Transformation.hs
+++ b/daemon/src/GHCSpecter/Util/Transformation.hs
@@ -12,7 +12,11 @@ module GHCSpecter.Util.Transformation (
 
 import Data.List qualified as L
 import Data.Text (Text)
-import GHCSpecter.Graphics.DSL (EventMap (..), ViewPort (..))
+import GHCSpecter.Graphics.DSL (
+  EventMap (..),
+  HitEvent,
+  ViewPort (..),
+ )
 import GHCSpecter.UI.Types.Event (ScrollDirection (..))
 
 -- | scroll
@@ -56,7 +60,7 @@ isInside (x, y) (ViewPort (x0, y0) (x1, y1)) =
 hitScene :: (Double, Double) -> [EventMap] -> Maybe EventMap
 hitScene (x, y) emaps = L.find (\emap -> (x, y) `isInside` eventMapGlobalViewPort emap) emaps
 
-hitItem :: (Double, Double) -> EventMap -> Maybe Text
+hitItem :: (Double, Double) -> EventMap -> Maybe HitEvent
 hitItem (x, y) emap
   | (x, y) `isInside` cvp =
       fst

--- a/render/src/GHCSpecter/Graphics/DSL.hs
+++ b/render/src/GHCSpecter/Graphics/DSL.hs
@@ -4,6 +4,9 @@ module GHCSpecter.Graphics.DSL (
   TextFontFace (..),
   TextPosition (..),
 
+  -- * event type
+  HitEvent (..),
+
   -- * graphics primitives
   Primitive (..),
   ViewPort (..),
@@ -45,9 +48,17 @@ data TextPosition = UpperLeft | LowerLeft
 data TextFontFace = Sans | Mono
   deriving (Show)
 
+data HitEvent = HitEvent
+  { hitEventHover :: Maybe Text
+  -- ^ event message when hovered
+  , hitEventClick :: (Bool, Maybe Text)
+  -- ^ *current* activation status (toggle on/off), and event message when clicked
+  }
+  deriving (Show)
+
 data Primitive
   = -- | (x, y) w h line_color background_color line_width handle_hovering
-    Rectangle (Double, Double) Double Double (Maybe Color) (Maybe Color) (Maybe Double) (Maybe Text)
+    Rectangle (Double, Double) Double Double (Maybe Color) (Maybe Color) (Maybe Double) (Maybe HitEvent)
   | -- | start [bend_point] end line_color line_width
     Polyline (Double, Double) [(Double, Double)] (Double, Double) Color Double
   | -- | (x, y) text_pos font_size text
@@ -73,6 +84,6 @@ data EventMap = EventMap
   { eventMapId :: Text
   , eventMapGlobalViewPort :: ViewPort
   , eventMapLocalViewPort :: ViewPort
-  , eventMapElements :: [(Text, ViewPort)]
+  , eventMapElements :: [(HitEvent, ViewPort)]
   }
   deriving (Show)

--- a/render/src/GHCSpecter/Graphics/DSL.hs
+++ b/render/src/GHCSpecter/Graphics/DSL.hs
@@ -48,17 +48,17 @@ data TextPosition = UpperLeft | LowerLeft
 data TextFontFace = Sans | Mono
   deriving (Show)
 
-data HitEvent = HitEvent
-  { hitEventHover :: Maybe Text
+data HitEvent e = HitEvent
+  { hitEventHover :: Maybe e
   -- ^ event message when hovered
-  , hitEventClick :: (Bool, Maybe Text)
+  , hitEventClick :: (Bool, Maybe e)
   -- ^ *current* activation status (toggle on/off), and event message when clicked
   }
   deriving (Show)
 
-data Primitive
+data Primitive e
   = -- | (x, y) w h line_color background_color line_width handle_hovering
-    Rectangle (Double, Double) Double Double (Maybe Color) (Maybe Color) (Maybe Double) (Maybe HitEvent)
+    Rectangle (Double, Double) Double Double (Maybe Color) (Maybe Color) (Maybe Double) (Maybe (HitEvent e))
   | -- | start [bend_point] end line_color line_width
     Polyline (Double, Double) [(Double, Double)] (Double, Double) Color Double
   | -- | (x, y) text_pos font_size text
@@ -72,18 +72,18 @@ data ViewPort = ViewPort
   deriving (Show)
 
 -- scene has local view port matched with global canvas
-data Scene = Scene
+data Scene e = Scene
   { sceneId :: Text
   , sceneGlobalViewPort :: ViewPort
   , sceneLocalViewPort :: ViewPort
-  , sceneElements :: [Primitive]
+  , sceneElements :: [Primitive e]
   }
   deriving (Show)
 
-data EventMap = EventMap
+data EventMap e = EventMap
   { eventMapId :: Text
   , eventMapGlobalViewPort :: ViewPort
   , eventMapLocalViewPort :: ViewPort
-  , eventMapElements :: [(HitEvent, ViewPort)]
+  , eventMapElements :: [(HitEvent e, ViewPort)]
   }
   deriving (Show)


### PR DESCRIPTION
For high-level component rendering, hide low-level Render by wrapping  it into ReaderT.
Low-level events are also wrapped into HitEvent, which is polymorphic for the future use.