### PR TITLE
Fix breakpoint position in runPhaseHook

### DIFF
--- a/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
+++ b/plugin/src-ghc96/Plugin/GHCSpecter/Hooks.hs
@@ -403,11 +403,11 @@ runPhaseHook' = PhaseHook $ \phase -> do
     Nothing -> runPhase phase'
     Just drvId -> do
       let locPrePhase = PreRunPhase phaseTxt
-      breakPoint drvId locPrePhase prePhaseCommands
       sendCompStateOnPhase drvId phase PhaseStart
+      breakPoint drvId locPrePhase prePhaseCommands
       result <- runPhase phase'
       let phase'Txt = phaseTxt
           locPostPhase = PostRunPhase (phaseTxt, phase'Txt)
-      breakPoint drvId locPostPhase postPhaseCommands
       sendCompStateOnPhase drvId phase PhaseEnd
+      breakPoint drvId locPostPhase postPhaseCommands
       pure result


### PR DESCRIPTION
GHC should be paused after sending the current status info in runPhaseHook. This solves the annoying "no module name" problem at the beginning of Hsc phase.