### PR TITLE
Integrate nixGL for non-NixOS linux

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,3 @@
 packages:
   ./daemon
   ./plugin
-  ./ghc-build-analyzer

--- a/flake.lock
+++ b/flake.lock
@@ -93,6 +93,30 @@
         "type": "github"
       }
     },
+    "nixGL": {
+      "inputs": {
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685908677,
+        "narHash": "sha256-E4zUPEUFyVWjVm45zICaHRpfGepfkE9Z2OECV9HXfA4=",
+        "owner": "guibou",
+        "repo": "nixGL",
+        "rev": "489d6b095ab9d289fe11af0219a9ff00fe87c7c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "guibou",
+        "ref": "main",
+        "repo": "nixGL",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1692215615,
@@ -115,6 +139,7 @@
         "flake-utils": "flake-utils",
         "hs-imgui": "hs-imgui",
         "hs-ogdf": "hs-ogdf",
+        "nixGL": "nixGL",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -52,11 +52,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1693489325,
-        "narHash": "sha256-U12duK8lC0Mbm8NavcF5SxFeTLtuOkjeTTnXAAxJmU0=",
+        "lastModified": 1694963134,
+        "narHash": "sha256-gGAzt0g9jqy6eNMXFSOjqOy+TaXGVnNOBKXvebqXKrA=",
         "owner": "wavewave",
         "repo": "hs-imgui",
-        "rev": "bb161fe8087261532d7272c3be2573af4e071812",
+        "rev": "5cded28d94e701e3c23a410f60dd309a98fdeca3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -47,16 +47,19 @@
         "flake-utils": [
           "flake-utils"
         ],
+        "nixGL": [
+          "nixGL"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1694963134,
-        "narHash": "sha256-gGAzt0g9jqy6eNMXFSOjqOy+TaXGVnNOBKXvebqXKrA=",
+        "lastModified": 1695058566,
+        "narHash": "sha256-NYzHKeBe9GQF8SXOWussT7j3+IEmvDSsdj4/nkb+nHY=",
         "owner": "wavewave",
         "repo": "hs-imgui",
-        "rev": "5cded28d94e701e3c23a410f60dd309a98fdeca3",
+        "rev": "46a9dc12be9caf20ec11049505997577a8d980d6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/master";
     flake-utils.url = "github:numtide/flake-utils";
+    nixGL = {
+      url = "github:guibou/nixGL/main";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
     fficxx = {
       url = "github:wavewave/fficxx/master";
       inputs = {
@@ -31,6 +38,7 @@
     self,
     nixpkgs,
     flake-utils,
+    nixGL,
     fficxx,
     hs-ogdf,
     hs-imgui,
@@ -39,7 +47,9 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {
         inherit system;
-        overlays = [hs-imgui.overlay.${system}];
+        overlays = [
+          (hs-imgui.overlay.${system})
+        ];
       };
 
       haskellOverlay = final: hself: hsuper: {
@@ -79,6 +89,8 @@
             pkgs.cabal-install
             pkgs.alejandra
             pkgs.ormolu
+            pkgs.zlib	    
+            nixGL.packages.${system}.default
           ];
           shellHook = ''
             export PS1="\n[${prompt}:\w]$ \0"
@@ -100,6 +112,8 @@
             pkgs.cabal-install
             pkgs.alejandra
             pkgs.ormolu
+            nixGL.packages.${system}.default
+            pkgs.zlib
             pyenv
           ];
           shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
               pkgs.alejandra
               pkgs.ormolu
             ]
-            ++ (pkgs.lib.optional pkgs.stdenv.isLinux nixGL.packages.${system}.default);
+            ++ (pkgs.lib.optional (pkgs.stdenv.isLinux && !pkgs.lib.inPureEvalMode) nixGL.packages.${system}.default);
           shellHook = ''
             export PS1="\n[${prompt}:\w]$ \0"
           '';
@@ -115,7 +115,7 @@
               pkgs.ormolu
               pyenv
             ]
-            ++ (pkgs.lib.optional pkgs.stdenv.isLinux nixGL.packages.${system}.default);
+            ++ (pkgs.lib.optional (pkgs.stdenv.isLinux && !pkgs.lib.inPureEvalMode) nixGL.packages.${system}.default);
           shellHook = ''
             export PS1="\n[${prompt}:\w]$ \0"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -84,14 +84,14 @@
         prompt = "ghc-specter:env";
       in
         pkgs.mkShell {
-          packages = [
-            hsenv
-            pkgs.cabal-install
-            pkgs.alejandra
-            pkgs.ormolu
-            pkgs.zlib	    
-            nixGL.packages.${system}.default
-          ];
+          packages =
+            [
+              hsenv
+              pkgs.cabal-install
+              pkgs.alejandra
+              pkgs.ormolu
+            ]
+            ++ (pkgs.lib.optional pkgs.stdenv.isLinux nixGL.packages.${system}.default);
           shellHook = ''
             export PS1="\n[${prompt}:\w]$ \0"
           '';
@@ -108,14 +108,14 @@
             p.ghc-specter-plugin
             p.ghc-specter-daemon
           ];
-          buildInputs = [
-            pkgs.cabal-install
-            pkgs.alejandra
-            pkgs.ormolu
-            nixGL.packages.${system}.default
-            pkgs.zlib
-            pyenv
-          ];
+          buildInputs =
+            [
+              pkgs.cabal-install
+              pkgs.alejandra
+              pkgs.ormolu
+              pyenv
+            ]
+            ++ (pkgs.lib.optional pkgs.stdenv.isLinux nixGL.packages.${system}.default);
           shellHook = ''
             export PS1="\n[${prompt}:\w]$ \0"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
       inputs = {
         nixpkgs.follows = "nixpkgs";
         flake-utils.follows = "flake-utils";
+        nixGL.follows = "nixGL";
         fficxx.follows = "fficxx";
       };
     };


### PR DESCRIPTION
for non-NixOS linux, one need to invoke an app using OpenGL with `nixGL`.
```
$ nix develop --impure
$ nixGL cabal run ghc-specter-daemon:exe:ghc-specter-daemon
```
