### PR TITLE
Positioning grouped console items correctly

### DIFF
--- a/daemon-exp/app/ghc-specter-daemon-exp/Render/Parts/Timing.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Render/Parts/Timing.hs
@@ -17,7 +17,7 @@ import GHCSpecter.Graphics.DSL (
   ViewPort (..),
  )
 import GHCSpecter.Render.Components.TimingView (
-  buildBlockers,
+  -- buildBlockers,
   buildMemChart,
   buildTimingChart,
   buildTimingRange,
@@ -78,6 +78,7 @@ renderTiming drvModMap tui ttable = do
             }
     renderScene sceneTimingRange'
   -- blocker lines
+  {-
   let minfo = do
         hoveredMod <- tui ^. timingUIHoveredModule
         vpCvs <- Map.lookup "blockers" wcfg
@@ -95,3 +96,4 @@ renderTiming drvModMap tui ttable = do
             { sceneGlobalViewPort = ViewPort (offsetX, offsetY) (w + offsetX, h + offsetY)
             }
     renderScene sceneBlockers'
+  -}

--- a/daemon-exp/app/ghc-specter-daemon-exp/Render/Parts/Timing.hs
+++ b/daemon-exp/app/ghc-specter-daemon-exp/Render/Parts/Timing.hs
@@ -17,7 +17,7 @@ import GHCSpecter.Graphics.DSL (
   ViewPort (..),
  )
 import GHCSpecter.Render.Components.TimingView (
-  -- buildBlockers,
+  buildBlockers,
   buildMemChart,
   buildTimingChart,
   buildTimingRange,
@@ -78,13 +78,12 @@ renderTiming drvModMap tui ttable = do
             }
     renderScene sceneTimingRange'
   -- blocker lines
-  {-
   let minfo = do
         hoveredMod <- tui ^. timingUIHoveredModule
         vpCvs <- Map.lookup "blockers" wcfg
         pure (hoveredMod, vpCvs)
   -- NOTE: the size information from vpCvs is ignored as dynamic size overrides it.
-  -- TODO: clipping is still valid. we need two-layer viewport system.
+  -- TODO: scene content intrinsic size should be present in Scene data type.
   for_ minfo $ \(hoveredMod, vpCvs) -> do
     let sceneBlockers = buildBlockers hoveredMod ttable
         ViewPort (offsetX, offsetY) _ = vpCvs
@@ -96,4 +95,3 @@ renderTiming drvModMap tui ttable = do
             { sceneGlobalViewPort = ViewPort (offsetX, offsetY) (w + offsetX, h + offsetY)
             }
     renderScene sceneBlockers'
-  -}

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -15,8 +15,6 @@ import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Semigroup (sconcat)
 import Data.Text (Text)
---
-import Debug.Trace (trace)
 import GHCSpecter.Data.Map (
   IsKey (..),
   KeyMap,
@@ -106,7 +104,7 @@ buildConsoleItem (ConsoleCommand txt) =
   toSizedLine $ NE.singleton $ drawText (0, 0) UpperLeft Mono Black 8 txt
 buildConsoleItem (ConsoleText txt) =
   toSizedLine $ NE.singleton $ drawText (0, 0) UpperLeft Mono Black 8 txt
-buildConsoleItem (ConsoleButton buttonss) = (vp, contentss') -- concatMap F.toList contentss
+buildConsoleItem (ConsoleButton buttonss) = (vp, contentss')
   where
     mkButton (label, cmd) =
       let hitEvent =
@@ -115,7 +113,8 @@ buildConsoleItem (ConsoleButton buttonss) = (vp, contentss') -- concatMap F.toLi
               , hitEventHoverOff = Nothing
               , hitEventClick = Just (Right (ConsoleButtonPressed False cmd))
               }
-       in rectangle (0, 0) 120 10 (Just Black) (Just White) (Just 1.0) (Just hitEvent)
+       in -- TODO: should not have this hard-coded size "120".
+          rectangle (0, 0) 120 10 (Just Black) (Just White) (Just 1.0) (Just hitEvent)
             :| [drawText (0, 0) UpperLeft Mono Black 8 label]
 
     mkRow :: [(Text, Text)] -> Maybe (ViewPort, NonEmpty (Primitive (ConsoleEvent k)))
@@ -128,7 +127,7 @@ buildConsoleItem (ConsoleButton buttonss) = (vp, contentss') -- concatMap F.toLi
     ls :: [(ViewPort, NonEmpty (Primitive (ConsoleEvent k)))]
     ls = mapMaybe mkRow buttonss
     (mvp, contentss) = flowLineByLine 0 ls
-    -- TODO: for now
+    -- TODO: for now, use this partial function. this should be properly removed.
     Just vp = mvp
     contentss' = NE.fromList (concatMap F.toList contentss)
 buildConsoleItem (ConsoleCore forest) =
@@ -149,7 +148,6 @@ buildConsoleMain contents mfocus =
   where
     mtxts = mfocus >>= (`lookupKey` contents)
     contentss = fmap buildConsoleItem $ join $ maybeToList mtxts
-    -- contentss' = mapMaybe NE.nonEmpty contentss
     (mvp, rendered) = flowLineByLine 0 contentss
     size = maybe 200 viewPortHeight mvp
 

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -41,7 +41,7 @@ import GHCSpecter.Render.Components.Tab (
 import GHCSpecter.Render.Components.Util (
   flowInline,
   flowLineByLine,
-  getLeastUpperBoundingBox,
+  toSizedLine,
  )
 import GHCSpecter.Server.Types (ConsoleItem (..))
 import GHCSpecter.UI.Constants (
@@ -66,9 +66,6 @@ buildConsoleTab tabs mfocus = ConsoleTab <$> buildTab tabCfg mfocus
         , tabCfgHeight = 15
         , tabCfgItems = tabs
         }
-
-toSizedLine :: NonEmpty (Primitive a) -> (ViewPort, NonEmpty (Primitive a))
-toSizedLine xs = (getLeastUpperBoundingBox xs, xs)
 
 buildConsoleHelp ::
   -- | getHelp. (title, help items), help item: Left: button, Right: text

--- a/daemon/src/GHCSpecter/Render/Components/Console.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Console.hs
@@ -15,6 +15,8 @@ import Data.List.NonEmpty qualified as NE
 import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
 import Data.Semigroup (sconcat)
 import Data.Text (Text)
+--
+import Debug.Trace (trace)
 import GHCSpecter.Data.Map (
   IsKey (..),
   KeyMap,
@@ -109,16 +111,16 @@ buildConsoleItem (ConsoleButton buttonss) = concatMap F.toList contentss
        in rectangle (0, 0) 120 10 (Just Black) (Just White) (Just 1.0) (Just hitEvent)
             :| [drawText (0, 0) UpperLeft Mono Black 8 label]
 
-    mkRow :: [(Text, Text)] -> Maybe (NonEmpty (Primitive (ConsoleEvent k)))
+    mkRow :: [(Text, Text)] -> Maybe (ViewPort, NonEmpty (Primitive (ConsoleEvent k)))
     mkRow buttons =
-      let placed = snd $ flowInline 0 $ fmap mkButton buttons
+      let (mvp, placed) = flowInline 0 $ fmap mkButton buttons
        in -- concat the horizontally placed items into a single NonEmpty list
           -- so to group them as a single line.
-          sconcat <$> NE.nonEmpty placed
+          (,) <$> mvp <*> (sconcat <$> NE.nonEmpty placed)
 
-    ls :: [NonEmpty (Primitive (ConsoleEvent k))]
+    ls :: [(ViewPort, NonEmpty (Primitive (ConsoleEvent k)))]
     ls = mapMaybe mkRow buttonss
-    (size, contentss) = flowLineByLine 0 ls
+    (size, contentss) = flowLineByLine 0 (fmap snd ls)
 buildConsoleItem (ConsoleCore forest) = []
 
 buildConsoleMain ::

--- a/daemon/src/GHCSpecter/Render/Components/TimingView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TimingView.hs
@@ -9,7 +9,7 @@ module GHCSpecter.Render.Components.TimingView (
   buildTimingChart,
   buildMemChart,
   buildTimingRange,
-  -- buildBlockers,
+  buildBlockers,
 ) where
 
 import Control.Lens (to, (%~), (^.), _1, _2)
@@ -47,8 +47,12 @@ import GHCSpecter.Graphics.DSL (
   drawText,
   polyline,
   rectangle,
+  viewPortHeight,
  )
-import GHCSpecter.Render.Components.Util (flowLineByLine)
+import GHCSpecter.Render.Components.Util (
+  flowLineByLine,
+  toSizedLine,
+ )
 import GHCSpecter.UI.Constants (
   timingHeight,
   timingMaxWidth,
@@ -367,7 +371,6 @@ buildTimingRange tui ttable =
         (Just 1.0)
         Nothing
 
-{-
 buildBlockers :: ModuleName -> TimingTable -> Scene e
 buildBlockers hoveredMod ttable =
   Scene
@@ -382,12 +385,12 @@ buildBlockers hoveredMod ttable =
     downMods =
       fromMaybe [] (M.lookup hoveredMod (ttable ^. ttableBlockedDownstreamDependency))
     --
-    selected = NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 hoveredMod)
-    line = NE.singleton (polyline (0, 0) [] (200, 0) Black 1)
-    blockedBy = NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 "Blocked By")
-    upstreams = fmap (\t -> NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 t)) upMods
-    blocking = NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 "Blocking")
-    downstreams = fmap (\t -> NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 t)) downMods
-    (size, contentss) = flowLineByLine 0 ([selected, line, blockedBy] ++ upstreams ++ [line, blocking] ++ downstreams)
+    selected = toSizedLine $ NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 hoveredMod)
+    line = toSizedLine $ NE.singleton (polyline (0, 0) [] (200, 0) Black 1)
+    blockedBy = toSizedLine $ NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 "Blocked By")
+    upstreams = fmap (\t -> toSizedLine $ NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 t)) upMods
+    blocking = toSizedLine $ NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 "Blocking")
+    downstreams = fmap (\t -> toSizedLine $ NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 t)) downMods
+    (mvp, contentss) = flowLineByLine 0 ([selected, line, blockedBy] ++ upstreams ++ [line, blocking] ++ downstreams)
+    size = maybe 200 viewPortHeight mvp
     box = rectangle (0, 0) 200 size (Just Black) Nothing (Just 1.0) Nothing
--}

--- a/daemon/src/GHCSpecter/Render/Components/TimingView.hs
+++ b/daemon/src/GHCSpecter/Render/Components/TimingView.hs
@@ -9,7 +9,7 @@ module GHCSpecter.Render.Components.TimingView (
   buildTimingChart,
   buildMemChart,
   buildTimingRange,
-  buildBlockers,
+  -- buildBlockers,
 ) where
 
 import Control.Lens (to, (%~), (^.), _1, _2)
@@ -367,6 +367,7 @@ buildTimingRange tui ttable =
         (Just 1.0)
         Nothing
 
+{-
 buildBlockers :: ModuleName -> TimingTable -> Scene e
 buildBlockers hoveredMod ttable =
   Scene
@@ -389,3 +390,4 @@ buildBlockers hoveredMod ttable =
     downstreams = fmap (\t -> NE.singleton (drawText (0, 0) UpperLeft Sans Black 8 t)) downMods
     (size, contentss) = flowLineByLine 0 ([selected, line, blockedBy] ++ upstreams ++ [line, blocking] ++ downstreams)
     box = rectangle (0, 0) 200 size (Just Black) Nothing (Just 1.0) Nothing
+-}

--- a/daemon/src/GHCSpecter/Render/Components/Util.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Util.hs
@@ -40,27 +40,41 @@ moveBoundingBoxBy :: (Double, Double) -> ViewPort -> ViewPort
 moveBoundingBoxBy (dx, dy) (ViewPort (vx0, vy0) (vx1, vy1)) =
   ViewPort (vx0 + dx, vy0 + dy) (vx1 + dx, vy1 + dy)
 
+viewPortSum :: Maybe ViewPort -> ViewPort -> ViewPort
+viewPortSum Nothing vp = vp
+viewPortSum (Just (ViewPort (x0, y0) (x1, y1))) (ViewPort (x0', y0') (x1', y1')) =
+  let x0'' = min x0 x0'
+      y0'' = min y0 y0'
+      x1'' = max x1 x1'
+      y1'' = max y1 y1'
+   in ViewPort (x0'', y0'') (x1'', y1'')
+
 -- | place grouped items horizontally
 flowInline ::
   -- | initial x offset
   Double ->
   -- | rendered items grouped by each x
   [NonEmpty (Primitive e)] ->
-  -- | (final offset after placement, placed itmes)
-  (Double, [NonEmpty (Primitive e)])
-flowInline offset0 = L.mapAccumL place offset0
+  -- | (bounding box of the collection, placed items)
+  (Maybe ViewPort, [NonEmpty (Primitive e)])
+flowInline offset0 itms0 = (mvp1, itms1)
   where
-    place !offset itms =
-      let shifted = fmap forEach itms
-          itms' = fmap snd shifted
-          doffset = maximum (fmap fst shifted)
-       in (offset + doffset, itms')
+    place (!offset, !mvp) itms =
+      let itms' = fmap forEach itms
+          vp' =
+            let vps = fmap primBoundingBox itms'
+                tl = (minimum $ fmap (fst . topLeft) vps, minimum $ fmap (snd . topLeft) vps)
+                br = (maximum $ fmap (fst . bottomRight) vps, maximum $ fmap (snd . bottomRight) vps)
+             in ViewPort tl br
+          w' = viewPortWidth vp'
+       in ((offset + w', Just (viewPortSum mvp vp')), itms')
       where
         forEach (Primitive shape vp hitEvent) =
           let shape' = moveShapeBy (offset, 0) shape
               vp' = moveBoundingBoxBy (offset, 0) vp
-              doffset = viewPortWidth vp
-           in (doffset, Primitive shape' vp' hitEvent)
+           in Primitive shape' vp' hitEvent
+
+    ((_, mvp1), itms1) = L.mapAccumL place (offset0, Nothing) itms0
 
 -- | place grouped items line by line
 flowLineByLine ::
@@ -68,7 +82,7 @@ flowLineByLine ::
   Double ->
   -- | rendered items grouped by each line
   [NonEmpty (Primitive e)] ->
-  -- | (final offset after placement, placed items)
+  -- | (bounding box of the collection, placed items)
   (Double, [NonEmpty (Primitive e)])
 flowLineByLine offset0 = L.mapAccumL place offset0
   where

--- a/daemon/src/GHCSpecter/Render/Components/Util.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Util.hs
@@ -95,11 +95,11 @@ flowLineByLine ::
   [(ViewPort, NonEmpty (Primitive e))] ->
   -- | (final offset, placed items)
   (Maybe ViewPort, [NonEmpty (Primitive e)])
-flowLineByLine offset0 itms0 = (mvp1, itms1) -- L.mapAccumL place offset0 itms0
+flowLineByLine offset0 itms0 = (mvp1, itms1)
   where
     place (!offset, !mvp) (vp, itms) =
       let itms' = fmap forEach itms
-          vp' = moveBoundingBoxBy (0, offset) vp -- getLeastUpperBoundingBox itms'
+          vp' = moveBoundingBoxBy (0, offset) vp
           h' = viewPortHeight vp'
        in ((offset + h', Just (viewPortSum mvp vp')), itms')
       where
@@ -109,8 +109,3 @@ flowLineByLine offset0 itms0 = (mvp1, itms1) -- L.mapAccumL place offset0 itms0
            in Primitive shape' vp_' hitEvent
 
     ((_, mvp1), itms1) = L.mapAccumL place (offset0, Nothing) itms0
-
---              doffset = viewPortHeight vp
---           in (doffset, Primitive shape' vp' hitEvent)
-
---          doffset = maximum (fmap fst shifted)

--- a/daemon/src/GHCSpecter/Render/Components/Util.hs
+++ b/daemon/src/GHCSpecter/Render/Components/Util.hs
@@ -3,6 +3,7 @@ module GHCSpecter.Render.Components.Util (
   getLeastUpperBoundingBox,
 
   -- * flow
+  toSizedLine,
   flowInline,
   flowLineByLine,
 ) where
@@ -60,6 +61,9 @@ getLeastUpperBoundingBox itms =
       br = (maximum $ fmap (fst . bottomRight) vps, maximum $ fmap (snd . bottomRight) vps)
    in ViewPort tl br
 
+toSizedLine :: NonEmpty (Primitive a) -> (ViewPort, NonEmpty (Primitive a))
+toSizedLine xs = (getLeastUpperBoundingBox xs, xs)
+
 -- | place grouped items horizontally
 flowInline ::
   -- | initial x offset
@@ -105,7 +109,7 @@ flowLineByLine offset0 itms0 = (mvp1, itms1) -- L.mapAccumL place offset0 itms0
            in Primitive shape' vp_' hitEvent
 
     ((_, mvp1), itms1) = L.mapAccumL place (offset0, Nothing) itms0
-         
+
 --              doffset = viewPortHeight vp
 --           in (doffset, Primitive shape' vp' hitEvent)
 


### PR DESCRIPTION
the element layout algorithm didn't distinguish grouped items from single primitive items
so items after button groups were not correctly displayed. Now it's fixed.