### PR TITLE
Dependency clean-up and better dev/env shell nix expr

### DIFF
--- a/daemon/app/ghc-specter-daemon-terminal/Main.hs
+++ b/daemon/app/ghc-specter-daemon-terminal/Main.hs
@@ -55,7 +55,8 @@ main = do
             { runHandlerRefreshAction = pure (),
               runHandlerHitScene = \_ -> pure Nothing,
               runHandlerGetScene = \_ -> pure Nothing,
-              runHandlerAddToStage = \_ -> pure ()
+              runHandlerAddToStage = \_ -> pure (),
+              runHandlerScrollDownConsoleToEnd = pure ()
             }
         runner =
           RunnerEnv

--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693200206,
-        "narHash": "sha256-jIndbOlrLZXq4TLvYDRbcWlGNdfQeF5a/ADNNuo1JG4=",
+        "lastModified": 1693519761,
+        "narHash": "sha256-lmFjhy3XqqvGjnahYafyypPmfuIJfypaeSd65vwMKcQ=",
         "owner": "wavewave",
         "repo": "hs-ogdf",
-        "rev": "98250668813539721896a03f4ecaa022661dbe5d",
+        "rev": "1b424f0fb4bbef0e466098f2eebe65b212140b5d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -85,32 +85,20 @@
           then "ghc-specter:env"
           else "ghc-specter:dev";
       in
-        pkgs.mkShell {
-          packages = [
-            # for build
-            hsenv
-            pkgs.ogdf
-            pkgs.cabal-install
-
-            # for doc
-            pyenv
-
-            # for formatting
-            pkgs.alejandra
-            pkgs.ormolu
-
-            # for agda
-            pkgs.zlib
-
-            # for socket testing
-            pkgs.socat
-
-            # for GUI
-            pkgs.pkgconfig
-            pkgs.imgui
-            pkgs.implot
-            pkgs.glfw
+        (hpkgsFor compiler).shellFor {
+          packages = p: [
+            p.ghc-specter-render
+            p.ghc-specter-plugin
+            p.ghc-specter-daemon
           ];
+          buildInputs =
+            [
+              pkgs.cabal-install
+              pkgs.alejandra
+              pkgs.ormolu
+              pyenv
+            ]
+            ++ (pkgs.lib.optionals isEnv [(hpkgsFor compiler).ghc-specter-daemon]);
           shellHook = ''
             export PS1="\n[${prompt}:\w]$ \0"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -66,24 +66,32 @@
           // hs-imgui.haskellOverlay.${system} pkgs hself hsuper
           // haskellOverlay pkgs hself hsuper);
 
-      mkShellFor = isEnv: compiler: let
+      mkEnvShellFor = compiler: let
         hsenv = (hpkgsFor compiler).ghcWithPackages (
-          p:
-            [
-              p.OGDF
-              p.imgui
-              p.implot
-              p.hspec-discover
-            ]
-            ++ (pkgs.lib.optionals isEnv [p.ghc-specter-daemon])
+          p: [
+            p.ghc-specter-daemon
+            p.ghc-specter-plugin
+          ]
         );
+        prompt = "ghc-specter:env";
+      in
+        pkgs.mkShell {
+          packages = [
+            hsenv
+            pkgs.cabal-install
+            pkgs.alejandra
+            pkgs.ormolu
+          ];
+          shellHook = ''
+            export PS1="\n[${prompt}:\w]$ \0"
+          '';
+        };
+
+      mkDevShellFor = compiler: let
         pyenv =
           pkgs.python3.withPackages
           (p: [p.sphinx p.sphinx_rtd_theme p.myst-parser]);
-        prompt =
-          if isEnv
-          then "ghc-specter:env"
-          else "ghc-specter:dev";
+        prompt = "ghc-specter:dev";
       in
         (hpkgsFor compiler).shellFor {
           packages = p: [
@@ -91,14 +99,12 @@
             p.ghc-specter-plugin
             p.ghc-specter-daemon
           ];
-          buildInputs =
-            [
-              pkgs.cabal-install
-              pkgs.alejandra
-              pkgs.ormolu
-              pyenv
-            ]
-            ++ (pkgs.lib.optionals isEnv [(hpkgsFor compiler).ghc-specter-daemon]);
+          buildInputs = [
+            pkgs.cabal-install
+            pkgs.alejandra
+            pkgs.ormolu
+            pyenv
+          ];
           shellHook = ''
             export PS1="\n[${prompt}:\w]$ \0"
           '';
@@ -120,10 +126,10 @@
       inherit haskellOverlay;
 
       devShells =
-        pkgs.lib.genAttrs supportedCompilers (mkShellFor false)
+        pkgs.lib.genAttrs supportedCompilers mkDevShellFor
         // {
           default = devShells.${defaultCompiler};
-          env = mkShellFor true defaultCompiler;
+          env = mkEnvShellFor defaultCompiler;
         };
 
       packages = pkgs.lib.genAttrs supportedCompilers mkPackagesFor;

--- a/render/ghc-specter-render.cabal
+++ b/render/ghc-specter-render.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:           ghc-specter-render
-version:        0.1.0.0
+version:        1.0.0.0
 synopsis:       render primitives independent of backend
 description:    Please see the README on GitHub at <https://github.com/MercuryTechnologies/ghc-specter#readme>
 category:       Development


### PR DESCRIPTION
hs-ogdf was the culprit responsible for redundant deps.
Also use `shellFor` for dev env to tidy up nix expr.