### PR TITLE
Dump cluster module graph from console

### DIFF
--- a/daemon/src/GHCSpecter/Driver/Terminal.hs
+++ b/daemon/src/GHCSpecter/Driver/Terminal.hs
@@ -58,6 +58,14 @@ main cliSess = do
                       chanQEv
                       (UsrEv (ConsoleEv ConsoleDumpMemory))
                 loop
+            | input == ":dump-modgraph" -> do
+                outputStrLn $ "Input was: " <> input
+                lift $
+                  atomically $
+                    writeTQueue
+                      chanQEv
+                      (UsrEv (ConsoleEv ConsoleDumpModGraph))
+                loop
             | ":focus " `L.isPrefixOf` input -> do
                 outputStrLn $ "Input was: " <> input
                 let mx :: Maybe Int = readMaybe (drop 7 input)

--- a/daemon/src/GHCSpecter/UI/Types/Event.hs
+++ b/daemon/src/GHCSpecter/UI/Types/Event.hs
@@ -148,8 +148,10 @@ data ConsoleEvent k
   | ConsoleInput Text
   | -- | True: send the command immediately, False: wait for user's Enter.
     ConsoleButtonPressed Bool Text
-  | ConsoleDumpTiming
+  | -- TODO: we should have these cases into one and make each case as a nested type.
+    ConsoleDumpTiming
   | ConsoleDumpMemory
+  | ConsoleDumpModGraph
   deriving (Show, Eq)
 
 data UserEvent


### PR DESCRIPTION
module graph information can be dumped from the console like timing and memory allocation info.