### PR TITLE
eventlog2html subclone to handle large eventlog data 

### DIFF
--- a/logcat/util/Extract.hs
+++ b/logcat/util/Extract.hs
@@ -33,7 +33,6 @@ data EventlogItem = EventlogItem
   }
   deriving (Show)
 
-
 readT :: (Read a) => Text -> a
 readT = read . T.unpack
 

--- a/logcat/util/Extract.hs
+++ b/logcat/util/Extract.hs
@@ -1,0 +1,80 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Extract (
+  EventlogItem (..),
+  extract,
+) where
+
+import Data.Maybe (catMaybes, listToMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import Text.HTML.TagSoup (
+  Tag (..),
+  parseTags,
+ )
+import Text.HTML.TagSoup.Tree (
+  TagTree (..),
+  renderTree,
+  tagTree,
+  universeTree,
+ )
+
+data EventlogItem = EventlogItem
+  { eventGraph :: [(Double, Double)]
+  , eventN :: Int
+  , eventLabel :: Text
+  , eventDesc :: Text
+  , eventCTy :: Text
+  , eventType :: Text
+  , eventModule :: Text
+  , eventLoc :: Text
+  , eventSize :: Double
+  }
+  deriving (Show)
+
+
+readT :: (Read a) => Text -> a
+readT = read . T.unpack
+
+parseLineChart :: Text -> [(Double, Double)]
+parseLineChart txt =
+  let xs = T.split (== ',') txt
+      parse x =
+        let [y1, y2] = T.split (== ':') x
+         in (readT y1, readT y2)
+   in fmap parse xs
+
+getLineChart x = listToMaybe $ do
+  TagBranch "td" _ xs <- [x]
+  TagBranch "span" _ ys <- xs
+  TagLeaf (TagText contents) <- ys
+  pure (parseLineChart contents)
+
+getText :: TagTree T.Text -> Maybe T.Text
+getText x = listToMaybe $ do
+  TagBranch "td" _ xs <- [x]
+  TagLeaf (TagText content) <- xs
+  pure content
+
+extract :: FilePath -> IO [EventlogItem]
+extract fp = do
+  txt <- TIO.readFile fp
+  let tags = parseTags txt
+      trs = tagTree tags
+      convert (c1 : c2 : c3 : c4 : c5 : c6 : c7 : c8 : c9 : _) =
+        EventlogItem
+          <$> getLineChart c1
+          <*> (readT @Int <$> getText c2)
+          <*> getText c3
+          <*> getText c4
+          <*> getText c5
+          <*> getText c6
+          <*> getText c7
+          <*> getText c8
+          <*> (readT @Double <$> getText c9)
+      infos = do
+        TagBranch "table" _ rows <- universeTree trs
+        TagBranch "tr" _ cols <- rows
+        pure (convert cols)
+  pure $ catMaybes infos

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -1,0 +1,293 @@
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Data.Foldable (for_)
+import Data.Function qualified as Fn (on)
+import Data.GI.Base (AttrOp ((:=)), after, get, new, on)
+import Data.GI.Gtk.Threading (postGUIASync)
+import Data.IORef (newIORef, modifyIORef', readIORef)
+import Data.List qualified as L
+import Data.Maybe (fromMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Time.Clock (
+  diffUTCTime,
+  getCurrentTime,
+  nominalDiffTimeToSeconds,
+ )
+import Data.Traversable (for)
+import Extract (EventlogItem (..), extract)
+import GI.Cairo.Render qualified as R
+import GI.Cairo.Render.Connector as RC
+import GI.Gdk qualified as Gdk
+import GI.Gtk qualified as Gtk
+import GI.Pango qualified as P
+import GI.PangoCairo qualified as PC
+import System.Environment (getArgs)
+import System.IO (hFlush, stdout)
+import Text.Printf (printf)
+
+data ViewPort = ViewPort (Double, Double) (Double, Double)
+  deriving (Show)
+
+data GridState = GridState
+  { gridViewPort :: ViewPort
+  , gridTempViewPort :: Maybe ViewPort
+  }
+  deriving (Show)
+
+gridInViewPort :: ViewPort -> ([Double], [Double])
+gridInViewPort (ViewPort (x0, y0) (x1, y1)) = (xs, ys)
+  where
+    u0, u1 :: Int
+    u0 = floor (x0 / 128.0)
+    u1 = floor (x1 / 128.0)
+    v0, v1 :: Int
+    v0 = floor (y0 / 128.0)
+    v1 = floor (y1 / 128.0)
+    --
+    xs = fmap (fromIntegral . (128 *)) [u0 .. u1]
+    ys = fmap (fromIntegral . (128 *)) [v0 .. v1]
+
+textPosInViewPort :: ViewPort -> [(Double, Double)]
+textPosInViewPort (ViewPort (x0, y0) (x1, y1)) =
+  [ (x, y) | x <- xs, y <- ys ]
+  where
+    u0, u1 :: Int
+    u0 = floor ((x0 - 120) / 512.0)
+    u1 = floor ((x1 - 120) / 512.0)
+    v0, v1 :: Int
+    v0 = floor ((y0 - 120) / 512.0)
+    v1 = floor ((y1 - 120) / 512.0)
+    --
+    xs = fmap (fromIntegral . (\x -> x * 512 + 120)) [u0 .. u1]
+    ys = fmap (fromIntegral . (\y -> y * 512 + 120)) [v0 .. v1]
+
+-- | scroll
+transformScroll ::
+  Gdk.ScrollDirection ->
+  Double ->
+  (Double, Double) ->
+  ViewPort ->
+  ViewPort
+transformScroll dir scale (dx, dy) vp = vp'
+  where
+    ViewPort (x0, y0) (x1, y1) = vp
+    dx' = dx / scale
+    dy' = dy / scale
+
+    vp' = case dir of
+      Gdk.ScrollDirectionRight ->
+        ViewPort (x0 + dx', y0) (x1 + dx', y1)
+      Gdk.ScrollDirectionLeft ->
+        ViewPort (x0 - dx', y0) (x1 - dx', y1)
+      Gdk.ScrollDirectionDown ->
+        ViewPort (x0, y0 + dy') (x1, y1 + dy')
+      Gdk.ScrollDirectionUp ->
+        ViewPort (x0, y0 - dy') (x1, y1 - dy')
+      Gdk.ScrollDirectionSmooth ->
+        ViewPort (x0 + dx', y0 + dy') (x1 + dx', y1 + dy')
+
+-- | zoom
+transformZoom ::
+  (Double, Double) ->
+  Double ->
+  ViewPort ->
+  ViewPort
+transformZoom (rx, ry) scale vp = vp'
+  where
+    ViewPort (x0, y0) (x1, y1) = vp
+    x = x0 + (x1 - x0) * rx
+    y = y0 + (y1 - y0) * ry
+    x0' = x + (x0 - x) / scale
+    y0' = y + (y0 - y) / scale
+    x1' = x + (x1 - x) / scale
+    y1' = y + (y1 - y) / scale
+    vp' = ViewPort (x0', y0') (x1', y1')
+
+drawTextLine :: (P.Context, P.FontDescription) -> (Double, Double) -> Text -> R.Render ()
+drawTextLine (pctxt, desc) (x, y) msg = do
+  layout :: P.Layout <- P.layoutNew pctxt
+  #setSize desc (10 * P.SCALE)
+  #setFontDescription layout (Just desc)
+  #setText layout msg (-1)
+  R.moveTo x y
+  ctxt <- RC.getContext
+  PC.showLayout ctxt layout
+
+drawTextMultiline ::
+  (P.Context, P.FontDescription) ->
+  (Double, Double) ->
+  [Text] ->
+  R.Render ()
+drawTextMultiline (ctxt, desc) (x, y) msgs = do
+  for_ (zip [y, y + 12 .. ] msgs) $ \(y', msg) ->
+    drawTextLine (ctxt, desc) (x, y') msg
+
+drawGrid :: ViewPort -> R.Render ()
+drawGrid vp@(ViewPort (vx0, vy0) (vx1, vy1)) = do
+  R.setSourceRGBA 0 0 0 1.0
+  R.setLineWidth 0.1
+  let (xs, ys) = gridInViewPort vp
+  for_ xs $ \x -> do
+    R.moveTo x vy0
+    R.lineTo x vy1
+    R.stroke
+  for_ ys $ \y -> do
+    R.moveTo vx0 y
+    R.lineTo vx1 y
+    R.stroke
+
+drawGraph :: (Double, Double) -> [(Double, Double)] -> R.Render ()
+drawGraph _ [] = pure ()
+drawGraph (ox, oy) ((x0, y0):ps) = do
+  let getMax vs = let vmax0 = maximum vs
+                   in if vmax0 < 1.0 then 1.0 else vmax0
+      xmax = getMax (x0 : fmap fst ps)
+      ymax = getMax (y0 : fmap snd ps)
+  let xform (x, y) = (ox + x * 200.0 / xmax, oy - y * 20.0 / ymax)
+  R.setSourceRGBA 0 0 1.0 1.0
+  R.setLineWidth 1.0
+  uncurry R.moveTo (xform (x0, y0))
+  for_ ps $ \(x, y) ->
+    uncurry R.lineTo (xform (x, y))
+  R.stroke
+
+drawItem :: (P.Context, P.FontDescription) -> (Double, Double) -> EventlogItem -> R.Render ()
+drawItem (pctxt, desc) (ox, oy) item = do
+  drawGraph (ox, oy) (eventGraph item)
+  R.setSourceRGBA 0.3 0.3 0.3 1.0
+  drawTextLine (pctxt, desc) (ox + 210, oy - 15.0) (T.pack $ show $ eventN item)
+  drawTextLine (pctxt, desc) (ox + 260, oy - 15.0) (T.pack $ show $ eventSize item)
+  drawTextLine (pctxt, desc) (ox + 320, oy - 15.0) (eventLabel item)
+  drawTextLine (pctxt, desc) (ox + 420, oy - 15.0) (eventDesc item)
+  drawTextLine (pctxt, desc) (ox + 700, oy - 15.0) (eventCTy item)
+  drawTextLine (pctxt, desc) (ox + 900, oy - 15.0) (eventType item)
+  drawTextLine (pctxt, desc) (ox + 1100, oy - 15.0) (eventModule item)
+  drawTextLine (pctxt, desc) (ox + 1300, oy - 15.0) (eventLoc item)
+
+myDraw ::
+  (P.Context, P.FontDescription, P.FontDescription) ->
+  GridState ->
+  [EventlogItem] ->
+  R.Render ()
+myDraw (pangoCtxt, descSans, descMono) s items = do
+  let (cx0, cy0) = (0, 0)
+      (cx1, cy1) = (1024, 768)
+      vp@(ViewPort (vx0, vy0) (vx1, vy1)) =
+        fromMaybe (gridViewPort s) (gridTempViewPort s)
+      scaleX = (cx1 - cx0) / (vx1 - vx0)
+      scaleY = (cy1 - cy0) / (vy1 - vy0)
+  R.save
+  R.rectangle cx0 cy0 (cx1 - cx0) (cy1 - cy0)
+  R.clip
+  --
+  R.translate cx0 cy0
+  R.scale scaleX scaleY
+  R.translate (-vx0) (-vy0)
+  --
+  drawGrid vp
+  for_ (zip [0..] items) $ \(i, item) ->
+    drawItem (pangoCtxt, descSans) (0, (i + 1) * 30) item
+
+initFont :: IO (Maybe (P.Context, P.FontDescription, P.FontDescription))
+initFont = do
+  fontMap :: PC.FontMap <- PC.fontMapGetDefault
+  pangoCtxt <- #createContext fontMap
+  familySans <- #getFamily fontMap "FreeSans"
+  mfaceSans <- #getFace familySans Nothing
+  familyMono <- #getFamily fontMap "FreeMono"
+  mfaceMono <- #getFace familyMono Nothing
+  for ((,) <$> mfaceSans <*> mfaceMono) $ \(faceSans, faceMono) -> do
+    descSans <- #describe faceSans
+    descMono <- #describe faceMono
+    pure (pangoCtxt, descSans, descMono)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  dat <- extract (args !! 0)
+  let items = take 100 $ L.sortBy (flip compare `Fn.on` eventSize) dat
+  mapM_ print items
+  ref <- newIORef (GridState (ViewPort (0, 0) (1024, 768)) Nothing)
+  _ <- Gtk.init Nothing
+  Just (pangoCtxt, descSans, descMono) <- initFont
+  mainWindow <- new Gtk.Window [#type := Gtk.WindowTypeToplevel]
+  drawingArea <- new Gtk.DrawingArea []
+  #addEvents
+    drawingArea
+    [ Gdk.EventMaskScrollMask
+    , Gdk.EventMaskTouchpadGestureMask
+    ]
+  _ <- drawingArea `on` #draw $
+    RC.renderWithContext $ do
+      start <- R.liftIO $ getCurrentTime
+      s <- R.liftIO $ readIORef ref
+      myDraw (pangoCtxt, descSans, descMono) s items
+      end <- R.liftIO getCurrentTime
+      let diff :: Double
+          diff = realToFrac $ nominalDiffTimeToSeconds (diffUTCTime end start)
+      R.liftIO $ do
+        printf "Rendering time: %.5f seconds\n" diff
+        hFlush stdout
+
+      pure True
+  _ <- drawingArea
+    `after` #scrollEvent
+    $ \ev -> do
+      x <- get ev #x
+      y <- get ev #y
+      dx <- get ev #deltaX
+      dy <- get ev #deltaY
+      dir <- get ev #direction
+      modifyIORef' ref $ \s ->
+        let cx0 = 0
+            cx1 = 1024
+            vp@(ViewPort (vx0, _) (vx1, _)) = gridViewPort s
+            scale = (cx1 - cx0) / (vx1 - vx0)
+            vp' = transformScroll dir scale (dx, dy) vp
+         in s
+              { gridViewPort = vp'
+              , gridTempViewPort = Nothing
+              }
+      postGUIASync (#queueDraw drawingArea)
+      pure True
+  gzoom <- Gtk.gestureZoomNew drawingArea
+  _ <- gzoom
+    `on` #scaleChanged
+    $ \scale -> do
+      (_, x, y) <- #getBoundingBoxCenter gzoom
+      modifyIORef' ref $ \s ->
+        let vp = gridViewPort s
+            (cx0, cy0) = (0, 0)
+            (cx1, cy1) = (1024, 768)
+            rx = (x - cx0) / (cx1 - cx0)
+            ry = (y - cy0) / (cy1 - cy0)
+            mtvp = Just $ transformZoom (rx, ry) scale vp
+         in s
+              { gridTempViewPort = mtvp
+              }
+      postGUIASync (#queueDraw drawingArea)
+  _ <- gzoom
+    `on` #end
+    $ \_ -> do
+      modifyIORef' ref $ \s ->
+        let vp = gridViewPort s
+            mtvp = gridTempViewPort s
+         in s
+              { gridViewPort = fromMaybe vp mtvp
+              , gridTempViewPort = Nothing
+              }
+      postGUIASync (#queueDraw drawingArea)
+  #setPropagationPhase gzoom Gtk.PropagationPhaseBubble
+  layout <- do
+    vbox <- new Gtk.Box [#orientation := Gtk.OrientationVertical, #spacing := 0]
+    #packStart vbox drawingArea True True 0
+    pure vbox
+  _ <- mainWindow `on` #destroy $ Gtk.mainQuit
+  #add mainWindow layout
+  #setDefaultSize mainWindow 1024 768
+  #showAll mainWindow
+  Gtk.main

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -7,7 +7,7 @@ import Data.Foldable (for_)
 import Data.Function qualified as Fn (on)
 import Data.GI.Base (AttrOp ((:=)), after, get, new, on)
 import Data.GI.Gtk.Threading (postGUIASync)
-import Data.IORef (newIORef, modifyIORef', readIORef)
+import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List qualified as L
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -53,7 +53,7 @@ gridInViewPort (ViewPort (x0, y0) (x1, y1)) = (xs, ys)
 
 textPosInViewPort :: ViewPort -> [(Double, Double)]
 textPosInViewPort (ViewPort (x0, y0) (x1, y1)) =
-  [ (x, y) | x <- xs, y <- ys ]
+  [(x, y) | x <- xs, y <- ys]
   where
     u0, u1 :: Int
     u0 = floor ((x0 - 120) / 512.0)
@@ -123,7 +123,7 @@ drawTextMultiline ::
   [Text] ->
   R.Render ()
 drawTextMultiline (ctxt, desc) (x, y) msgs = do
-  for_ (zip [y, y + 12 .. ] msgs) $ \(y', msg) ->
+  for_ (zip [y, y + 12 ..] msgs) $ \(y', msg) ->
     drawTextLine (ctxt, desc) (x, y') msg
 
 drawGrid :: ViewPort -> R.Render ()
@@ -142,9 +142,10 @@ drawGrid vp@(ViewPort (vx0, vy0) (vx1, vy1)) = do
 
 drawGraph :: (Double, Double) -> [(Double, Double)] -> R.Render ()
 drawGraph _ [] = pure ()
-drawGraph (ox, oy) ((x0, y0):ps) = do
-  let getMax vs = let vmax0 = maximum vs
-                   in if vmax0 < 1.0 then 1.0 else vmax0
+drawGraph (ox, oy) ((x0, y0) : ps) = do
+  let getMax vs =
+        let vmax0 = maximum vs
+         in if vmax0 < 1.0 then 1.0 else vmax0
       xmax = getMax (x0 : fmap fst ps)
       ymax = getMax (y0 : fmap snd ps)
   let xform (x, y) = (ox + x * 200.0 / xmax, oy - y * 20.0 / ymax)
@@ -189,7 +190,7 @@ myDraw (pangoCtxt, descSans, descMono) s items = do
   R.translate (-vx0) (-vy0)
   --
   drawGrid vp
-  for_ (zip [0..] items) $ \(i, item) ->
+  for_ (zip [0 ..] items) $ \(i, item) ->
     drawItem (pangoCtxt, descSans) (0, (i + 1) * 30) item
 
 initFont :: IO (Maybe (P.Context, P.FontDescription, P.FontDescription))
@@ -221,8 +222,10 @@ main = do
     [ Gdk.EventMaskScrollMask
     , Gdk.EventMaskTouchpadGestureMask
     ]
-  _ <- drawingArea `on` #draw $
-    RC.renderWithContext $ do
+  _ <- drawingArea
+    `on` #draw
+    $ RC.renderWithContext
+    $ do
       start <- R.liftIO $ getCurrentTime
       s <- R.liftIO $ readIORef ref
       myDraw (pangoCtxt, descSans, descMono) s items

--- a/logcat/util/flake.lock
+++ b/logcat/util/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1687371736,
+        "narHash": "sha256-EWL7P3xhD6XQurqR4ArDNm9Mef+B98hqYweLrVNxs6Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3f5bcf0be3e15226b0e9d698aa734ee098aa08f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/logcat/util/flake.nix
+++ b/logcat/util/flake.nix
@@ -1,0 +1,92 @@
+{
+  description = "github-api test";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      fontconf = pkgs.makeFontsConf { fontDirectories = [pkgs.freefont_ttf]; };
+      overrideCabal = pkgs.haskell.lib.overrideCabal;
+      fficxx-version = "0.7.0.0";
+      HROOT-version = "0.10.0.2";
+      hpkgs = pkgs.haskell.packages.ghc925.extend (hself: hsuper: {
+        "fficxx" = hself.callHackage "fficxx" fficxx-version {};
+        "fficxx-runtime" =
+          hself.callHackage "fficxx-runtime" fficxx-version {};
+        "stdcxx" = hself.callHackage "stdcxx" fficxx-version {};
+        "template" = pkgs.haskell.lib.doJailbreak hsuper.template;
+        "HROOT" =
+          overrideCabal (hself.callHackage "HROOT" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
+        "HROOT-core" =
+          overrideCabal (hself.callHackage "HROOT-core" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
+        "HROOT-graf" =
+          overrideCabal (hself.callHackage "HROOT-graf" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
+        "HROOT-hist" =
+          overrideCabal (hself.callHackage "HROOT-hist" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
+        "HROOT-io" =
+          overrideCabal (hself.callHackage "HROOT-io" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
+        "HROOT-math" =
+          overrideCabal (hself.callHackage "HROOT-math" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
+        "HROOT-net" =
+          overrideCabal (hself.callHackage "HROOT-net" HROOT-version {RHTTP = null;}) {librarySystemDepends = [pkgs.root];};
+        "HROOT-tree" =
+          overrideCabal (hself.callHackage "HROOT-tree" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
+
+        "ormolu" =
+          overrideCabal hsuper.ormolu {enableSeparateBinOutput = false;};
+      });
+      HROOTdeps = p: [
+        p.fficxx
+        p.fficxx-runtime
+        p.stdcxx
+        p.HROOT
+        #p.template
+      ];
+
+      hsenv = hpkgs.ghcWithPackages (p:
+        [
+          p.aeson
+          p.directory
+          p.filepath
+          p.gi-cairo
+          p.gi-cairo-connector
+          p.gi-cairo-render
+          p.gi-gdk
+          p.gi-gtk
+          p.gi-gtk-hs
+          p.gi-pango
+          p.gi-pangocairo
+          #p.haskell-gi-base
+          p.lens
+          p.lens-aeson
+          p.pretty-simple
+          p.tagsoup
+          p.text
+          p.time
+          p.vector
+        ]);
+        #++ HROOTdeps p);
+    in {
+      devShells.default = pkgs.mkShell {
+        name = "testshell";
+        buildInputs = [
+          hsenv
+          pkgs.gh
+          pkgs.jq
+          hpkgs.ormolu
+          pkgs.root
+          pkgs.alejandra
+        ];
+        shellHook = ''
+          export MACOSX_DEPLOYMENT_TARGET="10.16"
+          export FONTCONFIG_FILE="${fontconf}"
+          export PANGOCAIRO_BACKEND=fc
+          export PS1="\n[github-api:\w]$ \0"
+        '';
+      };
+    });
+}

--- a/logcat/util/flake.nix
+++ b/logcat/util/flake.nix
@@ -9,36 +9,34 @@
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {inherit system;};
-      fontconf = pkgs.makeFontsConf { fontDirectories = [pkgs.freefont_ttf]; };
+      fontconf = pkgs.makeFontsConf {fontDirectories = [pkgs.freefont_ttf];};
       overrideCabal = pkgs.haskell.lib.overrideCabal;
       hpkgs = pkgs.haskell.packages.ghc925.extend (hself: hsuper: {
         "ormolu" =
           overrideCabal hsuper.ormolu {enableSeparateBinOutput = false;};
       });
 
-      hsenv = hpkgs.ghcWithPackages (p:
-        [
-          p.aeson
-          p.directory
-          p.filepath
-          p.gi-cairo
-          p.gi-cairo-connector
-          p.gi-cairo-render
-          p.gi-gdk
-          p.gi-gtk
-          p.gi-gtk-hs
-          p.gi-pango
-          p.gi-pangocairo
-          #p.haskell-gi-base
-          p.lens
-          p.lens-aeson
-          p.pretty-simple
-          p.tagsoup
-          p.text
-          p.time
-          p.vector
-        ]);
-        #++ HROOTdeps p);
+      hsenv = hpkgs.ghcWithPackages (p: [
+        p.aeson
+        p.directory
+        p.filepath
+        p.gi-cairo
+        p.gi-cairo-connector
+        p.gi-cairo-render
+        p.gi-gdk
+        p.gi-gtk
+        p.gi-gtk-hs
+        p.gi-pango
+        p.gi-pangocairo
+        #p.haskell-gi-base
+        p.lens
+        p.lens-aeson
+        p.pretty-simple
+        p.tagsoup
+        p.text
+        p.time
+        p.vector
+      ]);
     in {
       devShells.default = pkgs.mkShell {
         name = "testshell";

--- a/logcat/util/flake.nix
+++ b/logcat/util/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "github-api test";
+  description = "shell for logcat/util";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/master";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   outputs = {
@@ -11,41 +11,10 @@
       pkgs = import nixpkgs {inherit system;};
       fontconf = pkgs.makeFontsConf { fontDirectories = [pkgs.freefont_ttf]; };
       overrideCabal = pkgs.haskell.lib.overrideCabal;
-      fficxx-version = "0.7.0.0";
-      HROOT-version = "0.10.0.2";
       hpkgs = pkgs.haskell.packages.ghc925.extend (hself: hsuper: {
-        "fficxx" = hself.callHackage "fficxx" fficxx-version {};
-        "fficxx-runtime" =
-          hself.callHackage "fficxx-runtime" fficxx-version {};
-        "stdcxx" = hself.callHackage "stdcxx" fficxx-version {};
-        "template" = pkgs.haskell.lib.doJailbreak hsuper.template;
-        "HROOT" =
-          overrideCabal (hself.callHackage "HROOT" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
-        "HROOT-core" =
-          overrideCabal (hself.callHackage "HROOT-core" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
-        "HROOT-graf" =
-          overrideCabal (hself.callHackage "HROOT-graf" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
-        "HROOT-hist" =
-          overrideCabal (hself.callHackage "HROOT-hist" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
-        "HROOT-io" =
-          overrideCabal (hself.callHackage "HROOT-io" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
-        "HROOT-math" =
-          overrideCabal (hself.callHackage "HROOT-math" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
-        "HROOT-net" =
-          overrideCabal (hself.callHackage "HROOT-net" HROOT-version {RHTTP = null;}) {librarySystemDepends = [pkgs.root];};
-        "HROOT-tree" =
-          overrideCabal (hself.callHackage "HROOT-tree" HROOT-version {}) {librarySystemDepends = [pkgs.root];};
-
         "ormolu" =
           overrideCabal hsuper.ormolu {enableSeparateBinOutput = false;};
       });
-      HROOTdeps = p: [
-        p.fficxx
-        p.fficxx-runtime
-        p.stdcxx
-        p.HROOT
-        #p.template
-      ];
 
       hsenv = hpkgs.ghcWithPackages (p:
         [
@@ -85,7 +54,7 @@
           export MACOSX_DEPLOYMENT_TARGET="10.16"
           export FONTCONFIG_FILE="${fontconf}"
           export PANGOCAIRO_BACKEND=fc
-          export PS1="\n[github-api:\w]$ \0"
+          export PS1="\n[logcat/util:\w]$ \0"
         '';
       };
     });


### PR DESCRIPTION
Html generated by eventlog2html by large eventlog data with info table is
corrupted due to stack overflow in javascript. This adds a simple utility
to display the content. Used for profiling GHC.