### PR TITLE
Automatically computed cluster node size by heuristic

### DIFF
--- a/daemon/src/GHCSpecter/Driver.hs
+++ b/daemon/src/GHCSpecter/Driver.hs
@@ -19,8 +19,7 @@ import GHCSpecter.Server.Types (initServerState)
 startComm :: Config -> IO ServerSession
 startComm cfg = do
   let socketFile = configSocket cfg
-      nodeSizeLimit = configModuleClusterSize cfg
-  ssRef <- atomically $ newTVar (initServerState nodeSizeLimit)
+  ssRef <- atomically $ newTVar initServerState
   workQ <- newTQueueIO
   chanSignal <- newTChanIO
   let servSess = ServerSession ssRef chanSignal

--- a/daemon/src/GHCSpecter/Driver/Comm.hs
+++ b/daemon/src/GHCSpecter/Driver/Comm.hs
@@ -81,10 +81,6 @@ updateInbox chanMsg = incrementSN . updater
          in (serverTiming . tsTimingMap %~ alterToKeyMap f drvId)
       CMBox (CMSession s') ->
         (serverSessionInfo .~ s')
-          . ( case sessionPreferredModuleClusterSize s' of
-                Nothing -> id
-                Just size -> (serverModuleClusterSize .~ size)
-            )
       CMBox (CMModuleGraph mgi _msrcs) ->
         (serverModuleGraphState . mgsModuleGraphInfo .~ mgi)
       CMBox (CMHsHie _ _) ->

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -150,16 +150,14 @@ data ServerState = ServerState
     _serverSuppView :: Map ModuleName [((Text, Int), SupplementaryView)],
     _serverModuleGraphState :: ModuleGraphState,
     _serverHieState :: HieState,
-    _serverModuleBreakpoints :: [ModuleName],
-    -- TODO: These numbers from configuration should be separated to an env in ReaderT.
-    _serverModuleClusterSize :: Int
+    _serverModuleBreakpoints :: [ModuleName]
   }
   deriving (Show, Generic)
 
 makeClassy ''ServerState
 
-initServerState :: Int -> ServerState
-initServerState nodeSizeLimit =
+initServerState {- Int -> -} :: ServerState
+initServerState {- nodeSizeLimit -} =
   ServerState
     { _serverMessageSN = 0,
       _serverShouldUpdate = True,
@@ -172,8 +170,7 @@ initServerState nodeSizeLimit =
       _serverSuppView = mempty,
       _serverModuleGraphState = emptyModuleGraphState,
       _serverHieState = emptyHieState,
-      _serverModuleBreakpoints = [],
-      _serverModuleClusterSize = nodeSizeLimit
+      _serverModuleBreakpoints = []
     }
 
 incrementSN :: ServerState -> ServerState

--- a/plugin/src-ghc96/Plugin/GHCSpecter/Init.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter/Init.hs
@@ -93,8 +93,7 @@ initGhcSession env = do
                     sessionGhcMode = ghcMode,
                     sessionBackend = backend,
                     sessionStartTime = Just startTime,
-                    sessionIsPaused = configStartWithBreakpoint cfg,
-                    sessionPreferredModuleClusterSize = Just (configModuleClusterSize cfg)
+                    sessionIsPaused = configStartWithBreakpoint cfg
                   }
           modifyTVar'
             sessionRef

--- a/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
+++ b/plugin/src/GHCSpecter/Channel/Outbound/Types.hs
@@ -179,8 +179,7 @@ data SessionInfo = SessionInfo
     sessionGhcMode :: GhcMode,
     sessionBackend :: Backend,
     sessionStartTime :: Maybe UTCTime,
-    sessionIsPaused :: Bool,
-    sessionPreferredModuleClusterSize :: Maybe Int
+    sessionIsPaused :: Bool
   }
   deriving (Show, Generic)
 
@@ -193,8 +192,7 @@ emptySessionInfo =
       sessionGhcMode = CompManager,
       sessionBackend = NCG,
       sessionStartTime = Nothing,
-      sessionIsPaused = True,
-      sessionPreferredModuleClusterSize = Nothing
+      sessionIsPaused = True
     }
 
 data ChanMessage (a :: Channel) where

--- a/plugin/src/GHCSpecter/Config.hs
+++ b/plugin/src/GHCSpecter/Config.hs
@@ -13,20 +13,17 @@ import GHC.Generics (Generic)
 data Config = Config
   { configSocket :: FilePath,
     configSessionFile :: FilePath,
-    configStartWithBreakpoint :: Bool,
-    configModuleClusterSize :: Int
+    configStartWithBreakpoint :: Bool
   }
   deriving (Show, Generic)
 
 -- | default configuration
--- NOTE: non-trivial default value: cluster size = 150.
 emptyConfig :: Config
 emptyConfig =
   Config
     { configSocket = "/tmp/ghc-specter.ipc",
       configSessionFile = "",
-      configStartWithBreakpoint = False {- True -},
-      configModuleClusterSize = 150
+      configStartWithBreakpoint = False {- True -}
     }
 
 defaultGhcSpecterConfigFile :: FilePath


### PR DESCRIPTION
users do not need to give the cluster size value.