### PR TITLE
Console uses native widgets

### DIFF
--- a/daemon/app/ghc-specter-daemon/Main.hs
+++ b/daemon/app/ghc-specter-daemon/Main.hs
@@ -69,7 +69,7 @@ main = do
     counter_ref <- newIORef 0
     em_ref <- newTVarIO []
     stage_ref <- newTVarIO (Stage [])
-
+    console_scroll_ref <- newTVarIO False
     let runHandler =
           RunnerHandler
             { runHandlerRefreshAction = pure (),
@@ -87,7 +87,10 @@ main = do
                 Stage cfgs <- readTVar stage_ref
                 let cfgs' = filter (\scene' -> scene.sceneId /= scene'.sceneId) cfgs
                     cfgs'' = scene : cfgs'
-                writeTVar stage_ref (Stage cfgs'')
+                writeTVar stage_ref (Stage cfgs''),
+              runHandlerScrollDownConsoleToEnd =
+                -- putStrLn "scrollDownConsoleToEnd called!"
+                atomically $ writeTVar console_scroll_ref True
             }
         runner =
           RunnerEnv
@@ -105,4 +108,4 @@ main = do
         Session.main runner servSess cliSess Control.mainLoop
 
     -- start UI loop
-    Render.main servSess cliSess (em_ref, stage_ref)
+    Render.main servSess cliSess (em_ref, stage_ref, console_scroll_ref)

--- a/daemon/app/ghc-specter-daemon/Main.hs
+++ b/daemon/app/ghc-specter-daemon/Main.hs
@@ -89,7 +89,6 @@ main = do
                     cfgs'' = scene : cfgs'
                 writeTVar stage_ref (Stage cfgs''),
               runHandlerScrollDownConsoleToEnd =
-                -- putStrLn "scrollDownConsoleToEnd called!"
                 atomically $ writeTVar console_scroll_ref True
             }
         runner =

--- a/daemon/app/ghc-specter-daemon/Render.hs
+++ b/daemon/app/ghc-specter-daemon/Render.hs
@@ -197,9 +197,9 @@ prepareAssets io = do
 main ::
   ServerSession ->
   ClientSession ->
-  (TVar [EventMap UserEvent], TVar Stage) ->
+  (TVar [EventMap UserEvent], TVar Stage, TVar Bool) ->
   IO ()
-main servSess cliSess (em_ref, stage_ref) = do
+main servSess cliSess (em_ref, stage_ref, console_scroll_ref) = do
   -- initialize window
   (ctxt, io, window) <- initialize "ghc-specter"
   -- prepare assets (fonts)
@@ -223,7 +223,8 @@ main servSess cliSess (em_ref, stage_ref) = do
             sharedFontMono = fontMono,
             sharedEventMap = em_ref,
             sharedStage = stage_ref,
-            sharedConsoleInput = p_consoleInput
+            sharedConsoleInput = p_consoleInput,
+            sharedWillScrollDownConsole = console_scroll_ref
           }
 
   -- main loop

--- a/daemon/app/ghc-specter-daemon/Render/Console.hs
+++ b/daemon/app/ghc-specter-daemon/Render/Console.hs
@@ -53,6 +53,7 @@ import ImGui.ImVec2.Implementation (imVec2_x_get, imVec2_y_get)
 import STD.Deletable (delete)
 import Util.GUI
   ( makeTabContents,
+    windowFlagsNoScrollbar,
     windowFlagsScroll,
   )
 import Util.Render
@@ -100,11 +101,12 @@ renderMainContent ss consoleMap mconsoleFocus inputEntry = do
     w <- ImGui.getWindowWidth
     x0 <- imVec2_x_get v0
     y0 <- imVec2_y_get v0
-    pos <- ImGui.newImVec2 (x0 + w - 150) (y0 + 60)
+    pos <- ImGui.newImVec2 (x0 + w - 150) (y0 + 20)
     ImGui.setNextWindowPos pos 0 zerovec
     liftIO $ delete pos
-  vec1 <- liftIO $ ImGui.newImVec2 130 260
-  _ <- liftIO $ ImGui.beginChild ("child_window" :: CString) vec1 (fromBool True) windowFlagsScroll
+  --
+  vec1 <- liftIO $ ImGui.newImVec2 130 200
+  _ <- liftIO $ ImGui.beginChild ("child_window" :: CString) vec1 (fromBool True) windowFlagsNoScrollbar
   renderHelp ss mconsoleFocus
   liftIO ImGui.endChild
   liftIO $ delete zerovec

--- a/daemon/app/ghc-specter-daemon/Render/Session.hs
+++ b/daemon/app/ghc-specter-daemon/Render/Session.hs
@@ -32,14 +32,9 @@ import GHCSpecter.UI.Types.Event
   )
 import Handler (sendToControl)
 import ImGui qualified
-import Render.Common (renderComponent)
 import STD.Deletable (delete)
 import Util.GUI (defTableFlags, windowFlagsNone)
-import Util.Render
-  ( SharedState (..),
-    mkRenderState,
-    runImRender,
-  )
+import Util.Render (SharedState (..))
 
 render :: UIState -> ServerState -> ReaderT (SharedState UserEvent) IO ()
 render _ui ss = do

--- a/daemon/app/ghc-specter-daemon/Render/Session.hs
+++ b/daemon/app/ghc-specter-daemon/Render/Session.hs
@@ -72,22 +72,22 @@ render _ui ss = do
   liftIO $ delete vec3
 
 renderSessionInfo :: ServerState -> ReaderT (SharedState UserEvent) IO ()
-renderSessionInfo ss = do
-  renderState <- mkRenderState
-  runImRender renderState $
-    renderComponent False SessionEv (Session.buildSession ss)
+renderSessionInfo ss =
+  liftIO $
+    T.withCString (Session.buildSession ss) $ \cstr ->
+      ImGui.textUnformatted cstr
 
 renderProcessPanel :: ServerState -> ReaderT (SharedState UserEvent) IO ()
-renderProcessPanel ss = do
-  renderState <- mkRenderState
-  runImRender renderState $
-    renderComponent False SessionEv (Session.buildProcessPanel ss)
+renderProcessPanel ss =
+  liftIO $
+    T.withCString (Session.buildProcessPanel ss) $ \cstr ->
+      ImGui.textUnformatted cstr
 
 renderRtsPanel :: ServerState -> ReaderT (SharedState UserEvent) IO ()
-renderRtsPanel ss = do
-  renderState <- mkRenderState
-  runImRender renderState $
-    renderComponent False SessionEv (Session.buildRtsPanel ss)
+renderRtsPanel ss =
+  liftIO $
+    T.withCString (Session.buildRtsPanel ss) $ \cstr ->
+      ImGui.textUnformatted cstr
 
 renderCompilationStatus :: ServerState -> ReaderT (SharedState UserEvent) IO ()
 renderCompilationStatus ss = do

--- a/daemon/app/ghc-specter-daemon/Render/Session.hs
+++ b/daemon/app/ghc-specter-daemon/Render/Session.hs
@@ -12,6 +12,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Reader (ReaderT, ask)
 import Data.List (partition)
 import Data.Maybe (isJust)
+import Data.Text.Foreign qualified as T
 import Foreign.C.String (CString)
 import Foreign.Marshal.Utils (fromBool, toBool)
 import GHCSpecter.Channel.Outbound.Types
@@ -95,9 +96,9 @@ renderCompilationStatus ss = do
     ImGui.textUnformatted (statusTxt :: CString)
     whenM (toBool <$> ImGui.button (buttonTxt :: CString)) $
       sendToControl shared (SessionEv event)
-  renderState <- mkRenderState
-  runImRender renderState $
-    renderComponent False SessionEv (Session.buildModuleInProgress drvModMap pausedMap timingInProg)
+    let txt = Session.buildModuleInProgress drvModMap pausedMap timingInProg
+    T.withCString txt $ \cstr ->
+      ImGui.textUnformatted cstr
   where
     sessionInfo = ss._serverSessionInfo
     statusTxt

--- a/daemon/app/ghc-specter-daemon/Util/GUI.hs
+++ b/daemon/app/ghc-specter-daemon/Util/GUI.hs
@@ -7,6 +7,7 @@ module Util.GUI
 
     -- * common flags
     windowFlagsNone,
+    windowFlagsNoScrollbar,
     windowFlagsScroll,
     windowFlagsNoScroll,
     defTableFlags,
@@ -109,6 +110,11 @@ windowFlagsNone :: CInt
 windowFlagsNone =
   fromIntegral $
     fromEnum ImGuiWindowFlags_None
+
+windowFlagsNoScrollbar :: CInt
+windowFlagsNoScrollbar =
+  fromIntegral $
+    fromEnum ImGuiWindowFlags_NoScrollbar
 
 windowFlagsScroll :: CInt
 windowFlagsScroll =

--- a/daemon/app/ghc-specter-daemon/Util/Render.hs
+++ b/daemon/app/ghc-specter-daemon/Util/Render.hs
@@ -101,7 +101,8 @@ data SharedState e = SharedState
     sharedFontMono :: ImFont,
     sharedEventMap :: TVar [EventMap e],
     sharedStage :: TVar Stage,
-    sharedConsoleInput :: CString
+    sharedConsoleInput :: CString,
+    sharedWillScrollDownConsole :: TVar Bool
   }
 
 data ImRenderState e = ImRenderState

--- a/daemon/ghc-specter-daemon.cabal
+++ b/daemon/ghc-specter-daemon.cabal
@@ -139,7 +139,7 @@ executable ghc-specter-daemon
     Util.Render
   hs-source-dirs:
       app/ghc-specter-daemon
-  ghc-options: -Wall -Wunused-packages -threaded -rtsopts -with-rtsopts=-N -fno-warn-partial-type-signatures -Werror
+  ghc-options: -Wall -Wunused-packages -threaded -rtsopts -with-rtsopts=-N -fno-warn-partial-type-signatures
   build-depends:
       base >=4.15 && <5
     , bytestring

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# OPTIONS_GHC -w #-}
 
 module GHCSpecter.Control
   ( mainLoop,
@@ -47,6 +48,7 @@ import GHCSpecter.Control.DSL
     refresh,
     refreshUIAfter,
     saveSession,
+    scrollDownConsoleToEnd,
     sendRequest,
     shouldUpdate,
   )
@@ -329,6 +331,7 @@ handleHoverScrollZoom hitWho handlers mev =
       when isHandled refresh
       pure isHandled
 
+{-
 scrollDownConsoleToEnd :: Control Event ()
 scrollDownConsoleToEnd = do
   mext <- fmap (sceneExtents =<<) (getScene "console-main")
@@ -337,6 +340,7 @@ scrollDownConsoleToEnd = do
       let ViewPortInfo (vp'@(ViewPort (x0', _y0') (_x1', y1'))) _ = ui ^. uiModel . modelConsole . consoleViewPort
           vp'' = moveBoundingBoxBy (x0 - x0', y1 - y1') vp'
        in (uiModel . modelConsole . consoleViewPort .~ ViewPortInfo vp'' Nothing) ui
+-}
 
 dumpWork :: (UIState -> ServerState -> Text) -> FilePath -> Control Event ()
 dumpWork mkContent file = do

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# OPTIONS_GHC -w #-}
 
 module GHCSpecter.Control
   ( mainLoop,
@@ -14,7 +13,7 @@ where
 import Control.Concurrent.STM (readTVarIO)
 import Control.Lens (Lens', to, (%~), (&), (.~), (^.), _1, _2)
 import Control.Monad (guard, void, when)
-import Data.Foldable (for_, traverse_)
+import Data.Foldable (traverse_)
 import Data.List qualified as L
 import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as M
@@ -62,7 +61,6 @@ import GHCSpecter.Graphics.DSL
     ViewPort (..),
     eventMapGlobalViewPort,
     eventMapId,
-    moveBoundingBoxBy,
   )
 import GHCSpecter.Server.Types
   ( ConsoleItem (..),
@@ -330,17 +328,6 @@ handleHoverScrollZoom hitWho handlers mev =
       let isHandled = or rs
       when isHandled refresh
       pure isHandled
-
-{-
-scrollDownConsoleToEnd :: Control Event ()
-scrollDownConsoleToEnd = do
-  mext <- fmap (sceneExtents =<<) (getScene "console-main")
-  for_ mext $ \(ViewPort (x0, _y0) (_x1, y1)) -> do
-    modifyUI $ \ui ->
-      let ViewPortInfo (vp'@(ViewPort (x0', _y0') (_x1', y1'))) _ = ui ^. uiModel . modelConsole . consoleViewPort
-          vp'' = moveBoundingBoxBy (x0 - x0', y1 - y1') vp'
-       in (uiModel . modelConsole . consoleViewPort .~ ViewPortInfo vp'' Nothing) ui
--}
 
 dumpWork :: (UIState -> ServerState -> Text) -> FilePath -> Control Event ()
 dumpWork mkContent file = do

--- a/daemon/src/GHCSpecter/Control/DSL.hs
+++ b/daemon/src/GHCSpecter/Control/DSL.hs
@@ -12,6 +12,7 @@ module GHCSpecter.Control.DSL
     hitScene,
     getScene,
     addToStage,
+    scrollDownConsoleToEnd,
     sendRequest,
     nextEvent,
     printMsg,
@@ -87,6 +88,9 @@ addToStage ::
   Scene () ->
   Control e ()
 addToStage scene = liftF (AddToStage scene ())
+
+scrollDownConsoleToEnd :: Control e ()
+scrollDownConsoleToEnd = liftF (ScrollDownConsoleToEnd ())
 
 sendRequest :: Request -> Control e ()
 sendRequest b = liftF (SendRequest b ())

--- a/daemon/src/GHCSpecter/Control/Runner.hs
+++ b/daemon/src/GHCSpecter/Control/Runner.hs
@@ -66,9 +66,8 @@ data RunnerHandler e = RunnerHandler
     runHandlerGetScene ::
       Text ->
       IO (Maybe (EventMap UserEvent)),
-    runHandlerAddToStage ::
-      Scene () ->
-      IO ()
+    runHandlerAddToStage :: Scene () -> IO (),
+    runHandlerScrollDownConsoleToEnd :: IO ()
   }
 
 -- | mutating state and a few handlers
@@ -203,6 +202,10 @@ stepControl (Free (GetScene name cont)) = do
 stepControl (Free (AddToStage scene next)) = do
   addToStage' <- runHandlerAddToStage . runnerHandler <$> ask
   liftIO $ addToStage' scene
+  pure (Left next)
+stepControl (Free (ScrollDownConsoleToEnd next)) = do
+  scrollDownConsoleToEnd' <- runHandlerScrollDownConsoleToEnd . runnerHandler <$> ask
+  liftIO scrollDownConsoleToEnd'
   pure (Left next)
 stepControl (Free (SendRequest b next)) = do
   sendRequest' b

--- a/daemon/src/GHCSpecter/Control/Types.hs
+++ b/daemon/src/GHCSpecter/Control/Types.hs
@@ -56,6 +56,7 @@ data ControlF e e' r where
     Scene () ->
     r ->
     ControlF e e r
+  ScrollDownConsoleToEnd :: r -> ControlF e e r
   SendRequest :: Request -> r -> ControlF e e r
   NextEvent :: (Event -> r) -> ControlF e e r
   PrintMsg :: Text -> r -> ControlF e e r
@@ -80,6 +81,7 @@ instance IxFunctor ControlF where
   imap f (HitScene x cont) = HitScene x (f . cont)
   imap f (GetScene x cont) = GetScene x (f . cont)
   imap f (AddToStage x next) = AddToStage x (f next)
+  imap f (ScrollDownConsoleToEnd next) = ScrollDownConsoleToEnd (f next)
   imap f (SendRequest x next) = SendRequest x (f next)
   imap f (NextEvent cont) = NextEvent (f . cont)
   imap f (PrintMsg x next) = PrintMsg x (f next)

--- a/daemon/src/GHCSpecter/UI/Console.hs
+++ b/daemon/src/GHCSpecter/UI/Console.hs
@@ -1,10 +1,11 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -w #-}
 
 module GHCSpecter.UI.Console
   ( -- * utilities
     getTabName,
+    buildEachLine,
+    buildTextBlock,
 
     -- * build component
     buildConsoleTab,
@@ -19,11 +20,10 @@ import Control.Monad (join)
 import Data.Foldable qualified as F
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NE
-import Data.Maybe (fromMaybe, mapMaybe, maybeToList)
+import Data.Maybe (fromMaybe, maybeToList)
 import Data.Semigroup (sconcat)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Tree (drawTree)
 import GHCSpecter.Channel.Common.Types (DriverId (..))
 import GHCSpecter.Data.Map
   ( IsKey (..),
@@ -44,8 +44,7 @@ import GHCSpecter.Graphics.DSL
     viewPortWidth,
   )
 import GHCSpecter.Layouter.Packer
-  ( flowInline,
-    flowLineByLine,
+  ( flowLineByLine,
     toSizedLine,
   )
 import GHCSpecter.Layouter.Text
@@ -153,7 +152,8 @@ buildTextBlock txt = do
   pure (vp, sconcat contentss)
 
 {-
--- This is obsolete.
+-- NOTE: This is obsolete.
+-- TODO: place this to the attic.
 
 buildConsoleItem ::
   forall m k.

--- a/daemon/src/GHCSpecter/UI/Console.hs
+++ b/daemon/src/GHCSpecter/UI/Console.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -w #-}
 
 module GHCSpecter.UI.Console
   ( -- * utilities
@@ -151,6 +152,9 @@ buildTextBlock txt = do
   let (vp, contentss) = flowLineByLine 0 ls''
   pure (vp, sconcat contentss)
 
+{-
+-- This is obsolete.
+
 buildConsoleItem ::
   forall m k.
   (MonadTextLayout m) =>
@@ -189,27 +193,15 @@ buildConsoleItem (ConsoleButton buttonss) = do
 buildConsoleItem (ConsoleCore forest) = buildTextBlock (T.unlines $ fmap render1 forest)
   where
     render1 tr = T.pack $ drawTree $ fmap show tr
+-}
 
 buildConsoleMain ::
-  forall m k.
-  (MonadTextLayout m, IsKey k, Eq k) =>
+  forall k.
+  (IsKey k, Eq k) =>
   KeyMap k [ConsoleItem] ->
   Maybe k ->
-  m (Scene (Primitive (ConsoleEvent k)))
-buildConsoleMain contents mfocus = do
-  contentss <-
-    case NE.nonEmpty items of
-      Nothing -> NE.singleton <$> buildEachLine "No console history"
-      Just items' -> traverse buildConsoleItem items'
-  let (extent, rendered) = flowLineByLine 0 contentss
-  pure
-    Scene
-      { sceneId = "console-main",
-        sceneGlobalViewPort = extent,
-        sceneLocalViewPort = extent,
-        sceneElements = F.toList $ sconcat rendered,
-        sceneExtents = Just extent
-      }
+  [ConsoleItem]
+buildConsoleMain contents mfocus = items
   where
     mtxts = mfocus >>= (`lookupKey` contents)
     items = join $ maybeToList mtxts

--- a/daemon/src/GHCSpecter/UI/Session.hs
+++ b/daemon/src/GHCSpecter/UI/Session.hs
@@ -13,6 +13,7 @@ import Control.Lens ((^.))
 import Data.IntMap qualified as IM
 import Data.List (partition)
 import Data.Maybe (fromMaybe, isJust)
+import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Lazy qualified as TL
 import GHCSpecter.Channel.Common.Types
@@ -62,14 +63,11 @@ import Text.Pretty.Simple (pShowNoColor)
 import Prelude hiding (div)
 
 buildModuleInProgress ::
-  (MonadTextLayout m) =>
   BiKeyMap DriverId ModuleName ->
   KeyMap DriverId BreakpointLoc ->
   [(DriverId, Timer)] ->
-  m (Scene (Primitive e))
-buildModuleInProgress drvModMap pausedMap timingInProg = do
-  scene <- buildTextView (T.unlines msgs) []
-  pure scene {sceneId = "module-status"}
+  Text
+buildModuleInProgress drvModMap pausedMap timingInProg = T.unlines msgs
   where
     msgs =
       let is = fmap fst timingInProg

--- a/daemon/src/GHCSpecter/UI/Session.hs
+++ b/daemon/src/GHCSpecter/UI/Session.hs
@@ -55,7 +55,6 @@ import GHCSpecter.Server.Types
     HasTimingState (..),
     ServerState (..),
   )
-import GHCSpecter.UI.Components.TextView (buildTextView)
 import GHCSpecter.UI.Types.Event
   ( SessionEvent (..),
   )
@@ -80,12 +79,9 @@ buildModuleInProgress drvModMap pausedMap timingInProg = T.unlines msgs
        in fmap formatMessage imodinfos
 
 buildProcessPanel ::
-  (MonadTextLayout m) =>
   ServerState ->
-  m (Scene (Primitive e))
-buildProcessPanel ss = do
-  scene <- buildTextView (T.unlines msgsProcessInfo) []
-  pure scene {sceneId = "session-process"}
+  Text
+buildProcessPanel ss = T.unlines msgsProcessInfo
   where
     sessionInfo = ss ^. serverSessionInfo
     msgsProcessInfo =
@@ -106,13 +102,8 @@ buildProcessPanel ss = do
               let mkItem x = T.pack x
                in fmap mkItem (procArguments procinfo)
 
-buildRtsPanel ::
-  (MonadTextLayout m) =>
-  ServerState ->
-  m (Scene (Primitive e))
-buildRtsPanel ss = do
-  scene <- buildTextView (T.unlines msgsRtsInfo) []
-  pure scene {sceneId = "session-rts"}
+buildRtsPanel :: ServerState -> Text
+buildRtsPanel ss = T.unlines msgsRtsInfo
   where
     sessionInfo = ss ^. serverSessionInfo
     msgsRtsInfo =
@@ -124,13 +115,16 @@ buildRtsPanel ss = do
             TL.toStrict $ pShowNoColor rtsflags
           ]
 
-buildSession ::
-  (MonadTextLayout m) =>
-  ServerState ->
-  m (Scene (Primitive e))
-buildSession ss = do
-  scene <- buildTextView txt []
-  pure scene {sceneId = "session-main"}
+buildSession :: ServerState -> Text
+buildSession ss =
+  T.unlines
+    [ msgSessionStart,
+      "",
+      "Compilation Status",
+      msgCompilationStatus,
+      "",
+      msgGhcMode
+    ]
   where
     sessionInfo = ss ^. serverSessionInfo
     mgi = ss ^. serverModuleGraphState . mgsModuleGraphInfo
@@ -161,16 +155,6 @@ buildSession ss = do
       where
         ghcMode = T.pack $ show $ sessionGhcMode sessionInfo
         backend = T.pack $ show $ sessionBackend sessionInfo
-
-    txt =
-      T.unlines
-        [ msgSessionStart,
-          "",
-          "Compilation Status",
-          msgCompilationStatus,
-          "",
-          msgGhcMode
-        ]
 
 buildPauseResume ::
   forall m.

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693421798,
-        "narHash": "sha256-foS9QbLwwD+dOXhAjKY8jnEODzzC2JwFymf3M2Y3iVg=",
+        "lastModified": 1693454429,
+        "narHash": "sha256-Uqs2uBRXblqv9H3Sx705V0Wfe8Ox84JD68FwZJdb7Kg=",
         "owner": "wavewave",
         "repo": "hs-imgui",
-        "rev": "e8c8e986f9700ed31ae37870b0f7a8d815d051cb",
+        "rev": "280af0b0b725322df5923d1984ab920605c0d53c",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693454429,
-        "narHash": "sha256-Uqs2uBRXblqv9H3Sx705V0Wfe8Ox84JD68FwZJdb7Kg=",
+        "lastModified": 1693456084,
+        "narHash": "sha256-v0LvvdGMO1ICPwJqQTYbYIk8mZBVDmCSsmPWAwoVQqA=",
         "owner": "wavewave",
         "repo": "hs-imgui",
-        "rev": "280af0b0b725322df5923d1984ab920605c0d53c",
+        "rev": "91f0c845dc8f7e1fa36b9b0141bbf2244e761290",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
and Session and compilation status as well.
Custom rendering is now restricted to ghc-specter-oriented components.