### PR TITLE
Handle eventlog directly to get closure statistics

### DIFF
--- a/logcat/util/FromHTML.hs
+++ b/logcat/util/FromHTML.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Extract (
-  EventlogItem (..),
+module FromHTML (
   extract,
 ) where
 
@@ -19,19 +18,7 @@ import Text.HTML.TagSoup.Tree (
   tagTree,
   universeTree,
  )
-
-data EventlogItem = EventlogItem
-  { eventGraph :: [(Double, Double)]
-  , eventN :: Int
-  , eventLabel :: Text
-  , eventDesc :: Text
-  , eventCTy :: Text
-  , eventType :: Text
-  , eventModule :: Text
-  , eventLoc :: Text
-  , eventSize :: Double
-  }
-  deriving (Show)
+import Types (ClosureInfoItem (..))
 
 readT :: (Read a) => Text -> a
 readT = read . T.unpack
@@ -56,13 +43,13 @@ getText x = listToMaybe $ do
   TagLeaf (TagText content) <- xs
   pure content
 
-extract :: FilePath -> IO [EventlogItem]
+extract :: FilePath -> IO [ClosureInfoItem]
 extract fp = do
   txt <- TIO.readFile fp
   let tags = parseTags txt
       trs = tagTree tags
       convert (c1 : c2 : c3 : c4 : c5 : c6 : c7 : c8 : c9 : _) =
-        EventlogItem
+        ClosureInfoItem
           <$> getLineChart c1
           <*> (readT @Int <$> getText c2)
           <*> getText c3

--- a/logcat/util/GHCEvents.hs
+++ b/logcat/util/GHCEvents.hs
@@ -1,0 +1,10 @@
+module GHCEvents (extract) where
+
+import Data.ByteString.Lazy qualified as BL
+import GHC.RTS.Events (EventLog (..))
+import GHC.RTS.Events.Incremental (readEventLog)
+
+extract :: FilePath -> IO (Either String (EventLog, Maybe String))
+extract fp = do
+  lbs <- BL.readFile fp
+  pure $ readEventLog lbs

--- a/logcat/util/GHCEvents.hs
+++ b/logcat/util/GHCEvents.hs
@@ -2,19 +2,14 @@
 {-# LANGUAGE RecordWildCards #-}
 
 module GHCEvents (
-  -- *
   InfoTableProvEntry (..),
   InfoTableMap (..),
   Chunk (..),
   getChunkedEvents,
-
-  -- *
   chunkStat,
   addStat,
   makeGraph,
   makeClosureInfoItem,
-
-  -- *
   extract,
 ) where
 
@@ -26,14 +21,13 @@ import Data.List.Split (keepDelimsL, split, whenElt)
 import Data.Maybe (mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Word (Word8, Word64)
+import Data.Word (Word64, Word8)
 import GHC.Exts.Heap.ClosureTypes (ClosureType (..))
 import GHC.RTS.Events (
   Data (events),
   Event (evCap, evSpec, evTime),
-  EventLog (..),
   EventInfo (..),
-  EventLog (header, dat),
+  EventLog (..),
   Timestamp,
  )
 import GHC.RTS.Events.Incremental (readEventLog)
@@ -111,7 +105,7 @@ getChunkedEvents l =
           , seResidency = heapProfResidency
           , seLabel = heapProfLabel
           }
-    toSE _  = Nothing
+    toSE _ = Nothing
 
     splitted = split (keepDelimsL $ whenElt isBegin) profs
 
@@ -127,7 +121,7 @@ addSample t !acc SampleEntry {..} =
   let f Nothing = Just (t, seResidency)
       f (Just (_, v)) = Just (t, v + seResidency)
       !acc' = HM.alter f seLabel acc
-    in acc'
+   in acc'
 
 chunkStat :: Chunk -> HashMap Text (Timestamp, Word64)
 chunkStat c = L.foldl' (addSample (chunkTimestamp c)) HM.empty (chunkSamples c)
@@ -146,8 +140,8 @@ makeClosureInfoItem ipeMap (cid, graph) =
   Just $
     ClosureInfoItem
       { clsGraph = graph'
-      -- TODO: find the way to get this info.
-      , clsN = 0
+      , -- TODO: find the way to get this info.
+        clsN = 0
       , clsLabel = cid
       , clsDesc = maybe "" ipeTableName mipe
       , clsCTy = maybe "" (T.pack . show . ipeClosureDesc) mipe
@@ -170,7 +164,6 @@ makeClosureInfoItem ipeMap (cid, graph) =
     -- trapezoidal sum
     accSize = L.foldl' step 0 (zip graph' (tail graph'))
     mipe = HM.lookup cid ipeMap
-
 
 loadEventlog :: FilePath -> IO (Either String (EventLog, Maybe String))
 loadEventlog fp = do

--- a/logcat/util/GHCEvents.hs
+++ b/logcat/util/GHCEvents.hs
@@ -1,10 +1,56 @@
-module GHCEvents (extract) where
+module GHCEvents (
+  -- *
+  extract,
+
+  -- *
+  Chunk (..),
+  getChunkedEvents,
+) where
 
 import Data.ByteString.Lazy qualified as BL
-import GHC.RTS.Events (EventLog (..))
+import Data.List.Split (keepDelimsL, split, whenElt)
+import Data.Maybe (mapMaybe)
+import GHC.RTS.Events (
+  Data (events),
+  Event (evCap, evSpec, evTime),
+  EventLog (..),
+  EventInfo (..),
+  EventLog (header, dat),
+  Timestamp,
+ )
 import GHC.RTS.Events.Incremental (readEventLog)
 
 extract :: FilePath -> IO (Either String (EventLog, Maybe String))
 extract fp = do
   lbs <- BL.readFile fp
   pure $ readEventLog lbs
+
+data Chunk = Chunk
+  { chunkTimestamp :: Timestamp
+  , chunkEvents :: [(Timestamp, Event)]
+  }
+  deriving (Show)
+
+getChunkedEvents :: EventLog -> [Chunk]
+getChunkedEvents l =
+  let evs = events (dat l)
+      f e =
+        let mx =
+              case evSpec e of
+                HeapProfSampleBegin {} -> Just e
+                HeapProfSampleString {} -> Just e
+                InfoTableProv {} -> Just e
+                _ -> Nothing
+         in (evTime e,) <$> mx
+      getSec (t, _) = t `div` 1_000_000
+      xs = mapMaybe f evs
+      ys = fmap getSec xs
+
+      isBegin (_, e) =
+        case evSpec e of
+          HeapProfSampleBegin {} -> True
+          _ -> False
+      splitted = split (keepDelimsL $ whenElt isBegin) xs
+
+      toChunk ((t, _) : xs) = Chunk t xs
+   in fmap toChunk splitted

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -224,9 +224,10 @@ main = do
     Right (l, _) -> do
       let (infos, chunks) = GHCEvents.getChunkedEvents l
           format c =
-            c {GHCEvents.chunkSample = take 3 (GHCEvents.chunkSample c)}
-      -- mapM_ pPrint $ take 10 $ GHCEvents.infoTableMapContents infos
+            c {GHCEvents.chunkSamples = take 3 (GHCEvents.chunkSamples c)}
       mapM_ (pPrint . format) chunks
+      mapM_ (pPrint . GHCEvents.chunkStat) $ take 3 chunks
+      pPrint $ GHCEvents.constructGraph chunks
 
 main' :: IO ()
 main' = do

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -225,7 +225,7 @@ main = do
       let (infos, chunks) = GHCEvents.getChunkedEvents l
           format c =
             c {GHCEvents.chunkSample = take 3 (GHCEvents.chunkSample c)}
-      mapM_ pPrint $ take 10 $ GHCEvents.infoTableMapContents infos
+      -- mapM_ pPrint $ take 10 $ GHCEvents.infoTableMapContents infos
       mapM_ (pPrint . format) chunks
 
 main' :: IO ()

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -19,6 +19,7 @@ import Data.Time.Clock (
  )
 import Data.Traversable (for)
 import Extract (EventlogItem (..), extract)
+import GHCEvents qualified as GHCEvents
 import GI.Cairo.Render qualified as R
 import GI.Cairo.Render.Connector as RC
 import GI.Gdk qualified as Gdk
@@ -208,6 +209,12 @@ initFont = do
 
 main :: IO ()
 main = do
+  args <- getArgs
+  result <- GHCEvents.extract (args !! 0)
+  print result
+
+main' :: IO ()
+main' = do
   args <- getArgs
   dat <- extract (args !! 0)
   let items = take 100 $ L.sortBy (flip compare `Fn.on` eventSize) dat

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -176,7 +176,7 @@ drawItem (pctxt, desc) (ox, oy) item = do
   drawGraph (ox, oy) (clsGraph item)
   R.setSourceRGBA 0.3 0.3 0.3 1.0
   drawTextLine (pctxt, desc) (ox + 210, oy - 15.0) (T.pack $ show $ clsN item)
-  drawTextLine (pctxt, desc) (ox + 260, oy - 15.0) (T.pack $ show $ clsSize item)
+  drawTextLine (pctxt, desc) (ox + 260, oy - 15.0) (T.pack $ printf "%.2f" $ clsSize item)
   drawTextLine (pctxt, desc) (ox + 320, oy - 15.0) (clsLabel item)
   drawTextLine (pctxt, desc) (ox + 420, oy - 15.0) (clsDesc item)
   drawTextLine (pctxt, desc) (ox + 700, oy - 15.0) (clsCTy item)
@@ -224,23 +224,7 @@ initFont = do
 main :: IO ()
 main = do
   args <- getArgs
-  eresult <- GHCEvents.extract (args !! 0)
-  case eresult of
-    Left err -> print err
-    Right (l, _) -> do
-      let (infos, chunks) = GHCEvents.getChunkedEvents l
-          format c =
-            c {GHCEvents.chunkSamples = take 3 (GHCEvents.chunkSamples c)}
-      mapM_ (pPrint . format) chunks
-      mapM_ (pPrint . GHCEvents.chunkStat) $ take 3 chunks
-      let graphs = HM.toList $ GHCEvents.makeGraph chunks
-      -- mapM_ pPrint graphs
-      mapM_ (pPrint . GHCEvents.makeClosureInfoItem infos) graphs
-
-main' :: IO ()
-main' = do
-  args <- getArgs
-  dat <- FromHTML.extract (args !! 0)
+  dat <- GHCEvents.extract (args !! 0)
   let items = take 100 $ L.sortBy (flip compare `Fn.on` clsSize) dat
   mapM_ print items
   ref <- newIORef (GridState (ViewPort (0, 0) (1024, 768)) Nothing)

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -24,6 +24,7 @@ import GHC.RTS.Events (
   Event (evCap, evSpec, evTime),
   EventInfo (..),
   EventLog (header, dat),
+  Timestamp,
  )
 import GHCEvents qualified as GHCEvents
 import GI.Cairo.Render qualified as R
@@ -35,6 +36,7 @@ import GI.PangoCairo qualified as PC
 import System.Environment (getArgs)
 import System.IO (hFlush, stdout)
 import Text.Printf (printf)
+import Text.Show.Pretty (pPrint)
 
 data ViewPort = ViewPort (Double, Double) (Double, Double)
   deriving (Show)
@@ -220,23 +222,11 @@ main = do
   case eresult of
     Left err -> print err
     Right (l, _) -> do
-      print (header l)
-      let evs = events (dat l)
-          f e =
-            let mx =
-                  case evSpec e of
-                    -- InfoTableProv {} -> Just e
-                    HeapProfSampleBegin {} -> Just e
-                    -- HeapProfSampleString {} -> Just e
-                    _ -> Nothing
-             in (evTime e,) <$> mx
-      let getSec (t, _) = t `div` 1_000_000
-          xs = mapMaybe f evs
-          ys = fmap getSec xs
-      print (length xs)
-      --print (length evs)
-      mapM_ print xs -- (take 100 xs)
-      -- mapM_ print (L.nub ys)
+      let cs = GHCEvents.getChunkedEvents l
+          c = head cs
+          c' = c {GHCEvents.chunkEvents = take 3 (GHCEvents.chunkEvents c)}
+      pPrint c'
+      -- print (header l)
 
 main' :: IO ()
 main' = do

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -24,7 +24,7 @@ import GHC.RTS.Events (
   Data (events),
   Event (evCap, evSpec, evTime),
   EventInfo (..),
-  EventLog (header, dat),
+  EventLog (dat, header),
   Timestamp,
  )
 import GHCEvents qualified as GHCEvents

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -7,6 +7,7 @@ import Data.Foldable (for_)
 import Data.Function qualified as Fn (on)
 import Data.GI.Base (AttrOp ((:=)), after, get, new, on)
 import Data.GI.Gtk.Threading (postGUIASync)
+import Data.HashMap.Strict qualified as HM
 import Data.IORef (modifyIORef', newIORef, readIORef)
 import Data.List qualified as L
 import Data.Maybe (fromMaybe, mapMaybe)
@@ -232,7 +233,9 @@ main = do
             c {GHCEvents.chunkSamples = take 3 (GHCEvents.chunkSamples c)}
       mapM_ (pPrint . format) chunks
       mapM_ (pPrint . GHCEvents.chunkStat) $ take 3 chunks
-      pPrint $ GHCEvents.constructGraph chunks
+      let graphs = HM.toList $ GHCEvents.makeGraph chunks
+      -- mapM_ pPrint graphs
+      mapM_ (pPrint . GHCEvents.makeClosureInfoItem infos) graphs
 
 main' :: IO ()
 main' = do

--- a/logcat/util/Main.hs
+++ b/logcat/util/Main.hs
@@ -222,11 +222,11 @@ main = do
   case eresult of
     Left err -> print err
     Right (l, _) -> do
-      let cs = GHCEvents.getChunkedEvents l
-          c = head cs
-          c' = c {GHCEvents.chunkEvents = take 3 (GHCEvents.chunkEvents c)}
-      pPrint c'
-      -- print (header l)
+      let (infos, chunks) = GHCEvents.getChunkedEvents l
+          format c =
+            c {GHCEvents.chunkSample = take 3 (GHCEvents.chunkSample c)}
+      mapM_ pPrint $ take 10 $ GHCEvents.infoTableMapContents infos
+      mapM_ (pPrint . format) chunks
 
 main' :: IO ()
 main' = do

--- a/logcat/util/Types.hs
+++ b/logcat/util/Types.hs
@@ -1,0 +1,18 @@
+module Types (
+  ClosureInfoItem (..),
+) where
+
+import Data.Text (Text)
+
+data ClosureInfoItem = ClosureInfoItem
+  { clsGraph :: [(Double, Double)]
+  , clsN :: Int
+  , clsLabel :: Text
+  , clsDesc :: Text
+  , clsCTy :: Text
+  , clsType :: Text
+  , clsModule :: Text
+  , clsLoc :: Text
+  , clsSize :: Double
+  }
+  deriving (Show)

--- a/logcat/util/flake.nix
+++ b/logcat/util/flake.nix
@@ -20,6 +20,7 @@
         p.aeson
         p.directory
         p.filepath
+        p.ghc-events
         p.gi-cairo
         p.gi-cairo-connector
         p.gi-cairo-render
@@ -28,7 +29,6 @@
         p.gi-gtk-hs
         p.gi-pango
         p.gi-pangocairo
-        #p.haskell-gi-base
         p.lens
         p.lens-aeson
         p.pretty-simple


### PR DESCRIPTION
now we do not have to rely on generated html file from eventlog2html. 
a step towards live info-table profiling.