### PR TITLE
Tab-related bug fixes

### DIFF
--- a/daemon/app/ghc-specter-daemon/Render.hs
+++ b/daemon/app/ghc-specter-daemon/Render.hs
@@ -140,19 +140,14 @@ singleFrame io window ui ss oldShared = do
   newShared' <- flip runReaderT newShared $ do
     -- main window
     _ <- liftIO $ begin ("main" :: CString) nullPtr 0
-    let currentTab = ui._uiModel._modelTab
-        -- TODO: this is current workaround. Timing tab will be separated out.
-        mpreselected =
-          case currentTab of
-            TabTiming -> Nothing
-            _ -> Just currentTab
+    let mnextTab = ui._uiModel._modelTabDestination
     tabState <-
       ifM
         (toBool <$> liftIO (beginTabBar ("#main-tabbar" :: CString)))
         ( do
             tabState <-
               makeTabContents
-                mpreselected
+                mnextTab
                 [ (TabSession, "Session", tabSession ui ss),
                   (TabModuleGraph, "Module graph", tabModuleGraph ui ss),
                   (TabSourceView, "Source view", tabSourceView ui ss),

--- a/daemon/app/ghc-specter-daemon/Render.hs
+++ b/daemon/app/ghc-specter-daemon/Render.hs
@@ -25,7 +25,10 @@ import GHCSpecter.Driver.Session.Types
   )
 import GHCSpecter.Graphics.DSL (EventMap)
 import GHCSpecter.Server.Types (ServerState (..))
-import GHCSpecter.UI.Types (UIState (..))
+import GHCSpecter.UI.Types
+  ( UIModel (..),
+    UIState (..),
+  )
 import GHCSpecter.UI.Types.Event
   ( Tab (..),
     UserEvent (..),
@@ -137,12 +140,19 @@ singleFrame io window ui ss oldShared = do
   newShared' <- flip runReaderT newShared $ do
     -- main window
     _ <- liftIO $ begin ("main" :: CString) nullPtr 0
+    let currentTab = ui._uiModel._modelTab
+        -- TODO: this is current workaround. Timing tab will be separated out.
+        mpreselected =
+          case currentTab of
+            TabTiming -> Nothing
+            _ -> Just currentTab
     tabState <-
       ifM
         (toBool <$> liftIO (beginTabBar ("#main-tabbar" :: CString)))
         ( do
             tabState <-
               makeTabContents
+                mpreselected
                 [ (TabSession, "Session", tabSession ui ss),
                   (TabModuleGraph, "Module graph", tabModuleGraph ui ss),
                   (TabSourceView, "Source view", tabSourceView ui ss),

--- a/daemon/app/ghc-specter-daemon/Render/Console.hs
+++ b/daemon/app/ghc-specter-daemon/Render/Console.hs
@@ -126,7 +126,7 @@ renderMainPanel ss tabs consoleMap mconsoleFocus inputEntry = do
           fmap
             (\(drv_id, tab_title) -> (drv_id, tab_title, renderMainContent ss consoleMap mconsoleFocus inputEntry))
             tabs
-    mselected <- makeTabContents tab_contents
+    mselected <- makeTabContents Nothing tab_contents
     when (mconsoleFocus /= mselected) $
       case mselected of
         Nothing -> pure ()

--- a/daemon/app/ghc-specter-daemon/Util/GUI.hs
+++ b/daemon/app/ghc-specter-daemon/Util/GUI.hs
@@ -172,9 +172,7 @@ makeTabContents mpreselected = fmap (getFirst . fold) . traverse go
         if Just tag == mpreselected
           then
             let flagSelected = fromIntegral (fromEnum ImGuiTabItemFlags_SetSelected)
-             in -- failed experiment yet.
-                -- toBool <$> liftIO (beginTabItem title' nullPtr flagSelected)
-                toBool <$> liftIO (beginTabItem_ title')
+             in toBool <$> liftIO (beginTabItem title' nullPtr flagSelected)
           else toBool <$> liftIO (beginTabItem_ title')
       when isSelected $ do
         void mkItem

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -204,7 +204,7 @@ handleConsoleCommand drvId msg
             ui' =
               ui
                 & (uiModel . modelSourceView . srcViewExpandedModule .~ mmod)
-                  . (uiModel . modelTab .~ TabSourceView)
+                  . (uiModel . modelTabDestination .~ Just TabSourceView)
          in (ui', ss)
       -- TODO: this goes back to top-level. this should be taken out of this function's scope.
       refresh
@@ -819,12 +819,12 @@ mainLoop = do
               tab <- (^. uiModel . modelTab) <$> getUI
               if (tab /= tab')
                 then do
-                  modifyUI (uiModel . modelTab .~ tab')
+                  modifyUI
+                    ((uiModel . modelTab .~ tab') . (uiModel . modelTabDestination .~ Nothing))
                   refresh
                   pure True
                 else pure False
-            ConsoleEv cev -> do
-              printMsg "I'm here"
+            ConsoleEv cev ->
               handleConsole cev >> pure False
             _ -> go ev >> pure False
 

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -177,6 +177,8 @@ emptyConsoleUI =
 data UIModel = UIModel
   { -- | current tab.
     _modelTab :: Tab,
+    -- | programmatic destination of Tab (for :goto-source) in the next frame.
+    _modelTabDestination :: Maybe Tab,
     -- | UI model of session
     _modelSession :: SessionUI,
     -- | UI model of main module graph
@@ -202,6 +204,7 @@ emptyUIModel :: UIModel
 emptyUIModel =
   UIModel
     { _modelTab = TabSession,
+      _modelTabDestination = Nothing,
       _modelSession = emptySessionUI,
       _modelMainModuleGraph = emptyModuleGraphUI,
       _modelSubModuleGraph = (UpTo30, emptyModuleGraphUI),

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693238797,
-        "narHash": "sha256-IETln0OR6/3pb21RrTmNL6IS983p9J7xLuWr3bwjF3M=",
+        "lastModified": 1693246860,
+        "narHash": "sha256-aG4MV6o/Xwv92Pwr505W0ZPhLFLQ3dLR1PE6S+BqCQU=",
         "owner": "wavewave",
         "repo": "hs-imgui",
-        "rev": "9005956fee2999c9c0db866faad5f7c27e53d3ee",
+        "rev": "a229792a181e208c976fbf59f8bbc771141019f4",
         "type": "github"
       },
       "original": {

--- a/plugin/src/GHCSpecter/Config.hs
+++ b/plugin/src/GHCSpecter/Config.hs
@@ -23,7 +23,7 @@ emptyConfig =
   Config
     { configSocket = "/tmp/ghc-specter.ipc",
       configSessionFile = "",
-      configStartWithBreakpoint = False -- True
+      configStartWithBreakpoint = True
     }
 
 defaultGhcSpecterConfigFile :: FilePath


### PR DESCRIPTION
`:goto-source` console command now goes to the source tab.
and session pause/resume works regardless of the selected tab (bug happened as the button is out of session tab).