### PR TITLE
Disable unused implot for now 

### DIFF
--- a/daemon/app/ghc-specter-daemon/Util/GUI.hs
+++ b/daemon/app/ghc-specter-daemon/Util/GUI.hs
@@ -44,7 +44,7 @@ import ImGui.ImGuiIO.Implementation
     imGuiIO_Framerate_get,
   )
 import ImGui.ImVec2.Implementation (imVec2_x_get, imVec2_y_get)
-import ImPlot qualified
+-- import ImPlot qualified
 import STD.Deletable (delete)
 import Text.Printf (printf)
 import Util.Orphans ()
@@ -71,7 +71,7 @@ initialize title = do
   -- Enable vsync
   glfwSwapInterval 1
   ctxt <- createContext
-  ImPlot.createImPlotContext
+  -- ImPlot.createImPlotContext
 
   -- Setup Dear ImGui style
   -- styleColorsDark

--- a/daemon/app/ghc-specter-daemon/Util/Plot.hs
+++ b/daemon/app/ghc-specter-daemon/Util/Plot.hs
@@ -4,10 +4,11 @@
 
 module Util.Plot
   ( -- * draw utilities
-    makeSparkline,
+    -- makeSparkline,
   )
 where
 
+{-
 import Control.Monad.Extra (whenM)
 import Data.Bits ((.|.))
 import FFICXX.Runtime.TH (IsCPrimitive (..), TemplateParamInfo (..))
@@ -75,3 +76,4 @@ makeSparkline pdat offset = do
     ImPlot.endPlot
   delete spark_size
   delete zero
+-}

--- a/daemon/app/ghc-specter-daemon/Util/Plot.hs
+++ b/daemon/app/ghc-specter-daemon/Util/Plot.hs
@@ -4,7 +4,8 @@
 
 module Util.Plot
   ( -- * draw utilities
-    -- makeSparkline,
+
+  -- makeSparkline,
   )
 where
 

--- a/daemon/ghc-specter-daemon.cabal
+++ b/daemon/ghc-specter-daemon.cabal
@@ -147,7 +147,7 @@ executable ghc-specter-daemon
     , ghc-specter-daemon
     , ghc-specter-plugin
     , imgui
-    , implot
+    -- , implot
     , mtl
     , stdcxx
     , stm


### PR DESCRIPTION
The implot utility function is not used yet. So disabled it for now (the transitive dep implot -> imgui caused unnecessary build issues which needs patches on nix expr.)
