### PR TITLE
Remove lens dependency.

### DIFF
--- a/daemon/ghc-specter-daemon.cabal
+++ b/daemon/ghc-specter-daemon.cabal
@@ -88,7 +88,6 @@ library
     , haskeline
     , indexed
     , indexed-free
-    , lens
     , pretty-simple
     , resourcet
     , safe

--- a/daemon/src/GHCSpecter/Control.hs
+++ b/daemon/src/GHCSpecter/Control.hs
@@ -11,7 +11,7 @@ module GHCSpecter.Control
 where
 
 import Control.Concurrent.STM (readTVarIO)
-import Control.Lens (Lens', (%~), (&), (.~), (^.), _2)
+import Control.Lens (Lens', (%~), (&), (^.), _2)
 import Control.Monad (guard, void, when)
 import Data.Foldable (traverse_)
 import Data.List qualified as L
@@ -76,7 +76,8 @@ import GHCSpecter.UI.Constants
     uiUpdateInterval,
   )
 import GHCSpecter.UI.Types
-  ( ConsoleUI (..),
+  ( BlockerUI (..),
+    ConsoleUI (..),
     HasBlockerUI (..),
     HasConsoleUI (..),
     HasModuleGraphUI (..),
@@ -84,9 +85,8 @@ import GHCSpecter.UI.Types
     HasSourceViewUI (..),
     HasTimingUI (..),
     HasUIModel (..),
-    HasUIState (..),
-    HasViewPortInfo (..),
     ModuleGraphUI (..),
+    SessionUI (..),
     SourceViewUI (..),
     TimingUI (..),
     UIModel (..),
@@ -129,10 +129,24 @@ import GHCSpecter.Worker.Timing
   )
 import System.IO (IOMode (..), withFile)
 
+data TinyLens a b = TinyLens {getL :: a -> b, setL :: b -> a -> a}
+
+modifyL :: TinyLens a b -> (b -> b) -> a -> a
+modifyL l f x =
+  let y = getL l x
+      !y' = f y
+   in setL l y' x
+
+composeL :: TinyLens a b -> TinyLens b c -> TinyLens a c
+composeL l1 l2 = TinyLens get' set'
+  where
+    get' = getL l2 . getL l1
+    set' x = modifyL l1 (setL l2 x)
+
 data HandlerHoverScrollZoom = HandlerHoverScrollZoom
-  { handlerHover :: [(Text, Lens' UIModel (Maybe Text))],
-    handlerScroll :: [(Text, Lens' UIModel ViewPortInfo)],
-    handlerZoom :: [(Text, Lens' UIModel ViewPortInfo)]
+  { handlerHover :: [(Text, TinyLens UIModel (Maybe Text))],
+    handlerScroll :: [(Text, TinyLens UIModel ViewPortInfo)],
+    handlerZoom :: [(Text, TinyLens UIModel ViewPortInfo)]
   }
 
 nextUserEvent :: (e ~ Event) => Control e UserEvent
@@ -235,22 +249,22 @@ appendNewCommand drvId newMsg = do
 
 scroll ::
   EventMap e ->
-  Lens' UIModel ViewPortInfo ->
+  TinyLens UIModel ViewPortInfo ->
   (Double, Double) ->
   UIModel ->
   UIModel
 scroll emap lensViewPort (dx, dy) model =
   let ViewPort (cx0, _) (cx1, _) = eventMapGlobalViewPort emap
-      vp@(ViewPort (vx0, _) (vx1, _)) = model ^. lensViewPort ^. vpViewPort
+      vp@(ViewPort (vx0, _) (vx1, _)) = (getL lensViewPort model)._vpViewPort
       mvpExtent = sceneExtents emap
       scale = (cx1 - cx0) / (vx1 - vx0)
       vp' = transformScroll mvpExtent scale (dx, dy) vp
       vp'' = if isValid vp' then vp' else vp
-   in (lensViewPort .~ ViewPortInfo vp'' Nothing) model
+   in setL lensViewPort (ViewPortInfo vp'' Nothing) model
 
 zoom ::
   EventMap e ->
-  Lens' UIModel ViewPortInfo ->
+  TinyLens UIModel ViewPortInfo ->
   ((Double, Double), Double) ->
   UIModel ->
   UIModel
@@ -259,12 +273,12 @@ zoom emap lensViewPort ((x, y), scale) model =
       -- NOTE: While zooming is in progress, the scaling is always relative to
       -- the currently drawn (temporary) view.
       vp =
-        fromMaybe (model ^. lensViewPort . vpViewPort) (model ^. lensViewPort . vpTempViewPort)
+        fromMaybe ((getL lensViewPort model)._vpViewPort) ((getL lensViewPort model)._vpTempViewPort)
       rx = (x - cx0) / (cx1 - cx0)
       ry = (y - cy0) / (cy1 - cy0)
       vp' = (transformZoom (rx, ry) scale vp)
       vp'' = if isValid vp' then vp' else vp
-   in (lensViewPort . vpTempViewPort .~ Just vp'') model
+   in modifyL lensViewPort (\vpi -> vpi {_vpTempViewPort = Just vp''}) model
 
 -- TODO: this function should handle all of MouseEvent.
 handleHoverScrollZoom ::
@@ -284,17 +298,17 @@ handleHoverScrollZoom hitWho handlers mev =
             let mupdated = do
                   emap <- memap
                   guard (eventMapId emap == component)
-                  let mprevHit = ui ^. uiModel . hoverLens
+                  let mprevHit = getL hoverLens ui._uiModel
                       mnowHit = do
                         hitEvent <- hitItem (x, y) emap
                         ev' <- hitEventHoverOn hitEvent
                         hitWho ev'
                   if mnowHit /= mprevHit
-                    then pure ((uiModel . hoverLens .~ mnowHit) ui, ss {_serverShouldUpdate = False})
+                    then pure (ui {_uiModel = setL hoverLens mnowHit ui._uiModel}, ss {_serverShouldUpdate = False})
                     else Nothing
              in fromMaybe (ui, ss) mupdated
-        let mprevHit = ui ^. uiModel . hoverLens
-            mnowHit = ui' ^. uiModel . hoverLens
+        let mprevHit = getL hoverLens ui._uiModel
+            mnowHit = getL hoverLens ui'._uiModel
             isChanged = mnowHit /= mprevHit
         pure isChanged
     Scroll scene_id (_x, _y) (dx, dy) -> do
@@ -307,7 +321,7 @@ handleHoverScrollZoom hitWho handlers mev =
             modifyUI $ \ui ->
               let mupdated = do
                     guard isHandled
-                    pure $ (uiModel %~ scroll emap scrollLens (dx, dy)) ui
+                    pure ui {_uiModel = scroll emap scrollLens (dx, dy) ui._uiModel}
                in fromMaybe ui mupdated
             pure isHandled
     ZoomUpdate scene_id (xcenter, ycenter) scale -> do
@@ -320,7 +334,7 @@ handleHoverScrollZoom hitWho handlers mev =
             modifyUI $ \ui ->
               let mupdated = do
                     guard isHandled
-                    pure $ (uiModel %~ zoom emap zoomLens ((xcenter, ycenter), scale)) ui
+                    pure ui {_uiModel = zoom emap zoomLens ((xcenter, ycenter), scale) ui._uiModel}
                in fromMaybe ui mupdated
             pure isHandled
     -- TODO: this should have pointer info.
@@ -328,8 +342,9 @@ handleHoverScrollZoom hitWho handlers mev =
       _ <-
         handleFor handlerZoom $ \(_component, zoomLens) -> do
           modifyUI $ \ui ->
-            let ui' = case ui ^. uiModel . zoomLens . vpTempViewPort of
-                  Just viewPort -> (uiModel . zoomLens .~ ViewPortInfo viewPort Nothing) ui
+            let ui' = case (getL zoomLens (ui._uiModel))._vpTempViewPort of
+                  Just viewPort ->
+                    ui {_uiModel = setL zoomLens (ViewPortInfo viewPort Nothing) ui._uiModel}
                   Nothing -> ui
              in ui'
           -- TODO: This is because it cannot distinguish components unfortunately.
@@ -339,8 +354,8 @@ handleHoverScrollZoom hitWho handlers mev =
     MouseClick {} -> pure False
   where
     handleFor ::
-      (HandlerHoverScrollZoom -> [(Text, Lens' UIModel a)]) ->
-      ((Text, Lens' UIModel a) -> Control e Bool) ->
+      (HandlerHoverScrollZoom -> [(Text, TinyLens UIModel a)]) ->
+      ((Text, TinyLens UIModel a) -> Control e Bool) ->
       Control e Bool
     handleFor getHandler go = do
       rs <- traverse go (getHandler handlers)
@@ -511,15 +526,35 @@ goSession ev = do
           HandlerHoverScrollZoom
             { handlerHover = [],
               handlerScroll =
-                [ ("module-status", modelSession . sessionUIModStatusViewPort),
-                  ("session-process", modelSession . sessionUIProcessViewPort),
-                  ("session-rts", modelSession . sessionUIRtsViewPort)
+                [ ( "module-status",
+                    composeL
+                      lensModelSession
+                      (TinyLens (._sessionUIModStatusViewPort) (\vp s -> s {_sessionUIModStatusViewPort = vp}))
+                  ),
+                  ( "session-process",
+                    composeL
+                      lensModelSession
+                      (TinyLens (._sessionUIProcessViewPort) (\vp s -> s {_sessionUIProcessViewPort = vp}))
+                  ),
+                  ( "session-rts",
+                    composeL
+                      lensModelSession
+                      (TinyLens (._sessionUIRtsViewPort) (\vp s -> s {_sessionUIRtsViewPort = vp}))
+                  )
                 ],
               handlerZoom =
-                [("session-process", modelSession . sessionUIProcessViewPort)]
+                [ ( "session-process",
+                    composeL
+                      lensModelSession
+                      (TinyLens (._sessionUIProcessViewPort) (\vp s -> s {_sessionUIProcessViewPort = vp}))
+                  )
+                ]
             }
           mev
     _ -> pure ()
+  where
+    lensModelSession =
+      TinyLens (._modelSession) (\x m -> m {_modelSession = x})
 
 goModuleGraph :: (e ~ Event) => UserEvent -> Control e ()
 goModuleGraph ev = do
@@ -568,21 +603,43 @@ goModuleGraph ev = do
           )
           HandlerHoverScrollZoom
             { handlerHover =
-                [ ("main-module-graph", modelMainModuleGraph . modGraphUIHover),
-                  ("sub-module-graph", modelSubModuleGraph . _2 . modGraphUIHover)
+                [ ("main-module-graph", composeL lensMainModuleGraph lensUIHover),
+                  ("sub-module-graph", composeL lensSubModuleGraph lensUIHover)
                 ],
               handlerScroll =
-                [ ("main-module-graph", modelMainModuleGraph . modGraphViewPort),
-                  ("sub-module-graph", modelSubModuleGraph . _2 . modGraphViewPort)
+                [ ("main-module-graph", composeL lensMainModuleGraph lensViewPort),
+                  ("sub-module-graph", composeL lensSubModuleGraph lensViewPort)
                 ],
               handlerZoom =
-                [ ("main-module-graph", modelMainModuleGraph . modGraphViewPort),
-                  ("sub-module-graph", modelSubModuleGraph . _2 . modGraphViewPort)
+                [ ("main-module-graph", composeL lensMainModuleGraph lensViewPort),
+                  ("sub-module-graph", composeL lensSubModuleGraph lensViewPort)
                 ]
             }
           mev
     _ -> pure ()
   where
+    lensMainModuleGraph =
+      TinyLens
+        (._modelMainModuleGraph)
+        (\g m -> m {_modelMainModuleGraph = g})
+    lensSubModuleGraph =
+      TinyLens
+        (snd . (._modelSubModuleGraph))
+        ( \g m ->
+            m
+              { _modelSubModuleGraph =
+                  let (lvl, _) = m._modelSubModuleGraph
+                   in (lvl, g)
+              }
+        )
+    lensUIHover =
+      TinyLens
+        (._modGraphUIHover)
+        (\h g -> g {_modGraphUIHover = h})
+    lensViewPort =
+      TinyLens
+        (._modGraphViewPort)
+        (\vp g -> g {_modGraphViewPort = vp})
     handleModuleGraphEv ::
       ModuleGraphEvent ->
       ModuleGraphUI ->
@@ -660,17 +717,40 @@ goSourceView ev = do
           HandlerHoverScrollZoom
             { handlerHover = [],
               handlerScroll =
-                [ ("module-tree", modelSourceView . srcViewModuleTreeViewPort),
-                  ("source-view", modelSourceView . srcViewSourceViewPort),
-                  ("supple-view-contents", modelSourceView . srcViewSuppViewPort)
+                [ ( "module-tree",
+                    composeL
+                      lensSourceView
+                      (TinyLens (._srcViewModuleTreeViewPort) (\vp s -> s {_srcViewModuleTreeViewPort = vp}))
+                  ),
+                  ( "source-view",
+                    composeL
+                      lensSourceView
+                      (TinyLens (._srcViewSourceViewPort) (\vp s -> s {_srcViewSourceViewPort = vp}))
+                  ),
+                  ( "supple-view-contents",
+                    composeL
+                      lensSourceView
+                      (TinyLens (._srcViewSuppViewPort) (\vp s -> s {_srcViewSuppViewPort = vp}))
+                  )
                 ],
               handlerZoom =
-                [ ("source-view", modelSourceView . srcViewSourceViewPort),
-                  ("supple-view-contents", modelSourceView . srcViewSuppViewPort)
+                [ ( "source-view",
+                    composeL
+                      lensSourceView
+                      (TinyLens (._srcViewSourceViewPort) (\vp s -> s {_srcViewSourceViewPort = vp}))
+                  ),
+                  ( "supple-view-contents",
+                    composeL
+                      lensSourceView
+                      (TinyLens (._srcViewSuppViewPort) (\vp s -> s {_srcViewSuppViewPort = vp}))
+                  )
                 ]
             }
           mev
     _ -> pure ()
+  where
+    lensSourceView =
+      TinyLens (._modelSourceView) (\s m -> m {_modelSourceView = s})
 
 goTiming :: (e ~ Event) => UserEvent -> Control e ()
 goTiming ev = do
@@ -777,12 +857,33 @@ goTiming ev = do
         handleHoverScrollZoom
           (\case TimingEv (HoverOnModule modu) -> Just modu; _ -> Nothing)
           HandlerHoverScrollZoom
-            { handlerHover = [("timing-chart", modelTiming . timingUIHoveredModule)],
-              handlerScroll = [("timing-chart", modelTiming . timingUIViewPort)],
-              handlerZoom = [("timing-chart", modelTiming . timingUIViewPort)]
+            { handlerHover =
+                [ ( "timing-chart",
+                    composeL
+                      lensTiming
+                      (TinyLens (._timingUIHoveredModule) (\h t -> t {_timingUIHoveredModule = h}))
+                  )
+                ],
+              handlerScroll =
+                [ ( "timing-chart",
+                    composeL
+                      lensTiming
+                      (TinyLens (._timingUIViewPort) (\vp t -> t {_timingUIViewPort = vp}))
+                  )
+                ],
+              handlerZoom =
+                [ ( "timing-chart",
+                    composeL
+                      lensTiming
+                      (TinyLens (._timingUIViewPort) (\vp t -> t {_timingUIViewPort = vp}))
+                  )
+                ]
             }
           mev
     _ -> pure ()
+  where
+    lensTiming =
+      TinyLens (._modelTiming) (\t m -> m {_modelTiming = t})
 
 goBlocker :: (e ~ Event) => UserEvent -> Control e ()
 goBlocker ev = do
@@ -814,14 +915,19 @@ goBlocker ev = do
           HandlerHoverScrollZoom
             { handlerHover = [],
               handlerScroll =
-                [ ("blocker-module-graph", modelBlocker . blockerUIViewPort)
+                [ ("blocker-module-graph", composeL lensBlocker lensViewPort)
                 ],
               handlerZoom =
-                [ ("blocker-module-graph", modelBlocker . blockerUIViewPort)
+                [ ("blocker-module-graph", composeL lensBlocker lensViewPort)
                 ]
             }
           mev
     _ -> pure ()
+  where
+    lensBlocker =
+      TinyLens (._modelBlocker) (\b m -> m {_modelBlocker = b})
+    lensViewPort =
+      TinyLens (._blockerUIViewPort) (\vp b -> b {_blockerUIViewPort = vp})
 
 initializeMainView :: Control e ()
 initializeMainView =
@@ -913,10 +1019,10 @@ mainLoop = do
                   HandlerHoverScrollZoom
                     { handlerHover = [],
                       handlerScroll =
-                        [ ("console-main", modelConsole . consoleViewPort)
+                        [ ("console-main", composeL lensConsole lensViewPort)
                         ],
                       handlerZoom =
-                        [ ("console-main", modelConsole . consoleViewPort)
+                        [ ("console-main", composeL lensConsole lensViewPort)
                         ]
                     }
                   mev
@@ -924,7 +1030,9 @@ mainLoop = do
                 then nextUserEvent
                 else pure ev
             _ -> pure ev
-
+          where
+            lensConsole = TinyLens (._modelConsole) (\c m -> m {_modelConsole = c})
+            lensViewPort = TinyLens (._consoleViewPort) (\vp c -> c {_consoleViewPort = vp})
         handleClick ev0 =
           case ev0 of
             MouseEv (MouseClick scene_id (x, y)) -> do

--- a/daemon/src/GHCSpecter/Data/GHC/Hie.hs
+++ b/daemon/src/GHCSpecter/Data/GHC/Hie.hs
@@ -1,24 +1,18 @@
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Data.GHC.Hie
   ( -- * Row data for Hie
     RefRow' (..),
-    HasRefRow' (..),
     DeclRow' (..),
-    HasDeclRow' (..),
     DefRow' (..),
-    HasDefRow' (..),
 
     -- * Hie info per module
     ModuleHieInfo (..),
-    HasModuleHieInfo (..),
     emptyModuleHieInfo,
   )
 where
 
-import Control.Lens (makeClassy)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import GHCSpecter.Channel.Common.Types (type ModuleName)
@@ -36,8 +30,6 @@ data RefRow' = RefRow'
   }
   deriving (Show, Generic)
 
-makeClassy ''RefRow'
-
 -- | DeclRow has OccName
 data DeclRow' = DeclRow'
   { _decl'Src :: FilePath,
@@ -50,8 +42,6 @@ data DeclRow' = DeclRow'
   }
   deriving (Show, Generic)
 
-makeClassy ''DeclRow'
-
 -- | DefRow has OccName
 data DefRow' = DefRow'
   { _def'Src :: FilePath,
@@ -63,8 +53,6 @@ data DefRow' = DefRow'
   }
   deriving (Show, Generic)
 
-makeClassy ''DefRow'
-
 data ModuleHieInfo = ModuleHieInfo
   { _modHieRefs :: [RefRow'],
     _modHieDecls :: [DeclRow'],
@@ -72,8 +60,6 @@ data ModuleHieInfo = ModuleHieInfo
     _modHieSource :: Text
   }
   deriving (Show, Generic)
-
-makeClassy ''ModuleHieInfo
 
 emptyModuleHieInfo :: ModuleHieInfo
 emptyModuleHieInfo = ModuleHieInfo [] [] [] ""

--- a/daemon/src/GHCSpecter/Data/Timing/Types.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Types.hs
@@ -1,19 +1,15 @@
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Data.Timing.Types
   ( -- * extracted information along the compilation pipeline of a given module
     PipelineInfo (..),
-    HasPipelineInfo (..),
 
     -- * collective timing information for the session
     TimingTable (..),
-    HasTimingTable (..),
     emptyTimingTable,
   )
 where
 
-import Control.Lens (makeClassy)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as M
 import Data.Time.Clock (NominalDiffTime)
@@ -30,8 +26,6 @@ data PipelineInfo a = PipelineInfo
   }
   deriving (Show, Generic, Functor)
 
-makeClassy ''PipelineInfo
-
 data TimingTable = TimingTable
   { -- | Start-time-ordered info table.
     _ttableTimingInfos :: [(DriverId, PipelineInfo (NominalDiffTime, Maybe MemInfo))],
@@ -39,8 +33,6 @@ data TimingTable = TimingTable
     _ttableBlockedDownstreamDependency :: Map ModuleName [ModuleName]
   }
   deriving (Show, Generic)
-
-makeClassy ''TimingTable
 
 emptyTimingTable :: TimingTable
 emptyTimingTable = TimingTable [] M.empty M.empty

--- a/daemon/src/GHCSpecter/Data/Timing/Util.hs
+++ b/daemon/src/GHCSpecter/Data/Timing/Util.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Data.Timing.Util
   ( -- * timing info utilities

--- a/daemon/src/GHCSpecter/Driver/Session/Types.hs
+++ b/daemon/src/GHCSpecter/Driver/Session/Types.hs
@@ -1,16 +1,11 @@
-{-# LANGUAGE TemplateHaskell #-}
-
 module GHCSpecter.Driver.Session.Types
   ( -- * session types for daemon
     ServerSession (..),
-    HasServerSession (..),
     ClientSession (..),
-    HasClientSession (..),
   )
 where
 
 import Control.Concurrent.STM (TChan, TQueue, TVar)
-import Control.Lens (makeClassy)
 import GHCSpecter.Channel.Inbound.Types (Request)
 import GHCSpecter.Server.Types (ServerState (..))
 import GHCSpecter.UI.Types (UIState)
@@ -25,12 +20,8 @@ data ServerSession = ServerSession
     _ssSubscriberSignal :: TChan Request
   }
 
-makeClassy ''ServerSession
-
 data ClientSession = ClientSession
   { _csUIStateRef :: TVar UIState,
     -- _csPublisherState :: TChan (UIState, ServerState),
     _csPublisherEvent :: TQueue Event
   }
-
-makeClassy ''ClientSession

--- a/daemon/src/GHCSpecter/Layouter/Graph/Types.hs
+++ b/daemon/src/GHCSpecter/Layouter/Graph/Types.hs
@@ -1,24 +1,17 @@
 {-# LANGUAGE FunctionalDependencies #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Layouter.Graph.Types
   ( -- * graph visualization information
     Point (..),
-    HasPoint (..),
     toTuple,
     Dimension (..),
-    HasDimension (..),
     NodeLayout (..),
-    HasNodeLayout (..),
     EdgeLayout (..),
-    HasEdgeLayout (..),
     GraphVisInfo (..),
-    HasGraphVisInfo (..),
     transposeGraphVis,
   )
 where
 
-import Control.Lens (makeClassy)
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
@@ -27,8 +20,6 @@ data Point = Point
     _pointY :: Double
   }
   deriving (Show, Generic)
-
-makeClassy ''Point
 
 toTuple :: Point -> (Double, Double)
 toTuple (Point x y) = (x, y)
@@ -39,8 +30,6 @@ data Dimension = Dim
   }
   deriving (Show, Generic)
 
-makeClassy ''Dimension
-
 data NodeLayout a = NodeLayout
   { -- | information in node
     _nodePayload :: a,
@@ -50,8 +39,6 @@ data NodeLayout a = NodeLayout
     _nodeSize :: Dimension
   }
   deriving (Show, Generic)
-
-makeClassy ''NodeLayout
 
 data EdgeLayout = EdgeLayout
   { -- | edge id from the graph layouter
@@ -65,16 +52,12 @@ data EdgeLayout = EdgeLayout
   }
   deriving (Show, Generic)
 
-makeClassy ''EdgeLayout
-
 data GraphVisInfo = GraphVisInfo
   { _gviCanvasDim :: Dimension,
     _gviNodes :: [NodeLayout (Int, Text)],
     _gviEdges :: [EdgeLayout]
   }
   deriving (Show, Generic)
-
-makeClassy ''GraphVisInfo
 
 -- | swap horizontal and vertical directions.
 transposeGraphVis :: GraphVisInfo -> GraphVisInfo

--- a/daemon/src/GHCSpecter/Server/Types.hs
+++ b/daemon/src/GHCSpecter/Server/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedRecordDot #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Server.Types
   ( ChanModule,
@@ -7,17 +6,14 @@ module GHCSpecter.Server.Types
 
     -- * Timing state
     TimingState (..),
-    HasTimingState (..),
     emptyTimingState,
 
     -- * ModuleGraph state
     ModuleGraphState (..),
-    HasModuleGraphState (..),
     emptyModuleGraphState,
 
     -- * Hie state
     HieState (..),
-    HasHieState (..),
     emptyHieState,
 
     -- * Supplementary view
@@ -28,13 +24,11 @@ module GHCSpecter.Server.Types
 
     -- * Server state
     ServerState (..),
-    HasServerState (..),
     initServerState,
     incrementSN,
   )
 where
 
-import Control.Lens (makeClassy)
 import Data.IntMap (IntMap)
 import Data.IntMap qualified as IM
 import Data.Map.Strict (Map)
@@ -78,8 +72,6 @@ data TimingState = TimingState
   }
   deriving (Show, Generic)
 
-makeClassy ''TimingState
-
 emptyTimingState :: TimingState
 emptyTimingState =
   TimingState
@@ -100,8 +92,6 @@ data ModuleGraphState = ModuleGraphState
   }
   deriving (Show, Generic)
 
-makeClassy ''ModuleGraphState
-
 emptyModuleGraphState :: ModuleGraphState
 emptyModuleGraphState =
   ModuleGraphState
@@ -117,8 +107,6 @@ newtype HieState = HieState
   { _hieModuleMap :: Map ModuleName ModuleHieInfo
   }
   deriving (Show, Generic)
-
-makeClassy ''HieState
 
 emptyHieState :: HieState
 emptyHieState = HieState mempty
@@ -157,8 +145,6 @@ data ServerState = ServerState
     _serverModuleBreakpoints :: [ModuleName]
   }
   deriving (Show, Generic)
-
-makeClassy ''ServerState
 
 initServerState :: ServerState
 initServerState =

--- a/daemon/src/GHCSpecter/UI/Constants.hs
+++ b/daemon/src/GHCSpecter/UI/Constants.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.UI.Constants
   ( -- * time interval
@@ -32,7 +31,6 @@ module GHCSpecter.UI.Constants
 
     -- * widget config types
     WidgetConfig (..),
-    HasWidgetConfig (..),
     emptyWidgetConfig,
 
     -- * default widget config
@@ -40,7 +38,6 @@ module GHCSpecter.UI.Constants
   )
 where
 
-import Control.Lens (makeClassy)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Text (Text)
@@ -103,8 +100,6 @@ data WidgetConfig = WidgetConfig
     _wcfgSourceView :: Map Text ViewPort,
     _wcfgTiming :: Map Text ViewPort
   }
-
-makeClassy ''WidgetConfig
 
 emptyWidgetConfig :: WidgetConfig
 emptyWidgetConfig =

--- a/daemon/src/GHCSpecter/UI/Types.hs
+++ b/daemon/src/GHCSpecter/UI/Types.hs
@@ -1,53 +1,42 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.UI.Types
   ( -- * ViewPortInfo
     ViewPortInfo (..),
-    HasViewPortInfo (..),
 
     -- * SessionUI
     SessionUI (..),
-    HasSessionUI (..),
     emptySessionUI,
 
     -- * ModuleGraphUI
     ModuleGraphUI (..),
-    HasModuleGraphUI (..),
     emptyModuleGraphUI,
 
     -- * SourceViewUI
     SourceViewUI (..),
-    HasSourceViewUI (..),
     emptySourceViewUI,
 
     -- * TimingUI
     TimingUI (..),
-    HasTimingUI (..),
     emptyTimingUI,
 
     -- * BlockerUI
     BlockerUI (..),
-    HasBlockerUI (..),
 
     -- * ConsoleUI
     ConsoleUI (..),
-    HasConsoleUI (..),
     emptyConsoleUI,
 
     -- * UIModel
     UIModel (..),
-    HasUIModel (..),
     emptyUIModel,
 
     -- * UIState
     UIState (..),
-    HasUIState (..),
     emptyUIState,
   )
 where
 
-import Control.Lens (makeClassy)
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import GHCSpecter.Channel.Common.Types (DriverId)
@@ -71,16 +60,12 @@ data ViewPortInfo = ViewPortInfo
   }
   deriving (Show)
 
-makeClassy ''ViewPortInfo
-
 data SessionUI = SessionUI
   { _sessionUIModStatusViewPort :: ViewPortInfo,
     _sessionUIMainViewPort :: ViewPortInfo,
     _sessionUIProcessViewPort :: ViewPortInfo,
     _sessionUIRtsViewPort :: ViewPortInfo
   }
-
-makeClassy ''SessionUI
 
 emptySessionUI :: SessionUI
 emptySessionUI =
@@ -98,8 +83,6 @@ data ModuleGraphUI = ModuleGraphUI
     _modGraphUIClick :: Maybe Text,
     _modGraphViewPort :: ViewPortInfo
   }
-
-makeClassy ''ModuleGraphUI
 
 emptyModuleGraphUI :: ModuleGraphUI
 emptyModuleGraphUI =
@@ -119,8 +102,6 @@ data SourceViewUI = SourceViewUI
     _srcViewSourceViewPort :: ViewPortInfo,
     _srcViewSuppViewPort :: ViewPortInfo
   }
-
-makeClassy ''SourceViewUI
 
 emptySourceViewUI :: SourceViewUI
 emptySourceViewUI =
@@ -144,8 +125,6 @@ data TimingUI = TimingUI
     _timingUIHoveredModule :: Maybe Text
   }
 
-makeClassy ''TimingUI
-
 emptyTimingUI :: TimingUI
 emptyTimingUI =
   TimingUI
@@ -159,8 +138,6 @@ emptyTimingUI =
 data BlockerUI = BlockerUI
   { _blockerUIViewPort :: ViewPortInfo
   }
-
-makeClassy ''BlockerUI
 
 emptyBlockerUI :: BlockerUI
 emptyBlockerUI =
@@ -176,8 +153,6 @@ data ConsoleUI = ConsoleUI
     -- | console viewport
     _consoleViewPort :: ViewPortInfo
   }
-
-makeClassy ''ConsoleUI
 
 emptyConsoleUI :: ConsoleUI
 emptyConsoleUI =
@@ -213,8 +188,6 @@ data UIModel = UIModel
     _modelTransientBanner :: Maybe Double
   }
 
-makeClassy ''UIModel
-
 emptyUIModel :: UIModel
 emptyUIModel =
   UIModel
@@ -248,8 +221,6 @@ data UIState = UIState
     -- | main UI state
     _uiModel :: UIModel
   }
-
-makeClassy ''UIState
 
 emptyUIState :: UTCTime -> UIState
 emptyUIState now =

--- a/daemon/src/GHCSpecter/Worker/CallGraph.hs
+++ b/daemon/src/GHCSpecter/Worker/CallGraph.hs
@@ -1,13 +1,10 @@
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module GHCSpecter.Worker.CallGraph
   ( -- * UnitSymbol
     UnitSymbol (..),
-    HasUnitSymbol (..),
     ModuleCallGraph (..),
-    HasModuleCallGraph (..),
 
     -- * top-level decl
     getTopLevelDecls,
@@ -26,7 +23,6 @@ module GHCSpecter.Worker.CallGraph
 where
 
 import Control.Concurrent.STM (TVar, atomically, modifyTVar')
-import Control.Lens (makeClassy)
 import Control.Monad.Trans.State (runState)
 import Data.Function (on)
 import Data.IntMap (IntMap)
@@ -67,8 +63,6 @@ data UnitSymbol = UnitSymbol
   }
   deriving (Eq, Ord, Show)
 
-makeClassy ''UnitSymbol
-
 -- | Call graph inside a module in the current unit scope
 -- the index runs from 1 through the number of symbols.
 data ModuleCallGraph = ModuleCallGraph
@@ -76,8 +70,6 @@ data ModuleCallGraph = ModuleCallGraph
     _modCallGraph :: IntMap [Int]
   }
   deriving (Show)
-
-makeClassy ''ModuleCallGraph
 
 getTopLevelDecls :: ModuleHieInfo -> [(((Int, Int), (Int, Int)), Text)]
 getTopLevelDecls modHieInfo = sortedTopLevelDecls


### PR DESCRIPTION
from now on, we only use GHC-provided record syntax or internal version of lens. 